### PR TITLE
Fix cron sendmail error in Docker container

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -13,11 +13,17 @@ fi
 
 # Set up cron job for feed updates (every 30 minutes)
 echo "Setting up cron job for feed updates..."
-echo "*/30 * * * * cd /data && /usr/local/bin/feedspool fetch && /usr/local/bin/feedspool render > /proc/1/fd/1 2> /proc/1/fd/2" > /etc/crontabs/root
+# Disable email notifications and redirect output to Docker logs
+cat > /etc/crontabs/root << EOF
+# Disable email notifications
+MAILTO=""
+# Run fetch and render every 30 minutes, output to Docker logs
+*/30 * * * * cd /data && /usr/local/bin/feedspool fetch && /usr/local/bin/feedspool render > /proc/1/fd/1 2> /proc/1/fd/2
+EOF
 
-# Start crond in background
+# Start crond in background (level 8 = only errors, no info messages)
 echo "Starting cron daemon..."
-crond -f &
+crond -f -d 8 &
 CRON_PID=$!
 
 # Function to handle shutdown signals


### PR DESCRIPTION
- Add MAILTO="" to disable cron email notifications completely
- Use crond -d 8 flag to reduce verbosity (only errors, no info)
- Use heredoc for cleaner crontab file creation
- Fixes BusyBox sendmail error about unrecognized -F option

Alpine's BusyBox sendmail doesn't support the flags that crond tries to use for email notifications. Since we're redirecting all output to Docker logs anyway, email notifications are unnecessary.

🤖 Generated with [Claude Code](https://claude.ai/code)