### PR TITLE
Optimize GitHub Actions workflows to eliminate redundant CI runs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+# Git and development files
+.git
+.github
+.gitignore
+*.md
+!README.md
+
+# Test and build artifacts
+tmp/
+build/
+dist/
+*.test
+coverage.out
+
+# Development files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Don't ignore Dockerfiles - we need both for different workflows
+!Dockerfile
+!Dockerfile.prebuilt
+!docker-entrypoint.sh

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,24 +1,37 @@
 name: Build and Push Docker Image
 
-# This workflow only builds and pushes Docker images after all CI checks pass
+# This workflow builds Docker images using binaries from the rolling release
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["Rolling Release"]
+    branches: [main]
+    types: [completed]
   release:
     types: [published]
 
 jobs:
-  ci:
-    uses: ./.github/workflows/ci.yml
-    
   docker:
-    needs: ci
+    # Only run if the rolling release workflow succeeded
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'release' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Download rolling release binary
+        if: github.event_name == 'workflow_run'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Download the Linux AMD64 binary from the latest release
+          gh release download latest --pattern "feedspool_latest_linux_amd64.tar.gz" --dir ./temp
+          cd temp
+          tar -xzf feedspool_latest_linux_amd64.tar.gz
+          mv feedspool ../
+          cd ..
+          rm -rf temp
+          chmod +x feedspool
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -44,10 +57,25 @@ jobs:
             org.opencontainers.image.description=RSS/Atom feed aggregator and static site generator
             org.opencontainers.image.vendor=lmorchard
 
-      - name: Build and push Docker image
+      - name: Build and push Docker image (from release binary)
+        if: github.event_name == 'workflow_run'
         uses: docker/build-push-action@v5
         with:
           context: .
+          file: Dockerfile.prebuilt
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64
+
+      - name: Build and push Docker image (from source)
+        if: github.event_name == 'release'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -1,5 +1,8 @@
 name: Rolling Release
 
+# This workflow runs CI checks once as a quality gate, then builds release artifacts.
+# The Docker workflow depends on this workflow completing successfully.
+
 on:
   push:
     branches: [ main ]

--- a/Dockerfile.prebuilt
+++ b/Dockerfile.prebuilt
@@ -1,0 +1,27 @@
+# Docker image for pre-built binary
+# This dockerfile expects the feedspool binary to already exist in the build context
+FROM docker.io/alpine:latest
+
+# Install cronie for cron support
+RUN apk add --no-cache cronie
+
+# Create data directory for volume mount
+RUN mkdir -p /data
+
+# Copy pre-built binary (should exist in build context)
+COPY feedspool /usr/local/bin/feedspool
+RUN chmod +x /usr/local/bin/feedspool
+
+# Copy entrypoint script
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+# Set working directory to data mount point
+WORKDIR /data
+
+# Expose the default port
+EXPOSE 8889
+
+# Set entrypoint and default command
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["serve"]


### PR DESCRIPTION
This refactors the CI/CD pipeline to run quality checks only once per main branch push, with Docker builds reusing tested artifacts from rolling releases.

GitHub Actions workflow changes:
- docker.yml: Now triggers on rolling release completion via workflow_run
- docker.yml: Downloads Linux AMD64 binary from latest GitHub release
- docker.yml: Uses Dockerfile.prebuilt for faster builds with pre-compiled binaries
- docker.yml: Maintains source builds for official releases (multi-arch support)
- rolling-release.yml: Added documentation about workflow dependencies

New files:
- Dockerfile.prebuilt: Lightweight Dockerfile for pre-built binaries
- .dockerignore: Excludes unnecessary files, includes both Dockerfiles

Benefits:
- Eliminates redundant CI runs (lint, test, build ran twice before)
- Faster Docker builds using pre-compiled release artifacts
- Better resource utilization and build times
- Maintains separation of concerns: Quality Gate → Release → Docker

Workflow sequence:
1. Push to main → Rolling Release runs CI once and creates artifacts
2. Rolling Release completion → Docker workflow downloads Linux binary and builds image
3. Official releases still build from source with full multi-architecture support

🤖 Generated with [Claude Code](https://claude.ai/code)