### PR TITLE
Fix Docker image build by using static linking for Linux binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,9 +74,14 @@ jobs:
         DATE: ${{ env.DATE }}
       shell: bash
       run: |
-        # Use make build for consistent build logic
-        make build
-        
+        # Use make build-static for Linux (Docker needs static binary for Alpine)
+        # Use make build for other platforms
+        if [ "$GOOS" = "linux" ]; then
+          make build-static
+        else
+          make build
+        fi
+
         # Rename to expected output for Windows
         if [ "$GOOS" = "windows" ] && [ -f feedspool ]; then
           mv feedspool feedspool.exe

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -78,9 +78,14 @@ jobs:
         DATE: ${{ env.DATE }}
       shell: bash
       run: |
-        # Use make build for consistent build logic
-        make build
-        
+        # Use make build-static for Linux (Docker needs static binary for Alpine)
+        # Use make build for other platforms
+        if [ "$GOOS" = "linux" ]; then
+          make build-static
+        else
+          make build
+        fi
+
         # Rename to expected output for Windows
         if [ "$GOOS" = "windows" ] && [ -f feedspool ]; then
           mv feedspool feedspool.exe


### PR DESCRIPTION
After PR #21 separated static and dynamic build targets, the GitHub Actions workflows were still calling 'make build' which now creates dynamically linked binaries. When these glibc-linked binaries were copied into Alpine-based Docker images (which use musl libc), they failed to execute with "not found" errors.

This fix updates both release workflows to use 'make build-static' for Linux builds, ensuring the binaries are statically linked and compatible with Alpine. Other platforms continue to use the dynamic 'make build' target.

Fixes the Docker image execution issue reported after merging PR #21.