### PR TITLE
Fix feed sorting to use published_date instead of first_seen

### DIFF
--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -7,16 +7,6 @@ import (
 )
 
 const (
-	// minReasonableItemDate is the minimum date we consider reasonable for feed items.
-	// Items with dates before this are likely due to:
-	// - Missing or malformed dates in feeds
-	// - Timezone bugs causing dates to appear centuries in the past
-	// - Epoch time (1970-01-01) or other sentinel values
-	//
-	// We use 2000-01-01 as a practical lower bound to allow legitimate old archives
-	// while still catching epoch dates and other obviously invalid timestamps.
-	minReasonableItemDate = "2000-01-01"
-
 	// Migration version constants.
 	migrationVersion1   = 1 // Initial schema (handled by InitSchema)
 	migrationVersion2   = 2 // Add latest_item_date column to feeds
@@ -234,7 +224,7 @@ func (db *DB) applyMigration4WithBackfill() error {
 				ELSE published_date
 			END
 		WHERE first_seen IS NULL
-	`, minReasonableItemDate, minReasonableItemDate)
+	`, MinReasonableItemDate, MinReasonableItemDate)
 	if _, err = tx.Exec(backfillSQL); err != nil {
 		return fmt.Errorf("failed to backfill first_seen: %w", err)
 	}

--- a/internal/database/models.go
+++ b/internal/database/models.go
@@ -12,6 +12,18 @@ import (
 	"github.com/mmcdole/gofeed"
 )
 
+const (
+	// MinReasonableItemDate is the minimum date we consider reasonable for feed items.
+	// Items with dates before this are likely due to:
+	// - Missing or malformed dates in feeds
+	// - Timezone bugs causing dates to appear centuries in the past
+	// - Epoch time (1970-01-01) or other sentinel values
+	//
+	// We use 2000-01-01 as a practical lower bound to allow legitimate old archives
+	// while still catching epoch dates and other obviously invalid timestamps.
+	MinReasonableItemDate = "2000-01-01"
+)
+
 type Feed struct {
 	URL                 string       `db:"url"`
 	Title               string       `db:"title"`


### PR DESCRIPTION
- Use item published_date (clamped) for feed latest_item_date calculation
- Use first_seen as fallback only when published_date is missing
- Extract clampItemDate helper to keep dates in reasonable range
- Refactor migrations.go to fix linting errors (complexity, magic numbers)
- Move MinReasonableItemDate constant to models.go for reuse

This fixes the issue where feeds showed "updated 3 minutes ago" (when we fetched them) but actual latest item was from 47 minutes ago. Feeds now sort and display by actual item publication times.