### PR TITLE
Add MANUAL.md and trim README to a landing page

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1,0 +1,821 @@
+# feedspool Manual
+
+This is the operator's manual for `feedspool`. It covers every subcommand, the
+configuration file, the SQLite data model, common recipes, and behavioral
+gotchas. It is written for both human operators and LLM agents that need to
+drive the tool.
+
+For a project overview and installation, see [README.md](README.md).
+For development workflow (build, lint, test), see [CLAUDE.md](CLAUDE.md).
+
+## Table of Contents
+
+- [Mental Model](#mental-model)
+- [Quick Start](#quick-start)
+- [Configuration](#configuration)
+- [Global Flags](#global-flags)
+- [Subcommand Reference](#subcommand-reference)
+- [Data Model](#data-model)
+- [SQL Recipes](#sql-recipes)
+- [Workflow Recipes](#workflow-recipes)
+- [Behavior Notes and Gotchas](#behavior-notes-and-gotchas)
+- [Docker Reference](#docker-reference)
+- [Custom Templates and Assets](#custom-templates-and-assets)
+- [Exit Codes](#exit-codes)
+
+## Mental Model
+
+feedspool has three layers, and most confusion comes from conflating them:
+
+1. **Subscription list** — an OPML or text file on disk. This is the *source
+   of truth* for which feeds you care about. `subscribe`, `unsubscribe`, and
+   `export` operate on it. `fetch` and `purge` can be told to operate
+   *relative to* it.
+2. **Database** (`feeds.db`) — a SQLite spool. Feed metadata, items, and
+   unfurl metadata accumulate here as you fetch. Treat it as cache: any feed
+   in the DB but not in your subscription list is leftover and a candidate
+   for `purge`.
+3. **Rendered site** — static HTML produced from the database by `render`.
+   It can be regenerated from the DB at any time and is served by `serve` (or
+   any static web server).
+
+The flow is: subscription list → `fetch` → database → `render` → static
+site → `serve`.
+
+## Quick Start
+
+```bash
+feedspool init                                    # create feeds.db
+echo "https://example.com/feed.xml" > feeds.txt   # subscribe
+feedspool fetch --format text --filename feeds.txt
+feedspool render --feeds feeds.txt --format text
+feedspool serve                                   # http://localhost:8080
+```
+
+With a `feedspool.yaml` configuring `feedlist.format` and `feedlist.filename`,
+the `--format`/`--filename`/`--feeds` flags become optional.
+
+## Configuration
+
+feedspool reads `./feedspool.yaml` by default. Override with `--config <path>`.
+A missing file is silently ignored unless `--config` was specified.
+
+Environment variables matching Viper's mapping rules are also honored.
+
+Precedence (highest wins): CLI flag > environment variable > config file >
+built-in default.
+
+### Full configuration reference
+
+```yaml
+# Top-level
+database: ./feeds.db        # Database file path
+timeout: 30s                # Per-feed/URL fetch timeout
+verbose: false              # Info-level logging
+debug: false                # Debug-level logging
+json: false                 # Default to JSON output
+
+# Default feed list — used by subscribe, unsubscribe, fetch, purge, render
+# when --format/--filename/--feeds are not provided
+feedlist:
+  format: ""                # "opml" or "text"
+  filename: ""              # path to feed list file
+
+fetch:
+  with_unfurl: false        # Run unfurl in parallel with fetch
+  concurrency: 32           # Max concurrent feed fetches
+  max_items: 100            # Max items kept per feed
+
+render:
+  output_dir: ./build
+  templates_dir: ""         # "" = use embedded templates
+  assets_dir: ""            # "" = use embedded assets
+  default_max_age: 24h      # Time window for items
+  default_clean: false      # Wipe output dir before render
+  default_min_items_per_feed: 5
+  default_max_items_per_feed: 50
+  feeds_per_page: 25        # 0 disables pagination
+
+serve:
+  port: 8080
+  dir: ./build
+
+init:
+  templates_dir: ./templates
+  assets_dir: ./assets
+
+unfurl:
+  skip_robots: false        # If true, ignore robots.txt
+  retry_after: 1h           # Re-attempt previously failed URLs after this
+  concurrency: 32
+
+purge:
+  max_age: 30d
+  skip_vacuum: false        # If true, skip VACUUM after purge
+  min_items_keep: 10        # Keep at least N items per feed regardless of age
+```
+
+Note: `serve.port: 8080` is the bare CLI default. The Docker image ships with
+a generated config that uses port `8889` instead; see
+[Docker Reference](#docker-reference).
+
+## Global Flags
+
+These apply to every subcommand:
+
+| Flag | Short | Default | Description |
+|---|---|---|---|
+| `--config` | `-c` | (search `./feedspool.yaml`) | Config file path |
+| `--database` | `-d` | `./feeds.db` | SQLite database path |
+| `--verbose` | `-v` | false | Info-level logging |
+| `--debug` | | false | Debug-level logging |
+| `--json` | | false | Emit JSON instead of human text |
+
+## Subcommand Reference
+
+### init
+
+Create or upgrade the database, and optionally extract embedded templates and
+assets to disk.
+
+**Usage:** `feedspool init [flags]`
+
+**Flags:**
+
+| Flag | Default | Description |
+|---|---|---|
+| `--upgrade` | false | Apply pending schema migrations to an existing DB |
+| `--extract-templates` | false | Write embedded templates to `--templates-dir` |
+| `--extract-assets` | false | Write embedded static assets to `--assets-dir` |
+| `--templates-dir` | `./templates` | Target dir for template extraction |
+| `--assets-dir` | `./assets` | Target dir for asset extraction |
+
+**Side effects:** Creates `feeds.db` if missing; runs migrations; writes
+files when `--extract-*` flags are used.
+
+**Example:**
+
+```bash
+feedspool init
+feedspool init --upgrade
+feedspool init --extract-templates --extract-assets
+```
+
+### subscribe
+
+Add a feed URL to your subscription list. Optionally autodiscover feed URLs
+from a webpage.
+
+**Usage:** `feedspool subscribe <url> [flags]`
+
+**Flags:**
+
+| Flag | Default | Description |
+|---|---|---|
+| `--format` | (config) | `opml` or `text` |
+| `--filename` | (config) | Path to subscription file |
+| `--discover` | false | Treat URL as a webpage; parse its HTML for `<link>` feed references |
+
+**Side effects:** Creates the subscription file if it does not exist; appends
+the URL. Network request only when `--discover` is set. Does not touch the
+database.
+
+**Examples:**
+
+```bash
+feedspool subscribe https://example.com/feed.xml
+feedspool subscribe --discover https://example.com/blog
+feedspool subscribe --format opml --filename feeds.opml https://example.com/feed.xml
+```
+
+### unsubscribe
+
+Remove a feed URL from a subscription list. Does *not* delete items from the
+database — use `purge --format <fmt> --filename <file>` for that.
+
+**Usage:** `feedspool unsubscribe <url> [flags]`
+
+**Flags:**
+
+| Flag | Default | Description |
+|---|---|---|
+| `--format` | (config) | `opml` or `text` |
+| `--filename` | (config) | Path to subscription file |
+
+### fetch
+
+Fetch feed content. Has three modes depending on arguments.
+
+**Usage:** `feedspool fetch [url] [flags]`
+
+**Modes:**
+
+- **Single URL:** `feedspool fetch https://example.com/feed.xml`
+- **From subscription file:** `feedspool fetch --format opml --filename feeds.opml`
+- **Refresh DB:** `feedspool fetch` — refetches every feed currently in the database
+
+**Flags:**
+
+| Flag | Default | Description |
+|---|---|---|
+| `--timeout` | `30s` | Per-feed HTTP timeout |
+| `--max-items` | `100` | Max items kept per feed |
+| `--force` | false | Ignore stored ETag/Last-Modified; refetch even if 304 would be served |
+| `--concurrency` | `32` | Max concurrent fetches |
+| `--max-age` | `0` | Skip feeds last fetched within this duration |
+| `--remove-missing` | false | (file mode) Delete DB feeds that are not in the subscription file |
+| `--format` | (config) | `opml` or `text` (file mode) |
+| `--filename` | (config) | Subscription file path (file mode) |
+| `--with-unfurl` | (config) | Run unfurl in parallel with the fetch |
+
+**Side effects:** Writes feeds and items to the database. Marks items no
+longer in the live feed as archived. May delete feed rows when
+`--remove-missing` is used. If `--with-unfurl` is set, also writes
+`url_metadata`.
+
+**JSON output (`--json`):**
+
+```json
+{
+  "mode": "single|file|database",
+  "totalFeeds": 12,
+  "successful": 10,
+  "errors": 1,
+  "cached": 1,
+  "totalItems": 250,
+  "removedFeeds": 0
+}
+```
+
+### show
+
+List items for a single feed.
+
+**Usage:** `feedspool show <url> [flags]`
+
+**Flags:**
+
+| Flag | Default | Description |
+|---|---|---|
+| `--format` | `table` | `table`, `json`, or `csv` |
+| `--sort` | `newest` | `newest` or `oldest` |
+| `--limit` | `0` | Max items (0 = all) |
+| `--since` | (none) | Filter items after this RFC3339 timestamp |
+| `--until` | (none) | Filter items before this RFC3339 timestamp |
+
+**JSON shape:**
+
+```json
+{
+  "url": "https://example.com/feed.xml",
+  "title": "Example Feed",
+  "description": "...",
+  "Items": [
+    {
+      "id": 1,
+      "feed_url": "https://example.com/feed.xml",
+      "guid": "...",
+      "title": "...",
+      "link": "https://example.com/article",
+      "published_date": "2026-05-01T12:00:00Z",
+      "first_seen": "2026-05-01T12:05:00Z",
+      "content": "...",
+      "summary": "...",
+      "archived": false
+    }
+  ]
+}
+```
+
+**Side effects:** Read-only.
+
+### unfurl
+
+Extract OpenGraph, Twitter Card, and favicon metadata from URLs.
+
+**Usage:** `feedspool unfurl [url] [flags]`
+
+**Modes:**
+
+- **Single URL:** `feedspool unfurl https://example.com/article`
+- **Batch:** `feedspool unfurl` — processes item URLs in the database that
+  do not yet have metadata (or whose previous fetch failed and is eligible
+  for retry).
+
+**Flags:**
+
+| Flag | Default | Description |
+|---|---|---|
+| `--limit` | `0` | Max URLs to process in batch mode (0 = no limit) |
+| `--format` | (none) | Single-URL mode: `json` for structured output |
+| `--concurrency` | `32` | Max concurrent fetches |
+| `--retry-after` | `1h` | Retry previously failed URLs after this duration |
+| `--retry-immediate` | false | Retry all failed URLs now, ignoring `--retry-after` |
+| `--skip-robots` | false | Bypass robots.txt checks |
+
+**Side effects:** Writes to `url_metadata`. Network requests to target URLs
+and to their `robots.txt` (unless `--skip-robots`).
+
+**JSON shape (single URL with `--format json`):**
+
+```json
+{
+  "url": "https://example.com/article",
+  "title": "...",
+  "description": "...",
+  "image_url": "https://example.com/og.jpg",
+  "favicon_url": "https://example.com/favicon.ico",
+  "metadata": { /* additional fields */ },
+  "last_fetch_at": "2026-05-09T12:00:00Z",
+  "fetch_status_code": 200,
+  "fetch_error": null,
+  "created_at": "2026-05-09T11:00:00Z",
+  "updated_at": "2026-05-09T12:00:00Z"
+}
+```
+
+### render
+
+Generate a static HTML site from the database.
+
+**Usage:** `feedspool render [feed-url...] [flags]`
+
+If feed URLs are provided positionally, only those are rendered; otherwise
+all feeds in the database (or in the subscription file, with `--feeds`) are
+included.
+
+**Flags:**
+
+| Flag | Default | Description |
+|---|---|---|
+| `--max-age` | (config: `24h`) | Time window for items, e.g. `24h`, `7d` |
+| `--start` | (none) | RFC3339 start of explicit time range |
+| `--end` | (none) | RFC3339 end of explicit time range |
+| `--min-items-per-feed` | (config: `5`) | Floor on items per feed; `0` for none |
+| `--max-items-per-feed` | (config: `50`) | Ceiling on items per feed; `0` for none |
+| `--feeds-per-page` | (config: `25`) | Pagination size; `0` disables pagination |
+| `--output` | `./build` | Output directory |
+| `--templates` | (embedded) | Custom templates directory |
+| `--assets` | (embedded) | Custom assets directory |
+| `--feeds` | (none) | Subscription file to filter feeds by |
+| `--format` | `text` | Subscription file format when `--feeds` is set |
+| `--clean` | false | Wipe output directory before render |
+
+`--max-age` and `--start`/`--end` are mutually exclusive. Custom template
+and asset directories must already exist; the parent of `--output` must
+exist.
+
+**Side effects:** Writes HTML, copies assets. Read-only on the database.
+
+### serve
+
+Run a development HTTP server over the rendered site.
+
+**Usage:** `feedspool serve [flags]`
+
+**Flags:**
+
+| Flag | Default | Description |
+|---|---|---|
+| `--port` | `8080` | TCP port to listen on |
+| `--dir` | `./build` | Directory to serve |
+
+`PORT` env var overrides the config-file value but not an explicit `--port`
+flag. Graceful shutdown on `SIGINT`/`SIGTERM` with a 5-second timeout.
+
+This is intended for development — front it with a real web server in
+production.
+
+### purge
+
+Two distinct cleanup operations, controlled by which flags you pass.
+
+**Usage:** `feedspool purge [flags]`
+
+**1. Age-based item purge (always runs).** Deletes archived items older than
+`--age`, while keeping at least `--min-items` per feed regardless of age.
+Orphaned `url_metadata` rows are deleted afterward.
+
+**2. Feed-list cleanup (optional).** When `--format` and `--filename` are
+provided (or configured as defaults), feeds whose URL is not in the
+subscription list are deleted. ON DELETE CASCADE removes their items.
+
+**Flags:**
+
+| Flag | Default | Description |
+|---|---|---|
+| `--age` | (config: `30d`) | Cutoff for archived-item deletion |
+| `--min-items` | (config: `10`) | Per-feed floor; `0` for no floor |
+| `--dry-run` | false | Report what would be deleted without modifying the DB |
+| `--format` | (config) | Subscription file format for feed cleanup |
+| `--filename` | (config) | Subscription file path for feed cleanup |
+| `--no-vacuum` | false | Skip post-purge `VACUUM` |
+
+**Side effects:** Deletes from `items`, `feeds`, and `url_metadata`. Runs
+`VACUUM` unless suppressed or in dry-run.
+
+**JSON shape (age-based):**
+
+```json
+{
+  "mode": "age",
+  "dryRun": false,
+  "cutoffDate": "2026-04-09T00:00:00Z",
+  "minItemsKeep": 10,
+  "deleted": 412,
+  "metadataDeleted": 27
+}
+```
+
+**JSON shape (feed-list cleanup):**
+
+```json
+{
+  "mode": "feedlist",
+  "dryRun": false,
+  "filename": "feeds.opml",
+  "format": "opml",
+  "deleted": 3,
+  "metadataDeleted": 5
+}
+```
+
+### export
+
+Write all feeds currently in the database to a subscription file.
+
+**Usage:** `feedspool export <filename> --format <opml|text>`
+
+**Side effects:** Overwrites the target file.
+
+### version
+
+Print version metadata.
+
+**Usage:** `feedspool version` (or `feedspool --version`)
+
+**Text output:**
+
+```
+feedspool version v1.2.3
+  commit: abc1234
+  built:  2026-05-09T12:00:00Z
+```
+
+**JSON output (`--json`):**
+
+```json
+{ "version": "v1.2.3", "commit": "abc1234", "date": "2026-05-09T12:00:00Z" }
+```
+
+## Data Model
+
+The database is plain SQLite. You can query it directly with `sqlite3
+feeds.db` while feedspool is running (SQLite supports concurrent readers).
+
+### `feeds`
+
+One row per feed URL.
+
+| Column | Type | Notes |
+|---|---|---|
+| `url` | TEXT PK | Feed URL |
+| `title` | TEXT | Parsed feed title |
+| `description` | TEXT | Parsed feed description |
+| `last_updated` | DATETIME | From feed's UpdatedParsed/PublishedParsed |
+| `etag` | TEXT | HTTP ETag for conditional GET |
+| `last_modified` | TEXT | HTTP Last-Modified for conditional GET |
+| `last_fetch_time` | DATETIME | Last fetch attempt (success or failure) |
+| `last_successful_fetch` | DATETIME | Last 200 OK |
+| `error_count` | INTEGER | Consecutive errors; reset on success |
+| `last_error` | TEXT | Last error message |
+| `latest_item_date` | DATETIME | Most recent item's clamped `published_date` |
+| `feed_json` | JSON | Full parsed feed structure |
+
+### `items`
+
+One row per (feed_url, guid). Items not present in the latest fetch are
+flagged `archived=1` rather than deleted.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | INTEGER PK | Autoincrement |
+| `feed_url` | TEXT | FK → `feeds.url`, ON DELETE CASCADE |
+| `guid` | TEXT | Normalized GUID; see [GUID dedup](#guid-deduplication) |
+| `title` | TEXT | |
+| `link` | TEXT | Item URL |
+| `published_date` | DATETIME | *Clamped*; see [date clamping](#published-date-clamping) |
+| `content` | TEXT | Full content (HTML entities decoded) |
+| `summary` | TEXT | Description/summary |
+| `archived` | BOOLEAN | `1` once item disappears from the live feed |
+| `item_json` | JSON | Full parsed item |
+| `first_seen` | DATETIME | Wall-clock time we first inserted this item |
+
+Indexes: `idx_items_feed_url`, `idx_items_published_date`,
+`idx_items_archived`. UNIQUE constraint on `(feed_url, guid)`.
+
+### `url_metadata`
+
+Unfurl results, keyed by item link URL.
+
+| Column | Type | Notes |
+|---|---|---|
+| `url` | TEXT PK | |
+| `title`, `description`, `image_url`, `favicon_url` | TEXT | Extracted |
+| `metadata` | JSON | Extra fields (Twitter Card, OpenGraph extras) |
+| `last_fetch_at` | DATETIME | |
+| `fetch_status_code` | INTEGER | Last HTTP status |
+| `fetch_error` | TEXT | Last error, if any |
+| `created_at` | DATETIME | |
+| `updated_at` | DATETIME | Auto-updated by trigger |
+
+A row with `fetch_status_code` in 2xx is considered final; failures may be
+retried per `--retry-after`.
+
+### `schema_migrations`
+
+Internal version tracking. Current version: 4.
+
+## SQL Recipes
+
+Run these via `sqlite3 feeds.db "..."` or any SQLite client.
+
+**Recent items across all feeds:**
+
+```sql
+SELECT i.published_date, f.title AS feed, i.title, i.link
+FROM items i JOIN feeds f ON f.url = i.feed_url
+WHERE i.archived = 0
+ORDER BY i.published_date DESC
+LIMIT 50;
+```
+
+**Items mentioning a topic:**
+
+```sql
+SELECT i.published_date, i.title, i.link
+FROM items i
+WHERE i.archived = 0
+  AND (i.title LIKE '%foo%' OR i.content LIKE '%foo%' OR i.summary LIKE '%foo%')
+ORDER BY i.published_date DESC;
+```
+
+**Feeds that have not produced anything recently:**
+
+```sql
+SELECT url, title, latest_item_date
+FROM feeds
+WHERE latest_item_date < datetime('now', '-30 days')
+   OR latest_item_date IS NULL
+ORDER BY latest_item_date ASC NULLS FIRST;
+```
+
+**Feeds that consistently fail:**
+
+```sql
+SELECT url, error_count, last_error, last_fetch_time
+FROM feeds
+WHERE error_count > 3
+ORDER BY error_count DESC;
+```
+
+**Items missing unfurl metadata:**
+
+```sql
+SELECT i.link
+FROM items i
+LEFT JOIN url_metadata m ON m.url = i.link
+WHERE i.archived = 0 AND m.url IS NULL;
+```
+
+**Item count per feed:**
+
+```sql
+SELECT f.title, COUNT(i.id) AS items
+FROM feeds f LEFT JOIN items i ON i.feed_url = f.url AND i.archived = 0
+GROUP BY f.url
+ORDER BY items DESC;
+```
+
+## Workflow Recipes
+
+**Subscribe from a public OPML and render:**
+
+```bash
+curl -o feeds.opml https://example.com/list.opml
+feedspool fetch --format opml --filename feeds.opml --with-unfurl
+feedspool render --feeds feeds.opml --format opml
+feedspool serve
+```
+
+**Refresh everything in the spool:**
+
+```bash
+feedspool fetch                # all feeds in DB
+feedspool unfurl               # backfill missing metadata
+feedspool render
+```
+
+**Find what's new since yesterday:**
+
+```bash
+feedspool render --max-age 24h --output ./build-daily
+```
+
+…or via SQL:
+
+```sql
+SELECT i.published_date, f.title, i.title, i.link
+FROM items i JOIN feeds f ON f.url = i.feed_url
+WHERE i.first_seen > datetime('now', '-1 day') AND i.archived = 0
+ORDER BY i.first_seen DESC;
+```
+
+**Drop everything not in your subscription list, then trim old items:**
+
+```bash
+feedspool purge --format opml --filename feeds.opml --age 30d --dry-run
+feedspool purge --format opml --filename feeds.opml --age 30d
+```
+
+**Rebuild from scratch:**
+
+```bash
+rm feeds.db build/
+feedspool init
+feedspool fetch --format opml --filename feeds.opml --with-unfurl
+feedspool render
+```
+
+**Backup the spool:** `cp feeds.db feeds.db.bak` while the tool is idle, or
+use `sqlite3 feeds.db ".backup feeds.db.bak"` for a hot copy.
+
+## Behavior Notes and Gotchas
+
+### Published-date clamping
+
+Many feeds emit timestamps that are wrong: future-dated items, epoch zero,
+or values from before 2000. feedspool clamps every item's `published_date`
+into a sane range when ingesting:
+
+- A `published_date` later than `now()` is clamped down to the item's
+  `first_seen` value (or `now()` if `first_seen` is unknown). This stops
+  feeds-from-the-future from sticking at the top of every render.
+- A `published_date` before 2000-01-01 is clamped *up* to 2000-01-01 — this
+  catches epoch-zero defaults from broken feeds.
+- The unclamped value is preserved inside `item_json` if you need it.
+
+`feeds.latest_item_date` is computed from the clamped values, so feed
+ordering reflects clamped reality, not what the feed claims.
+
+### Conditional HTTP and `--force`
+
+On every fetch, feedspool sends `If-None-Match` (from stored ETag) and
+`If-Modified-Since` (from stored Last-Modified). A `304 Not Modified`
+response counts as a cache hit: items aren't re-processed and
+`last_successful_fetch` is *not* updated. Pass `--force` to drop the
+conditional headers and refetch unconditionally — useful when a feed's
+content changed but its server lies about it.
+
+### Subscription list is the source of truth
+
+`subscribe` and `unsubscribe` modify the OPML/text file only — they don't
+touch the database. The database accumulates whatever you fetch. To bring
+the DB back in line with the subscription list, run `purge --format <fmt>
+--filename <file>` (or `fetch --remove-missing`).
+
+### What `purge` actually deletes
+
+Age-based purge deletes *archived* items only. Live items are never
+deleted by age. The `--min-items` floor protects the N most recent items
+per feed regardless of age, so a feed that goes quiet doesn't lose its
+entire history at once.
+
+Feed-list cleanup deletes feeds whose URL is not in the subscription file,
+along with all of their items via cascade. Run with `--dry-run` first.
+
+### Unfurl retry semantics
+
+A previous unfurl attempt with status 2xx is final and never retried.
+Failed attempts are eligible for retry only after `--retry-after` has
+elapsed since `last_fetch_at`. Use `--retry-immediate` to override that
+window. By default, `robots.txt` is consulted before each fetch; pass
+`--skip-robots` to bypass it.
+
+### Concurrency and rate limiting
+
+There is no per-host rate limiting. The only knob is `--concurrency`
+(default 32 for both `fetch` and `unfurl`). Lower it if you're hammering a
+small upstream.
+
+### GUID deduplication
+
+Some feeds (notably the BBC) emit GUIDs that change on every fetch by
+appending a fragment. feedspool normalizes the GUID by stripping the
+fragment and falling back to a hash of `link + title` when needed, so the
+same item doesn't get re-inserted on every refresh.
+
+### HTML entity decoding
+
+Feed titles, descriptions, content, and summaries are unescaped on ingest
+so that consumers get plain HTML, not double-encoded entities.
+
+### Concurrent reads while running
+
+SQLite supports multiple readers, so you can `sqlite3 feeds.db` while a
+fetch is in progress. Avoid concurrent writes (e.g., two `feedspool fetch`
+processes against the same DB).
+
+## Docker Reference
+
+The `lmorchard/feedspool` image bundles feedspool with cron and a
+generated config that fetches every 30 minutes and serves on port 8889.
+
+### Volume layout
+
+Mount a host directory at `/data`. Inside it:
+
+| Path | Purpose |
+|---|---|
+| `feeds.txt` *or* `feeds.opml` | Subscription file (auto-detected) |
+| `feedspool.yaml` | Optional; auto-generated from a template if missing |
+| `feeds.db` | Created automatically |
+| `build/` | Rendered HTML, served by the container |
+
+### Environment variables
+
+| Var | Default | Effect |
+|---|---|---|
+| `PORT` | `8889` | HTTP server port (also exposed by `EXPOSE`) |
+| `CRON_SCHEDULE` | `*/30 * * * *` | Cron expression for periodic fetch+render |
+
+### Quick start
+
+```bash
+mkdir feedspool-data
+echo "https://feeds.bbci.co.uk/news/rss.xml" > feedspool-data/feeds.txt
+docker run -d -p 8889:8889 -v ./feedspool-data:/data lmorchard/feedspool:latest
+```
+
+### docker-compose
+
+```yaml
+services:
+  feedspool:
+    image: lmorchard/feedspool:latest
+    ports:
+      - "8889:8889"
+    volumes:
+      - ./feedspool-data:/data
+    environment:
+      - PORT=8889
+    restart: unless-stopped
+```
+
+### One-shot operations
+
+```bash
+docker run --rm -v ./feedspool-data:/data lmorchard/feedspool:latest init
+docker run --rm -v ./feedspool-data:/data lmorchard/feedspool:latest fetch
+docker run --rm -v ./feedspool-data:/data lmorchard/feedspool:latest render
+```
+
+### Building images locally
+
+- `Dockerfile` — multi-stage build from source. Slower, fully
+  self-contained: `docker build -t feedspool .`
+- `Dockerfile.prebuilt` — single-stage build from an existing binary,
+  used by CI: `make build && docker build -f Dockerfile.prebuilt -t feedspool .`
+
+### Troubleshooting
+
+```bash
+docker logs <name>
+docker exec -it <name> /bin/sh
+docker exec <name> /usr/local/bin/feedspool fetch
+```
+
+Common issues: host directory permissions, wrong path in `feedspool.yaml`,
+or an empty/missing subscription file.
+
+## Custom Templates and Assets
+
+The default templates and CSS are embedded in the binary. Extract them and
+point `render` at the copies to customize.
+
+```bash
+feedspool init --extract-templates --extract-assets
+# edit ./templates/index.html and ./assets/style.css
+feedspool render --templates ./templates --assets ./assets
+```
+
+The site uses HTML `<details>` for collapsible items, supports pagination
+via `--feeds-per-page`, and exposes feed descriptions as tooltips.
+
+## Exit Codes
+
+- `0` — success
+- `1` — any error (bad flags, DB error, network failure, validation, etc.)
+
+There is currently no distinction between error classes via exit codes;
+parse stderr or use `--json` for structured failure output where available.

--- a/README.md
+++ b/README.md
@@ -55,360 +55,38 @@ Use the Makefile:
 make build
 ```
 
-## Usage
+## Documentation
 
-### Help
+- **[MANUAL.md](MANUAL.md)** — operator's manual: every subcommand and flag, full configuration reference, SQLite data model, SQL and workflow recipes, behavior gotchas, Docker reference. Read this first.
+- **[CLAUDE.md](CLAUDE.md)** — development notes for contributors and AI assistants.
 
-You can get general help and subcommand-specific help with embedded documentation:
-
-```bash
-./feedspool --help
-./feedspool init --help
-./feedspool version
-./feedspool --version  # Alternative to version subcommand
-```
-
-### Initialize database
+## Quick start
 
 ```bash
-# Initialize database only
-./feedspool init
+feedspool init
+echo "https://example.com/feed.xml" > feeds.txt
+feedspool fetch --format text --filename feeds.txt
+feedspool render --feeds feeds.txt --format text
+feedspool serve   # http://localhost:8080
 ```
 
-### Feed Fetching
+`feedspool --help` and `feedspool <subcommand> --help` show inline reference.
+For everything beyond the basics, see [MANUAL.md](MANUAL.md).
+
+## Docker
 
 ```bash
-# Fetch a single feed
-./feedspool fetch https://example.com/feed.xml
-
-# Fetch all feeds from OPML file
-./feedspool fetch --format opml --filename feeds.opml
-
-# Fetch all feeds from text list
-./feedspool fetch --format text --filename feeds.txt
-
-# Fetch all feeds in database
-./feedspool fetch
-
-# Fetch feeds with parallel metadata extraction (unfurling)
-./feedspool fetch --with-unfurl
-```
-
-### Subscription Management
-
-```bash
-# Subscribe to a feed (adds to your default feed list)
-./feedspool subscribe https://example.com/feed.xml
-
-# Subscribe with autodiscovery from HTML page
-./feedspool subscribe --discover https://example.com/blog
-
-# Unsubscribe from a feed
-./feedspool unsubscribe https://example.com/feed.xml
-
-# Export database feeds to OPML
-./feedspool export --format opml feeds.opml
-
-# Export database feeds to text list
-./feedspool export --format text feeds.txt
-```
-
-### URL Metadata Extraction (Unfurling)
-
-Extract OpenGraph metadata, Twitter Cards, and favicons from web pages:
-
-```bash
-# Extract metadata from a single URL
-./feedspool unfurl https://example.com/article
-
-# Extract metadata from a single URL as JSON
-./feedspool unfurl https://example.com/article --format json
-
-# Process all item URLs in database without metadata  
-./feedspool unfurl
-
-# Process with custom limits and options
-./feedspool unfurl --limit 100 --concurrency 8
-./feedspool unfurl --retry-immediate --skip-robots
-```
-
-### Show items on the command line
-
-```bash
-./feedspool show https://example.com/feed.xml
-```
-
-### Generate static HTML site
-
-```bash
-# Generate HTML from all feeds in database
-./feedspool render
-
-# Generate HTML with a time range of feed items
-./feedspool render --max-age 24h
-./feedspool render --start 2023-01-01T00:00:00Z --end 2023-12-31T23:59:59Z
-
-# Control how many items are shown per feed
-./feedspool render --min-items-per-feed 5 --max-items-per-feed 50
-
-# Enable pagination (show 25 feeds per page)
-./feedspool render --feeds-per-page 25
-
-# Disable pagination entirely
-./feedspool render --feeds-per-page 0
-
-# Generate HTML from specific feeds
-./feedspool render https://example.com/feed.xml
-
-# Generate HTML with custom output directory
-./feedspool render --output-dir /path/to/output
-
-# Use custom templates and assets (extract first with init command)
-./feedspool render --templates ./my-templates --assets ./my-assets
-```
-
-### Cleanup Operations
-
-```bash
-# Clean up old archived items (items no longer in feeds)
-./feedspool purge --age 30d
-
-# Clean up old items while preserving a minimum per feed
-./feedspool purge --age 30d --min-items 10
-
-# Preview what would be deleted without actually deleting
-./feedspool purge --age 30d --dry-run
-
-# Remove unsubscribed feeds (keep only those in feed list)
-./feedspool purge --format opml --filename feeds.opml
-```
-
-## Configuration
-
-You can set defaults for just about every command line option in a YAML
-configuration file, aiming to make CLI usage simple.
-
-Create a `feedspool.yaml` file (see `feedspool.yaml.example`) or use command-line flags:
-
-### Global Options
-- `--database` - Database file path (default: ./feeds.db)
-- `--json` - Output in JSON format
-
-### Default Feed List Configuration
-```yaml
-feedlist:
-  format: "opml"        # or "text"
-  filename: "feeds.opml" # or "feeds.txt"
-```
-
-### Fetch Configuration
-```yaml
-fetch:
-  with_unfurl: true     # Enable parallel unfurling during fetch
-  concurrency: 16       # Fetch-specific concurrency
-  max_items: 50         # Max items per feed to store
-```
-
-### Render Configuration
-```yaml
-render:
-  output_dir: "./build"             # Output directory for generated HTML
-  default_max_age: "24h"            # Default time range for items
-  default_min_items_per_feed: 5    # Minimum items to show per feed
-  feeds_per_page: 25                # Feeds per page (0 = disable pagination)
-```
-
-### Unfurl Configuration  
-```yaml
-unfurl:
-  skip_robots: false    # Respect robots.txt (default: true)
-  retry_after: "1h"     # Retry failed fetches after duration
-  concurrency: 8        # Unfurl-specific concurrency
-```
-
-### Command Options
-- `--concurrency` - Max concurrent fetches (default: 32)
-- `--timeout` - Per-feed timeout (default: 30s) 
-- `--max-items` - Max items per feed (default: 100)
-- `--force` - Ignore cache headers and fetch anyway
-- `--max-age` - Skip feeds fetched within this duration
-- `--with-unfurl` - Extract metadata in parallel with feed fetching
-- `--format` - Feed list format (opml or text)
-- `--filename` - Feed list filename
-
-## Docker Usage
-
-feedspool is available as a Docker container for easy deployment and hosting.
-
-### Quick Start
-
-The simplest way to get started is with just a feeds file:
-
-```bash
-# Create a directory and add your feeds
 mkdir feedspool-data
 echo "https://feeds.bbci.co.uk/news/rss.xml" > feedspool-data/feeds.txt
-echo "https://www.reddit.com/r/programming.rss" >> feedspool-data/feeds.txt
-
-# Run the container
 docker run -d -p 8889:8889 -v ./feedspool-data:/data lmorchard/feedspool:latest
 ```
 
-The container will automatically:
-- Detect your `feeds.txt` (or `feeds.opml`) file
-- Create a default configuration optimized for Docker
-- Initialize the database
-- Fetch and render your feeds immediately
-- Start the web server on port 8889
-- Update feeds every 30 minutes via cron
+The container auto-detects `feeds.txt` or `feeds.opml`, generates a default
+config, initializes the database, fetches and renders, then runs feedspool
+every 30 minutes via cron and serves the result on port 8889.
 
-### Minimal Configuration
-
-The Docker container is designed to work with minimal setup. Just provide one of these files in your mounted volume:
-
-- **feeds.txt** - Simple text file with one feed URL per line
-- **feeds.opml** - OPML format feed list
-
-The container will automatically detect which format you're using and configure itself accordingly. No `feedspool.yaml` required!
-
-### Advanced Configuration
-
-For more control, you can provide a custom configuration. Place these files in your mounted directory:
-
-#### Files (all optional - sensible defaults are provided)
-- **feedspool.yaml** - Custom configuration (auto-generated if missing)
-- **feeds.txt** or **feeds.opml** - Your feed subscriptions
-- **feeds.db** - SQLite database (created automatically)
-- **build/** - Generated HTML files (created automatically)
-
-#### Sample feedspool.yaml
-```yaml
-# Database file path
-database: ./feeds.db
-
-# Default feed list settings
-feedlist:
-  format: "text"        # or "opml"
-  filename: "feeds.txt" # or "feeds.opml"
-
-# Static site generator settings
-render:
-  output_dir: "./build"
-  default_max_age: "24h"
-
-# HTTP server settings (will be overridden by PORT env var in container)
-serve:
-  port: 8889
-  dir: "./build"
-```
-
-#### Sample feeds.txt
-```
-https://feeds.bbci.co.uk/news/rss.xml
-https://www.reddit.com/r/programming.rss
-https://example.com/blog/feed.xml
-```
-
-### Environment Variables
-
-- **PORT** - Server port (default: 8889)
-  ```bash
-  docker run -d -p 9000:9000 -e PORT=9000 -v ./feedspool-data:/data lmorchard/feedspool:latest
-  ```
-
-- **CRON_SCHEDULE** - Cron schedule for automatic feed updates (default: */30 * * * *)
-  ```bash
-  # Update every 5 minutes instead of every 30 minutes
-  docker run -d -p 8889:8889 -e CRON_SCHEDULE="*/5 * * * *" -v ./feedspool-data:/data lmorchard/feedspool:latest
-  
-  # Update hourly at the top of the hour
-  docker run -d -p 8889:8889 -e CRON_SCHEDULE="0 * * * *" -v ./feedspool-data:/data lmorchard/feedspool:latest
-  ```
-
-### Docker Compose
-
-```yaml
-version: '3.8'
-
-services:
-  feedspool:
-    image: lmorchard/feedspool:latest
-    container_name: feedspool
-    ports:
-      - "8889:8889"
-    volumes:
-      - ./feedspool-data:/data
-    environment:
-      - PORT=8889
-      # - CRON_SCHEDULE=*/5 * * * *  # Optional: customize update frequency
-    restart: unless-stopped
-```
-
-### Build from Source
-
-```bash
-git clone https://github.com/lmorchard/feedspool-go.git
-cd feedspool-go
-docker build -t feedspool .
-```
-
-#### Docker Build Options
-
-This project includes two Docker build approaches:
-
-- **`Dockerfile`** - Multi-stage build that compiles from source code
-  - Use when building locally or when you don't have a pre-built binary
-  - Slower build but completely self-contained
-  - `docker build -t feedspool .`
-
-- **`Dockerfile.prebuilt`** - Single-stage build using a pre-compiled binary
-  - Used by GitHub Actions for faster CI/CD builds
-  - Requires the `feedspool` binary to exist in the build context
-  - `make build && docker build -f Dockerfile.prebuilt -t feedspool .`
-
-### Manual Operations
-
-Run one-time commands without starting the full service:
-
-```bash
-# Initialize database
-docker run --rm -v ./feedspool-data:/data lmorchard/feedspool:latest init
-
-# Fetch feeds manually
-docker run --rm -v ./feedspool-data:/data lmorchard/feedspool:latest fetch
-
-# Generate HTML manually
-docker run --rm -v ./feedspool-data:/data lmorchard/feedspool:latest render
-```
-
-### Troubleshooting
-
-#### View Container Logs
-```bash
-docker logs <container-name>
-```
-
-#### Check Container Status
-```bash
-docker ps
-```
-
-#### Access Container Shell
-```bash
-docker exec -it <container-name> /bin/sh
-```
-
-#### Manual Feed Update
-The container automatically fetches and renders feeds every 30 minutes. To trigger manually:
-```bash
-docker exec <container-name> /usr/local/bin/feedspool fetch
-docker exec <container-name> /usr/local/bin/feedspool render
-```
-
-#### Common Issues
-- **Permission denied**: Ensure your host directory is readable/writable
-- **Database errors**: Make sure `feedspool.yaml` specifies correct database path
-- **Empty feeds**: Check your `feeds.txt` or `feeds.opml` file exists and has valid URLs
+For environment variables, docker-compose, manual operations, and the two
+Dockerfile variants, see [MANUAL.md#docker-reference](MANUAL.md#docker-reference).
 
 ## Development
 
@@ -470,37 +148,6 @@ make test
 # Check linting
 make lint
 ```
-
-## HTML Site Generation
-
-The `render` command generates a static HTML site from your feeds. The generated site includes:
-- Main index page with all feeds and items
-- Collapsible feed items using HTML `<details>` elements
-- Feed descriptions available as tooltips on feed titles
-- Optional pagination support for large feed collections
-- Interactive feed navigation UI with feed selector
-- Per-feed item limits (min/max) for flexible content display
-- Incremental loading optimizations for smooth scrolling
-
-### Customization
-
-There's a default template and static assets embedded in the binary.
-These can be extracted as files and customized:
-
-```bash
-# Extract default templates and assets to filesystem
-./feedspool init --extract-templates --extract-assets
-
-# Customize the files in ./templates/ and ./assets/ directories
-# Then use your custom files:
-./feedspool render --templates ./templates --assets ./assets
-```
-
-This allows you to:
-- Modify the HTML template structure in `templates/index.html`
-- Customize the CSS styling in `assets/style.css`
-- Add your own branding, colors, and layout changes
-- Create completely custom site designs while keeping the data structure
 
 ## TODO
 


### PR DESCRIPTION
## Summary

- Adds **MANUAL.md** — an operator's manual aimed at users and LLM agents. Covers every subcommand and flag, the full YAML configuration reference, the SQLite data model (every table and column), SQL and workflow recipes, behavior gotchas (date clamping, conditional HTTP / `--force`, what `purge` actually deletes, unfurl retry semantics, GUID dedup), and a full Docker reference.
- Trims **README.md** from ~516 lines to ~163. Keeps the project pitch, features, install, quick start, a Docker one-liner, and dev setup. The deep usage and configuration content moved into MANUAL.md; the README now links there.
- No code changes.

Rationale: the README was doing double duty as both project intro and full operator reference. Splitting them gives a clearer landing page and a comprehensive manual that an LLM agent (or a careful operator) can rely on without parsing `--help` output. This is in lieu of an embedded MCP server for now — most of the same leverage, far less surface area to maintain.

Also noticed but left for a separate PR: the example comment in `cmd/serve.go:35` says "port 8889" while the actual CLI default is `8080` (8889 is the Docker default).

## Test plan

- [ ] `make build` still succeeds (sanity — docs-only change)
- [ ] Skim MANUAL.md for flag/default accuracy against actual `--help` output for a couple of subcommands
- [ ] Render README.md and MANUAL.md on GitHub and confirm internal links work (`MANUAL.md#docker-reference`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)