### PR TITLE
Fix CI skip check breaking on multi-line commit messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,10 @@ jobs:
     steps:
     - name: Check if CI should be skipped
       id: skip_check
+      env:
+        HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
       run: |
-        if [[ "${{ github.event.head_commit.message }}" == "[noci]"* ]]; then
+        if [[ "$HEAD_COMMIT_MESSAGE" == "[noci]"* ]]; then
           echo "skip=true" >> $GITHUB_OUTPUT
           echo "CI skipped due to [noci] in commit message"
         else


### PR DESCRIPTION
## What broke

[Run 32757706444](https://github.com/lmorchard/feedspool-go/actions/runs/32757706444/job/97528956810) failed on `main` — not in the code, but in CI's own guard step. `.github/workflows/ci.yml` spliced the raw commit message into the shell script text:

```bash
if [[ "${{ github.event.head_commit.message }}" == "[noci]"* ]]; then
```

GitHub substitutes that *before* bash parses the line. The squash-merge message for #42 spans 170+ lines and contains double quotes (`generated "?" placeholders`, `"1 feed" / "1 new item"`), so the quoted string closed early:

```
line 173: conditional binary operator expected
line 173: syntax error near `"1'
```

Bash exited 2, so `skip_check` never wrote an output — and every step gated on `steps.skip_check.outputs.skip != 'true'` was skipped. Checkout, lint, tests, Build, and Create Rolling Release all silently did nothing. **Lint and tests never ran on that commit.**

It was also a template injection hole: a commit message containing `$(...)` or backticks would have executed on the runner with `contents: write`.

## The fix

Pass the message through the environment so bash sees data instead of code. This was the only such interpolation in the workflows.

## Verification

The fixed conditional, checked against four cases:

| Input | Result |
|---|---|
| The real #42 merge message | `skip=false`, exit 0 |
| `[noci] docs tweak` | `skip=true`, exit 0 |
| Empty (the `pull_request` path — no `head_commit`) | `skip=false`, exit 0 |
| `$(touch /tmp/PWNED) \`touch /tmp/PWNED2\`` | inert, no files created |

Since CI never checked `main`, I also ran the gates locally on that tree: `go test -race ./...` passes across all 14 packages, and lint reports 0 issues under CI's pinned golangci-lint v2.13.1.

## Caveat on this PR's own CI run

A green check here does **not** exercise the fix. `pull_request` events have no `head_commit`, so the variable is empty on this run — the same reason the bug lay dormant until a push to `main`. It takes effect once `rolling-release` calls the workflow after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)