### PR TITLE
Pin golangci-lint to one version shared by make lint and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,18 @@ jobs:
       if: steps.skip_check.outputs.skip != 'true'
       run: go mod download
 
+    # Read the pin from the Makefile so local `make lint` and CI cannot drift
+    # onto different versions and disagree about what counts as a finding.
+    - name: Determine golangci-lint version
+      id: lint_version
+      if: steps.skip_check.outputs.skip != 'true'
+      run: echo "version=$(make print-golangci-lint-version)" >> "$GITHUB_OUTPUT"
+
     - name: Run golangci-lint
       if: steps.skip_check.outputs.skip != 'true'
       uses: golangci/golangci-lint-action@v8
       with:
-        version: v2.13.1
+        version: ${{ steps.lint_version.outputs.version }}
         args: --timeout=5m
 
     - name: Run tests

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ feedspool.yaml
 # Agent scratch space
 .claude/worktrees/
 .superpowers/
+
+# Pinned dev tools installed by the Makefile
+/bin/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,8 @@ The Makefile handles build flags, version injection, and other build-time config
 
 After every set of major changes, YOU MUST run `make format` and `make lint` for basic source code linting and then `make test` to ensure tests pass.
 
+`make lint` installs and runs the golangci-lint version pinned as `GOLANGCI_LINT_VERSION` in the Makefile, into a gitignored `bin/`. CI reads that same pin via `make print-golangci-lint-version`, so local and CI runs agree on what counts as a finding. Do not `go install ...golangci-lint@latest` to work around a lint problem — a different version reports a different set of findings (2.12.2 flags 8 `goconst` issues that 2.13.1 does not). Change the pin in the Makefile instead, and expect CI to move with it.
+
 You should also endeavor to keep the test suite up to date - our goal is not 100% coverage, but significant new logic and changes should be covered.
 
 We don't really bother testing code in cmd/ but all internal/ modules should be tested.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-static test clean run lint format fmt setup
+.PHONY: build build-static test clean run lint format fmt setup print-golangci-lint-version
 
 VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "v0.0.1")
 COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
@@ -8,6 +8,16 @@ LDFLAGS := -X github.com/lmorchard/feedspool-go/cmd.Version=$(VERSION) -X github
 # Output path for `build`/`build-static`. Override to build somewhere other
 # than the repo root, e.g. `make build BINARY=/tmp/feedspool-test`.
 BINARY := feedspool
+
+# Keep this in step with the version CI installs. CI reads it from here via
+# `make print-golangci-lint-version`, so this is the only place to change it.
+GOLANGCI_LINT_VERSION := v2.13.1
+
+# Tools live under the repo, not in GOPATH/bin, so pinning them here cannot
+# clobber a globally installed copy. The version is part of the filename, so
+# bumping the pin above installs the new one instead of reusing a stale binary.
+TOOLS_DIR := $(CURDIR)/bin
+GOLANGCI_LINT := $(TOOLS_DIR)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 
 build:
 	@echo "Building for $(shell go env GOOS)/$(shell go env GOARCH)"
@@ -41,16 +51,20 @@ format fmt:
 	go fmt ./...
 	$$(go env GOPATH)/bin/gofumpt -w .
 
-lint:
-	@GOPATH=$$(go env GOPATH); \
-	if [ ! -f "$$GOPATH/bin/golangci-lint" ]; then \
-		echo "golangci-lint not found. Please install it: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest"; \
-		exit 1; \
-	fi
-	$$(go env GOPATH)/bin/golangci-lint run --timeout=5m
+# Built with the local Go toolchain on purpose: a golangci-lint compiled
+# against an older stdlib cannot type-check a newer one.
+$(GOLANGCI_LINT):
+	@echo "Installing golangci-lint $(GOLANGCI_LINT_VERSION) into $(TOOLS_DIR)"
+	@GOBIN=$(TOOLS_DIR) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+	@mv $(TOOLS_DIR)/golangci-lint $@
 
-setup:
+lint: $(GOLANGCI_LINT)
+	$(GOLANGCI_LINT) run --timeout=5m
+
+print-golangci-lint-version:
+	@echo $(GOLANGCI_LINT_VERSION)
+
+setup: $(GOLANGCI_LINT)
 	@echo "Installing development tools..."
 	go install mvdan.cc/gofumpt@latest
-	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 	@echo "Tools installed successfully!"


### PR DESCRIPTION
Follow-up to #43. `make lint` ran whatever golangci-lint was in `GOPATH/bin` while `ci.yml` pinned its own version, so local and CI runs could disagree about what counts as a finding. They already did — on the same tree, 2.12.2 reported 8 `goconst` issues that CI's pinned 2.13.1 does not. The Makefile's install hint said `@latest`, which guaranteed the drift.

That costs time in both directions: chasing findings that only exist locally, or worse, a clean local run hiding something CI will reject.

## Approach

`GOLANGCI_LINT_VERSION` in the Makefile is now the only place the version appears. CI reads it through a new `print-golangci-lint-version` target rather than repeating the string, so bumping the pin moves both at once.

Two details worth flagging for review:

- **Installs into a gitignored `bin/`, not `GOPATH/bin`.** Pinning a project tool shouldn't clobber whatever version you have installed globally for other work.
- **The version is part of the binary's filename** (`bin/golangci-lint-v2.13.1`). That makes reinstall-on-bump fall out of make's ordinary dependency check — no version-comparison logic, and no way to silently reuse a stale binary.

I kept the `golangci-lint-action` in CI rather than having CI call `make lint`. Calling `make lint` would be the strongest possible sync, but it builds golangci-lint from source on every run; the action fetches a prebuilt binary and caches. Sharing the pin gets the correctness benefit without the minutes. Happy to switch if you'd rather have the stronger guarantee.

## Verification

| Check | Result |
|---|---|
| `make print-golangci-lint-version` | `v2.13.1` |
| Cold `make lint` (no `bin/`) | installs pin, **0 issues** — matches CI |
| Second `make lint` | reuses binary, no reinstall |
| `make lint GOLANGCI_LINT_VERSION=v2.12.2` | installs 2.12.2, reproduces the 8 `goconst` findings |
| Back to default pin | reuses cached v2.13.1, 0 issues |
| `make -n setup` with missing tool | installs the pinned version, not `@latest` |
| `git check-ignore bin` | ignored |
| `make test` | passes |

## Not included

`make format` has the same drift shape — it uses whatever gofumpt is in `GOPATH/bin`, installed `@latest`. I left it alone since formatting isn't a CI check today, so there's no second version to sync against. Worth pinning on the same pattern if you ever add a format gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)