### PR TITLE
Publish the Docker image as a linux/amd64 + linux/arm64 manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,36 @@ jobs:
           exit 1
         fi
 
+    # buildx names the binary it copies by TARGETARCH, so stage one per target.
+    - name: Stage per-arch binaries for the multi-arch image
+      if: matrix.goos == 'linux' && matrix.goarch == 'amd64'
+      run: |
+        set -euo pipefail
+        # This job already built linux/amd64 for the release archive.
+        cp feedspool feedspool-linux-amd64
+        # Cross-compiling costs nothing now that cgo is disabled.
+        GOOS=linux GOARCH=arm64 make build BINARY=feedspool-linux-arm64
+
+        # Assert each binary really is the architecture its filename claims.
+        # This has to happen here rather than inside the image: a RUN step
+        # cannot tell, because binfmt/qemu will transparently execute a
+        # foreign-arch binary and report success.
+        assert_arch() {
+          actual=$(file -b "$1")
+          case "$actual" in
+            *"$2"*) echo "ok: $1 is $2" ;;
+            *) echo "::error::$1 should be $2 but is: $actual"; exit 1 ;;
+          esac
+        }
+        assert_arch feedspool-linux-amd64 x86-64
+        assert_arch feedspool-linux-arm64 aarch64
+
+    # Needed to run the arm64 image's RUN layers (apk, the binary smoke test)
+    # on an amd64 runner.
+    - name: Set up QEMU
+      if: matrix.goos == 'linux' && matrix.goarch == 'amd64'
+      uses: docker/setup-qemu-action@v3
+
     - name: Set up Docker Buildx
       if: matrix.goos == 'linux' && matrix.goarch == 'amd64'
       uses: docker/setup-buildx-action@v3
@@ -140,12 +170,12 @@ jobs:
       with:
         context: .
         file: Dockerfile.prebuilt
+        platforms: linux/amd64,linux/arm64
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        platforms: linux/amd64
 
   release:
     name: Create Release

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -91,6 +91,36 @@ jobs:
           exit 1
         fi
 
+    # buildx names the binary it copies by TARGETARCH, so stage one per target.
+    - name: Stage per-arch binaries for the multi-arch image
+      if: matrix.goos == 'linux' && matrix.goarch == 'amd64'
+      run: |
+        set -euo pipefail
+        # This job already built linux/amd64 for the release archive.
+        cp feedspool feedspool-linux-amd64
+        # Cross-compiling costs nothing now that cgo is disabled.
+        GOOS=linux GOARCH=arm64 make build BINARY=feedspool-linux-arm64
+
+        # Assert each binary really is the architecture its filename claims.
+        # This has to happen here rather than inside the image: a RUN step
+        # cannot tell, because binfmt/qemu will transparently execute a
+        # foreign-arch binary and report success.
+        assert_arch() {
+          actual=$(file -b "$1")
+          case "$actual" in
+            *"$2"*) echo "ok: $1 is $2" ;;
+            *) echo "::error::$1 should be $2 but is: $actual"; exit 1 ;;
+          esac
+        }
+        assert_arch feedspool-linux-amd64 x86-64
+        assert_arch feedspool-linux-arm64 aarch64
+
+    # Needed to run the arm64 image's RUN layers (apk, the binary smoke test)
+    # on an amd64 runner.
+    - name: Set up QEMU
+      if: matrix.goos == 'linux' && matrix.goarch == 'amd64'
+      uses: docker/setup-qemu-action@v3
+
     - name: Set up Docker Buildx
       if: matrix.goos == 'linux' && matrix.goarch == 'amd64'
       uses: docker/setup-buildx-action@v3
@@ -122,12 +152,12 @@ jobs:
       with:
         context: .
         file: Dockerfile.prebuilt
+        platforms: linux/amd64,linux/arm64
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        platforms: linux/amd64
 
     - name: Create archive (Unix)
       if: matrix.goos != 'windows'

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ _testmain.go
 
 feedspool-go
 feedspool
+# Per-arch binaries staged for the multi-arch Docker image
+feedspool-linux-*
 data
 
 # SQLite database files

--- a/Dockerfile.prebuilt
+++ b/Dockerfile.prebuilt
@@ -1,6 +1,12 @@
-# Docker image for pre-built binary
-# This dockerfile expects the feedspool binary to already exist in the build context
+# Docker image for pre-built binaries.
+#
+# Expects one binary per target architecture in the build context, named
+# feedspool-linux-<arch> (e.g. feedspool-linux-amd64, feedspool-linux-arm64).
+# TARGETARCH is supplied by buildx, so a single invocation can build a
+# multi-arch manifest and each image picks up its matching binary.
 FROM docker.io/alpine:latest
+
+ARG TARGETARCH
 
 # Install cronie for cron support
 RUN apk add --no-cache cronie
@@ -8,13 +14,16 @@ RUN apk add --no-cache cronie
 # Create data directory for volume mount
 RUN mkdir -p /data
 
-# Copy pre-built binary (should exist in build context)
-COPY feedspool /usr/local/bin/feedspool
+# Copy the pre-built binary matching this image's architecture
+COPY feedspool-linux-${TARGETARCH} /usr/local/bin/feedspool
 RUN chmod +x /usr/local/bin/feedspool
 
-# Verify the binary was copied and works (basic test)
-RUN ls -la /usr/local/bin/feedspool
-RUN /usr/local/bin/feedspool version || echo "Binary test in Docker failed"
+# Smoke-test the binary, failing the build rather than warning if it is missing
+# or broken. This deliberately does NOT prove the binary matches TARGETARCH: a
+# host with binfmt/qemu handlers registered will happily execute a foreign-arch
+# binary right here. The architecture assertion lives in the workflow, where
+# file(1) can read the ELF header directly.
+RUN /usr/local/bin/feedspool version
 
 # Copy entrypoint script
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -963,6 +963,10 @@ processes against the same DB).
 The `lmorchard/feedspool` image bundles feedspool with cron and a
 generated config that fetches every 30 minutes and serves on port 8889.
 
+Published as a multi-arch manifest for `linux/amd64` and `linux/arm64`, so
+Docker pulls the right image for the host without a `--platform` flag. That
+covers Apple Silicon, Raspberry Pi 4/5, and ARM cloud instances natively.
+
 ### Volume layout
 
 Mount a host directory at `/data`. Inside it:


### PR DESCRIPTION
Follow-up to #45, which made cross-compiling free and this change cheap.

## The one-line version would have shipped a broken image

`Dockerfile.prebuilt` did `COPY feedspool /usr/local/bin/feedspool` — and that binary is the **linux/amd64** one the matrix job built for the release archive. Adding `linux/arm64` to the `platforms:` line alone would have put an amd64 executable inside the arm64 image.

So instead:

- `Dockerfile.prebuilt` takes `TARGETARCH` from buildx and copies `feedspool-linux-${TARGETARCH}`, so one invocation builds both images from one context and each picks up its matching binary
- the workflows stage those binaries first — cross-compiling the arm64 one is free now that cgo is gone
- **QEMU** is set up, because the arm64 image's `RUN` layers (`apk add`, the binary smoke test) execute in the target architecture on an amd64 runner

## Why the arch check is in the workflow, not the image

My first attempt put the guard inside the image — make `RUN feedspool version` hard-fail and let it catch a wrong-arch binary. **That does not work, and I verified it doesn't:** I staged an amd64 binary as `feedspool-linux-arm64`, built for arm64, and the build passed with **exit 0**. binfmt/qemu transparently executed the foreign-arch binary and reported success.

So the assertion moved to the workflow, where `file(1)` can read the ELF header directly:

```
ok: feedspool-linux-amd64 is x86-64
ok: feedspool-linux-arm64 is aarch64
```

and against a deliberately mislabeled binary:

```
::error::/tmp/mislabeled-arm64 should be aarch64 but is: ELF 64-bit LSB executable, x86-64, …
```

The in-image smoke test stays, and it's now a hard failure rather than `|| echo "Binary test in Docker failed"` — which would have let a genuinely broken binary through. Its comment just no longer claims to prove anything about architecture.

## Verification

Done locally with buildx, both platforms:

| Check | Result |
|---|---|
| Both images build | Yes, incl. amd64 under emulation |
| `uname -m` inside each | `aarch64` / `x86_64` |
| Binary runs in each | Correct version output |
| Mislabeled binary | Rejected by the assertion |
| Correctly matched binaries | Pass |

CI here won't exercise any of it — the Docker build only runs on push to `main` — so the real proof is the rolling-release run after merge. I'd plan to pull the resulting `latest` on this arm64 machine *without* `--platform` and confirm it resolves natively; that's the symptom that started this.

Also documents the multi-arch manifest in MANUAL.md's Docker Reference, and gitignores the staged `feedspool-linux-*` binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)