### PR TITLE
Stamp releases with the tag name instead of "latest"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,18 @@
 .PHONY: build test clean run lint format fmt setup print-golangci-lint-version
 
-VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "v0.0.1")
-COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
-DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+# Assigned with ?= so the release workflows can pass the authoritative values
+# in the environment. They already do, deriving VERSION from the pushed tag;
+# with := those exports were silently ignored, because a Makefile assignment
+# beats the environment.
+#
+# --match keeps the fallback away from the rolling "latest" tag. That tag sits
+# on the same commit as a release tag, and actions/checkout rewrites the fetched
+# release tag to point straight at the commit, so in CI both are lightweight and
+# describe is free to pick either one. Restricting the pattern removes the
+# coin flip.
+VERSION ?= $(shell git describe --tags --always --dirty --match 'v[0-9]*' 2>/dev/null || echo "v0.0.1")
+COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS := -X github.com/lmorchard/feedspool-go/cmd.Version=$(VERSION) -X github.com/lmorchard/feedspool-go/cmd.Commit=$(COMMIT) -X github.com/lmorchard/feedspool-go/cmd.Date=$(DATE)
 
 # Output path for `build`. Override to build somewhere other than the repo


### PR DESCRIPTION
Both **v1.0.0 and v1.0.1** artifacts report `feedspool version latest`. Confirmed on the published Docker images for each. Pre-existing bug, not introduced by the recent work.

## Root cause

The release workflows already compute the right value — they export `VERSION=${GITHUB_REF#refs/tags/}` — but the Makefile assigned `VERSION` with `:=`, and **a Makefile assignment beats the environment**. Those exports were silently discarded. (These are the "dead env vars" I'd flagged a few times; turns out they were written to solve exactly this.)

That left `git describe --tags` as the real source, and it resolves to the wrong tag during a release:

1. `rolling-release.yml` moves a **lightweight** `latest` tag onto main's head
2. A release gets tagged at that same commit
3. Locally the annotated release tag wins the tie — **which is why this looked fine when I checked it on my workstation before pushing v1.0.1**
4. In CI it doesn't. `actions/checkout` re-fetches the release tag as `+<sha>:refs/tags/<tag>`, pointing the ref straight at the commit. Both tags are now lightweight, describe is free to pick either, and it picked `latest`.

## Fix

Two changes. Either alone would fix the release path; they're kept together because they protect different callers:

- **`VERSION`, `COMMIT`, `DATE` use `?=`** so the workflows' explicit values win. This is what those exports were for.
- **The describe fallback takes `--match 'v[0-9]*'`** so it can't land on the rolling tag regardless of how refs were fetched. This covers local and rolling builds, which pass no `VERSION`.

## Verification

My earlier check was a false negative because I tested where the annotated tag survives. So this time I reproduced CI's actual state — both tags lightweight on one commit:

| Expression | Result |
|---|---|
| `git describe --tags --always --dirty` (old) | `latest` ← the bug |
| `… --match 'v[0-9]*'` (new) | `v1.0.1` |

Then end to end through the Makefile:

| Path | Env | Stamps |
|---|---|---|
| Release | `VERSION=v1.0.2 COMMIT=abc1234` | `v1.0.2`, `commit: abc1234` |
| Rolling | `VERSION=latest` | `latest` |
| Local dev | none | `v1.0.1-dirty` via matched describe |

Lint clean, all 12 packages pass. No Go code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)