### PR TITLE
Make render --clean atomic

### DIFF
--- a/internal/renderer/atomic.go
+++ b/internal/renderer/atomic.go
@@ -1,0 +1,50 @@
+package renderer
+
+import (
+	"fmt"
+	"os"
+)
+
+// AtomicSwap moves originalDir to oldDir, then renderDir to originalDir, and removes oldDir.
+func AtomicSwap(renderDir, originalDir string) error {
+	oldDir := originalDir + ".old"
+	_ = os.RemoveAll(oldDir)
+
+	if err := os.Rename(originalDir, oldDir); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to move old directory aside: %w", err)
+	}
+	if err := os.Rename(renderDir, originalDir); err != nil {
+		_ = os.Rename(oldDir, originalDir) // Try to put original back
+		return fmt.Errorf("failed to put new directory in place: %w", err)
+	}
+	_ = os.RemoveAll(oldDir)
+	return nil
+}
+
+// PrepareStagingDir returns a staging directory path and removes it if it exists.
+func PrepareStagingDir(originalDir string) (string, error) {
+	renderDir := originalDir + ".new"
+	if err := os.RemoveAll(renderDir); err != nil {
+		return "", fmt.Errorf("failed to clear staging directory: %w", err)
+	}
+	return renderDir, nil
+}
+
+// SetupStagingDir prepares a temporary staging directory if clean is requested.
+// It returns the temporary directory name and a cleanup function to defer.
+func SetupStagingDir(clean bool, outputDir string) (renderDir string, cleanup func(), err error) {
+	if !clean {
+		return outputDir, func() {}, nil
+	}
+
+	renderDir, err = PrepareStagingDir(outputDir)
+	if err != nil {
+		return "", nil, err
+	}
+
+	cleanup = func() {
+		os.RemoveAll(renderDir)
+	}
+
+	return renderDir, cleanup, nil
+}

--- a/internal/renderer/workflow.go
+++ b/internal/renderer/workflow.go
@@ -66,12 +66,15 @@ func summarize(feeds []database.Feed, items map[string][]database.Item) *Result 
 
 // ExecuteWorkflow performs the complete render operation with the given configuration.
 func ExecuteWorkflow(config *WorkflowConfig) (*Result, error) {
-	// Clean output directory if requested (do this early to avoid dependency issues)
-	if config.Clean {
-		if err := cleanOutputDirectory(config.OutputDir, config.Quiet); err != nil {
-			return nil, err
-		}
+	originalOutputDir := config.OutputDir
+
+	renderDir, cleanup, err := SetupStagingDir(config.Clean, originalOutputDir)
+	if err != nil {
+		return nil, err
 	}
+	defer cleanup()
+	config.OutputDir = renderDir
+	defer func() { config.OutputDir = originalOutputDir }()
 
 	// Setup database
 	db, err := database.New(config.Database)
@@ -131,7 +134,15 @@ func ExecuteWorkflow(config *WorkflowConfig) (*Result, error) {
 		return nil, err
 	}
 
-	return summarize(feeds, items), nil
+	result := summarize(feeds, items)
+
+	if config.Clean {
+		if err := AtomicSwap(renderDir, originalOutputDir); err != nil {
+			return nil, err
+		}
+	}
+
+	return result, nil
 }
 
 // loadFeedURLs reads the feed list at feedsFile and returns its URLs together
@@ -529,23 +540,4 @@ func printSuccessMessage(feedCount int, feedTemplateExists bool, outputDir, outp
 func generateFeedID(feedURL string) string {
 	hash := sha256.Sum256([]byte(feedURL))
 	return fmt.Sprintf("%x", hash)[:8]
-}
-
-func cleanOutputDirectory(outputDir string, quiet bool) error {
-	// Check if directory exists
-	if _, err := os.Stat(outputDir); os.IsNotExist(err) {
-		// Directory doesn't exist, nothing to clean
-		return nil
-	}
-
-	if !quiet {
-		fmt.Printf("Cleaning output directory: %s\n", outputDir) //nolint:forbidigo // User-facing output
-	}
-
-	// Remove the entire directory
-	if err := os.RemoveAll(outputDir); err != nil {
-		return fmt.Errorf("failed to remove output directory: %w", err)
-	}
-
-	return nil
 }

--- a/internal/sitegroup/render.go
+++ b/internal/sitegroup/render.go
@@ -109,11 +109,14 @@ func RenderAll(dir string, base *renderer.WorkflowConfig) (*RenderSummary, error
 		logrus.Warnf("Skipping feed list %s: %v", s.Path, s.Err)
 	}
 
-	if base.Clean {
-		if err := os.RemoveAll(base.OutputDir); err != nil {
-			return nil, fmt.Errorf("failed to clean output directory %s: %w", base.OutputDir, err)
-		}
+	originalOutputDir := base.OutputDir
+	renderDir, cleanup, err := renderer.SetupStagingDir(base.Clean, originalOutputDir)
+	if err != nil {
+		return nil, err
 	}
+	defer cleanup()
+	base.OutputDir = renderDir
+	defer func() { base.OutputDir = originalOutputDir }()
 
 	summary := &RenderSummary{
 		Sites:   make([]SiteResult, 0, len(sites)),
@@ -139,6 +142,12 @@ func RenderAll(dir string, base *renderer.WorkflowConfig) (*RenderSummary, error
 
 	if err := renderIndex(base, summary, startTime, endTime); err != nil {
 		return nil, err
+	}
+
+	if base.Clean {
+		if err := renderer.AtomicSwap(renderDir, originalOutputDir); err != nil {
+			return nil, err
+		}
 	}
 
 	logrus.Infof("Generated %d site(s) in %s", len(summary.Sites), base.OutputDir)


### PR DESCRIPTION
Fixes #48 by rendering into a staging directory and doing an atomic swap at the end when --clean is requested. This means zero downtime for clean renders, even if rendering fails. Clean up staging directory on failure.