### PR TITLE
Per-feed User-Agent override

### DIFF
--- a/internal/database/feed_repository.go
+++ b/internal/database/feed_repository.go
@@ -13,8 +13,8 @@ import (
 func (db *DB) UpsertFeed(feed *Feed) error {
 	query := `
 		INSERT INTO feeds (url, title, description, last_updated, etag, last_modified,
-			last_fetch_time, last_successful_fetch, error_count, last_error, latest_item_date, feed_json)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			last_fetch_time, last_successful_fetch, error_count, user_agent, last_error, latest_item_date, feed_json)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(url) DO UPDATE SET
 			title = excluded.title,
 			description = excluded.description,
@@ -24,6 +24,7 @@ func (db *DB) UpsertFeed(feed *Feed) error {
 			last_fetch_time = excluded.last_fetch_time,
 			last_successful_fetch = excluded.last_successful_fetch,
 			error_count = excluded.error_count,
+			user_agent = COALESCE(NULLIF(excluded.user_agent, ''), feeds.user_agent),
 			last_error = excluded.last_error,
 			latest_item_date = COALESCE(excluded.latest_item_date, feeds.latest_item_date),
 			feed_json = excluded.feed_json
@@ -32,7 +33,7 @@ func (db *DB) UpsertFeed(feed *Feed) error {
 	_, err := db.conn.Exec(query,
 		feed.URL, feed.Title, feed.Description, feed.LastUpdated, feed.ETag,
 		feed.LastModified, feed.LastFetchTime, feed.LastSuccessfulFetch,
-		feed.ErrorCount, feed.LastError, feed.LatestItemDate, feed.FeedJSON)
+		feed.ErrorCount, feed.UserAgent, feed.LastError, feed.LatestItemDate, feed.FeedJSON)
 	if err != nil {
 		return fmt.Errorf("failed to upsert feed: %w", err)
 	}
@@ -45,7 +46,7 @@ func (db *DB) UpsertFeed(feed *Feed) error {
 func (db *DB) GetFeed(url string) (*Feed, error) {
 	query := `
 		SELECT url, title, description, last_updated, etag, last_modified,
-			last_fetch_time, last_successful_fetch, error_count, last_error, latest_item_date, feed_json
+			last_fetch_time, last_successful_fetch, error_count, user_agent, last_error, latest_item_date, feed_json
 		FROM feeds WHERE url = ?
 	`
 
@@ -53,7 +54,7 @@ func (db *DB) GetFeed(url string) (*Feed, error) {
 	err := db.conn.QueryRow(query, url).Scan(
 		&feed.URL, &feed.Title, &feed.Description, &feed.LastUpdated, &feed.ETag,
 		&feed.LastModified, &feed.LastFetchTime, &feed.LastSuccessfulFetch,
-		&feed.ErrorCount, &feed.LastError, &feed.LatestItemDate, &feed.FeedJSON,
+		&feed.ErrorCount, &feed.UserAgent, &feed.LastError, &feed.LatestItemDate, &feed.FeedJSON,
 	)
 
 	if err == sql.ErrNoRows {
@@ -70,7 +71,7 @@ func (db *DB) GetFeed(url string) (*Feed, error) {
 func (db *DB) GetAllFeeds() ([]*Feed, error) {
 	query := `
 		SELECT url, title, description, last_updated, etag, last_modified,
-			last_fetch_time, last_successful_fetch, error_count, last_error, latest_item_date, feed_json
+			last_fetch_time, last_successful_fetch, error_count, user_agent, last_error, latest_item_date, feed_json
 		FROM feeds ORDER BY url
 	`
 
@@ -86,7 +87,7 @@ func (db *DB) GetAllFeeds() ([]*Feed, error) {
 		err := rows.Scan(
 			&feed.URL, &feed.Title, &feed.Description, &feed.LastUpdated, &feed.ETag,
 			&feed.LastModified, &feed.LastFetchTime, &feed.LastSuccessfulFetch,
-			&feed.ErrorCount, &feed.LastError, &feed.LatestItemDate, &feed.FeedJSON,
+			&feed.ErrorCount, &feed.UserAgent, &feed.LastError, &feed.LatestItemDate, &feed.FeedJSON,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan feed: %w", err)
@@ -142,7 +143,8 @@ func (db *DB) GetFeedsWithItemsByTimeRange(start, end time.Time, feedURLs []stri
 	// Use latest_item_date to determine if feed has recent items, falling back to last_updated
 	feedsQuery := `
 		SELECT f.url, f.title, f.description, f.last_updated, f.etag, f.last_modified,
-			f.last_fetch_time, f.last_successful_fetch, f.error_count, f.last_error, f.latest_item_date, f.feed_json
+			f.last_fetch_time, f.last_successful_fetch, f.error_count, f.user_agent, 
+			f.last_error, f.latest_item_date, f.feed_json
 		FROM feeds f
 		WHERE COALESCE(f.latest_item_date, f.last_updated) >= ?
 			AND COALESCE(f.latest_item_date, f.last_updated) <= ?
@@ -184,7 +186,7 @@ func (db *DB) GetFeedsWithItemsByTimeRange(start, end time.Time, feedURLs []stri
 		err := rows.Scan(
 			&feed.URL, &feed.Title, &feed.Description, &feed.LastUpdated, &feed.ETag,
 			&feed.LastModified, &feed.LastFetchTime, &feed.LastSuccessfulFetch,
-			&feed.ErrorCount, &feed.LastError, &feed.LatestItemDate, &feed.FeedJSON,
+			&feed.ErrorCount, &feed.UserAgent, &feed.LastError, &feed.LatestItemDate, &feed.FeedJSON,
 		)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to scan feed: %w", err)
@@ -268,7 +270,7 @@ func (db *DB) GetFeedsWithItemsMinimum(
 func (db *DB) getFeedsFiltered(feedURLs []string) ([]Feed, error) {
 	query := `
 		SELECT url, title, description, last_updated, etag, last_modified,
-			last_fetch_time, last_successful_fetch, error_count, last_error, latest_item_date, feed_json
+			last_fetch_time, last_successful_fetch, error_count, user_agent, last_error, latest_item_date, feed_json
 		FROM feeds
 	`
 	args := []interface{}{}
@@ -303,7 +305,7 @@ func (db *DB) getFeedsFiltered(feedURLs []string) ([]Feed, error) {
 		err := rows.Scan(
 			&feed.URL, &feed.Title, &feed.Description, &feed.LastUpdated, &feed.ETag,
 			&feed.LastModified, &feed.LastFetchTime, &feed.LastSuccessfulFetch,
-			&feed.ErrorCount, &feed.LastError, &feed.LatestItemDate, &feed.FeedJSON,
+			&feed.ErrorCount, &feed.UserAgent, &feed.LastError, &feed.LatestItemDate, &feed.FeedJSON,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan feed: %w", err)

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -12,7 +12,8 @@ const (
 	migrationVersion2   = 2 // Add latest_item_date column to feeds
 	migrationVersion3   = 3 // Add url_metadata table
 	migrationVersion4   = 4 // Add first_seen column to items
-	maxMigrationVersion = migrationVersion4
+	migrationVersion5   = 5 // Add user_agent column to feeds
+	maxMigrationVersion = migrationVersion5
 )
 
 // getMigrations returns the database migration scripts.
@@ -40,6 +41,7 @@ func getMigrations() map[int]string {
 			UPDATE url_metadata SET updated_at = CURRENT_TIMESTAMP WHERE url = NEW.url;
 		END;`,
 		migrationVersion4: `ALTER TABLE items ADD COLUMN first_seen DATETIME;`,
+		migrationVersion5: `ALTER TABLE feeds ADD COLUMN user_agent TEXT NOT NULL DEFAULT '';`,
 	}
 }
 
@@ -115,6 +117,8 @@ func (db *DB) applySpecificMigration(version int) error {
 		return db.applyMigration3()
 	case migrationVersion4:
 		return db.applyMigration4()
+	case migrationVersion5:
+		return db.applyMigration5()
 	default:
 		// For any new migrations, just apply them directly
 		migrations := getMigrations()
@@ -253,5 +257,30 @@ func (db *DB) applyMigration4WithBackfill() error {
 		return fmt.Errorf("failed to commit migration: %w", err)
 	}
 	committed = true
+	return nil
+}
+
+// applyMigration5 adds the user_agent column to feeds table.
+func (db *DB) applyMigration5() error {
+	// Check if user_agent column already exists
+	var colCount int
+	err := db.conn.QueryRow(`
+		SELECT COUNT(*) FROM pragma_table_info('feeds')
+		WHERE name = 'user_agent'
+	`).Scan(&colCount)
+	if err != nil {
+		return fmt.Errorf("failed to check column existence: %w", err)
+	}
+
+	if colCount == 0 {
+		migrations := getMigrations()
+		return db.ApplyMigration(migrationVersion5, migrations[migrationVersion5])
+	}
+
+	// Column exists, just record the migration
+	_, err = db.conn.Exec("INSERT INTO schema_migrations (version) VALUES (?)", migrationVersion5)
+	if err != nil {
+		return fmt.Errorf("failed to record migration %d: %w", migrationVersion5, err)
+	}
 	return nil
 }

--- a/internal/database/migrations_test.go
+++ b/internal/database/migrations_test.go
@@ -224,8 +224,8 @@ func TestRunMigrationsOnProperlyInitializedDatabase(t *testing.T) {
 		t.Fatalf("GetMigrationVersion() error = %v", err)
 	}
 
-	if version != 4 {
-		t.Errorf("After InitSchema + RunMigrations, version should be 4, got %d", version)
+	if version != maxMigrationVersion {
+		t.Errorf("After InitSchema + RunMigrations, version should be %d, got %d", maxMigrationVersion, version)
 	}
 
 	// Verify we have the latest_item_date column
@@ -286,8 +286,8 @@ func TestRunMigrationsOnExistingDatabase(t *testing.T) {
 		t.Fatalf("GetMigrationVersion() error = %v", err)
 	}
 
-	if version != 4 {
-		t.Errorf("After migration, version should be 4, got %d", version)
+	if version != maxMigrationVersion {
+		t.Errorf("After migration, version should be %d, got %d", maxMigrationVersion, version)
 	}
 
 	// Verify latest_item_date column was added
@@ -333,8 +333,8 @@ func TestRunMigrationsIdempotent(t *testing.T) {
 		t.Fatalf("GetMigrationVersion() error = %v", err)
 	}
 
-	if version != 4 {
-		t.Errorf("After double migration, version should be 4, got %d", version)
+	if version != maxMigrationVersion {
+		t.Errorf("After double migration, version should be %d, got %d", maxMigrationVersion, version)
 	}
 
 	// Should still have exactly one latest_item_date column
@@ -399,8 +399,8 @@ func TestRunMigrationsWithExistingColumn(t *testing.T) {
 		t.Fatalf("GetMigrationVersion() error = %v", err)
 	}
 
-	if version != 4 {
-		t.Errorf("With existing column, version should be 4, got %d", version)
+	if version != maxMigrationVersion {
+		t.Errorf("With existing column, version should be %d, got %d", maxMigrationVersion, version)
 	}
 
 	// Verify column still exists and works

--- a/internal/database/models.go
+++ b/internal/database/models.go
@@ -38,6 +38,7 @@ type Feed struct {
 	LastFetchTime       time.Time    `db:"last_fetch_time"`
 	LastSuccessfulFetch time.Time    `db:"last_successful_fetch"`
 	ErrorCount          int          `db:"error_count"`
+	UserAgent           string       `db:"user_agent"`
 	LastError           string       `db:"last_error"`
 	LatestItemDate      sql.NullTime `db:"latest_item_date"`
 	FeedJSON            JSON         `db:"feed_json"`

--- a/internal/database/schema.sql
+++ b/internal/database/schema.sql
@@ -10,6 +10,7 @@ CREATE TABLE IF NOT EXISTS feeds (
     last_fetch_time DATETIME,
     last_successful_fetch DATETIME,
     error_count INTEGER NOT NULL DEFAULT 0,
+    user_agent TEXT NOT NULL DEFAULT '',
     last_error TEXT NOT NULL DEFAULT '',
     latest_item_date DATETIME,
     feed_json JSON

--- a/internal/fetcher/fetcher.go
+++ b/internal/fetcher/fetcher.go
@@ -66,6 +66,12 @@ func (f *Fetcher) FetchFeed(feedURL string) *FetchResult {
 	}
 
 	headers := make(map[string]string)
+
+	// Apply per-feed User-Agent override if present
+	if existingFeed != nil && existingFeed.UserAgent != "" {
+		headers["User-Agent"] = existingFeed.UserAgent
+	}
+
 	if !f.forceFlag && existingFeed != nil {
 		if existingFeed.ETag != "" {
 			headers["If-None-Match"] = existingFeed.ETag

--- a/internal/fetcher/fetcher_test.go
+++ b/internal/fetcher/fetcher_test.go
@@ -398,3 +398,36 @@ func TestFetchConcurrentWithMaxAge(t *testing.T) {
 		t.Errorf("FetchConcurrent() should skip recently fetched feed (cached=true)")
 	}
 }
+
+func TestFetchFeedUserAgentOverride(t *testing.T) {
+	db := setupTestDatabase(t)
+	const customUA = "MyCustomUserAgent/1.0"
+
+	// Create test server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("User-Agent") != customUA {
+			t.Errorf("Expected User-Agent %q, got %q", customUA, r.Header.Get("User-Agent"))
+		}
+		w.Header().Set("Content-Type", "application/rss+xml")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(testFeedXML))
+	}))
+	defer server.Close()
+
+	// Pre-populate feed with custom User-Agent
+	err := db.UpsertFeed(&database.Feed{
+		URL:       server.URL,
+		Title:     "Custom UA Feed",
+		UserAgent: customUA,
+	})
+	if err != nil {
+		t.Fatalf("Failed to pre-populate feed: %v", err)
+	}
+
+	fetcher := NewFetcher(db, 30*time.Second, 100, false)
+	result := fetcher.FetchFeed(server.URL)
+
+	if result.Error != nil {
+		t.Errorf("Expected no error, got %v", result.Error)
+	}
+}


### PR DESCRIPTION
Fixes #37 by adding a user_agent column to the feeds table, and applying it during fetching if it's present. This provides an escape hatch when a particular feed needs a different UA to come back unblocked.