### PR TITLE
Add per-feed User-Agent support to OPML lists

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -178,10 +178,14 @@ from a webpage.
 | `--format` | (config) | `opml` or `text` |
 | `--filename` | (config) | Path to subscription file |
 | `--discover` | false | Treat URL as a webpage; parse its HTML for `<link>` feed references |
+| `--user-agent` | (unset) | Set the feed's User-Agent override in an OPML list; use `--user-agent=` to clear it |
 
-**Side effects:** Creates the subscription file if it does not exist; appends
-the URL. Network request only when `--discover` is set. Does not touch the
-database.
+`--user-agent` works only with OPML lists. Re-subscribing to an existing URL
+updates its `userAgent` outline attribute instead of adding a duplicate.
+
+**Side effects:** Creates the subscription file if it does not exist; adds or
+updates the URL. Makes a network request only when `--discover` is set. Does
+not touch the database.
 
 **Examples:**
 
@@ -189,6 +193,7 @@ database.
 feedspool subscribe https://example.com/feed.xml
 feedspool subscribe --discover https://example.com/blog
 feedspool subscribe --format opml --filename feeds.opml https://example.com/feed.xml
+feedspool subscribe --format opml --filename feeds.opml --user-agent "Custom Reader/1.0" https://example.com/feed.xml
 ```
 
 ### unsubscribe
@@ -235,7 +240,9 @@ Fetch feed content. Has three modes depending on arguments.
 **Side effects:** Writes feeds and items to the database. Marks items no
 longer in the live feed as archived. May delete feed rows when
 `--remove-missing` is used. If `--with-unfurl` is set, also writes
-`url_metadata`.
+`url_metadata`. Before fetching OPML lists, including directory mode, copies
+each outline's `userAgent` value into the feed row; a missing attribute clears
+the override. Conflicting values for one URL stop the fetch.
 
 **JSON output (`--json`):**
 
@@ -490,6 +497,9 @@ subscription list are deleted. ON DELETE CASCADE removes their items.
 Write all feeds currently in the database to a subscription file.
 
 **Usage:** `feedspool export <filename> --format <opml|text>`
+
+OPML exports include each feed's `userAgent` override. Text lists contain URLs
+only.
 
 **Side effects:** Overwrites the target file.
 
@@ -915,6 +925,12 @@ content changed but its server lies about it.
 touch the database. The database accumulates whatever you fetch. To bring
 the DB back in line with the subscription list, run `purge --format <fmt>
 --filename <file>` (or `fetch --remove-missing`).
+
+OPML outlines may carry a per-feed `userAgent` attribute. An OPML-backed fetch
+synchronizes that attribute before making requests. Directory mode does the
+same across all OPML files and rejects conflicting values for one URL. Removing
+the attribute restores feedspool's default User-Agent on the next fetch. Text
+lists cannot store per-feed User-Agent overrides.
 
 ### What `purge` actually deletes
 

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -74,15 +74,15 @@ func runExport(_ *cobra.Command, args []string) error {
 	// Create new feed list of specified format
 	list := feedlist.NewFeedList(feedFormat)
 
-	// Add all feed URLs to the list
+	// Add all feeds and any metadata supported by the target format.
 	for _, feed := range feeds {
-		if err := list.AddURL(feed.URL); err != nil {
+		if err := list.AddFeed(feedlist.Feed{
+			URL:       feed.URL,
+			UserAgent: feed.UserAgent,
+		}); err != nil {
 			return fmt.Errorf("failed to add URL %s to feed list: %w", feed.URL, err)
 		}
 	}
-
-	// For OPML format, we could enhance with feed metadata in the future
-	// For now, both formats just export URLs
 
 	// Save to specified filename
 	if err := list.Save(exportFilename); err != nil {

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -253,6 +253,9 @@ func runDirFetch(
 			len(plan.URLs), pluralize(len(plan.URLs), "feed", "feeds"),
 			plan.References, pluralize(plan.References, "reference", "references"))
 	}
+	if err := orchestrator.SynchronizeFeedConfigs(plan.FeedConfigs); err != nil {
+		return err
+	}
 
 	results := orchestrator.FetchFromURLs(ctx, plan.URLs, opts)
 

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -8,9 +8,10 @@ import (
 )
 
 var (
-	subscribeFormat   string
-	subscribeFilename string
-	subscribeDiscover bool
+	subscribeFormat    string
+	subscribeFilename  string
+	subscribeDiscover  bool
+	subscribeUserAgent string
 )
 
 var subscribeCmd = &cobra.Command{
@@ -22,6 +23,8 @@ If --discover is specified, the URL will be treated as a webpage and parsed for 
 
 Examples:
   feedspool subscribe https://example.com/feed.xml
+  feedspool subscribe --user-agent "Custom Reader/1.0" https://example.com/feed.xml
+  feedspool subscribe --user-agent= https://example.com/feed.xml
   feedspool subscribe --discover https://example.com/blog
   feedspool subscribe --format text --filename feeds.txt https://example.com/feed.xml`,
 	Args: cobra.ExactArgs(1),
@@ -32,10 +35,16 @@ func init() {
 	subscribeCmd.Flags().StringVar(&subscribeFormat, "format", "", "Feed list format (opml or text)")
 	subscribeCmd.Flags().StringVar(&subscribeFilename, "filename", "", "Feed list filename")
 	subscribeCmd.Flags().BoolVar(&subscribeDiscover, "discover", false, "Discover RSS/Atom feeds from HTML page")
+	subscribeCmd.Flags().StringVar(
+		&subscribeUserAgent,
+		"user-agent",
+		"",
+		"Per-feed User-Agent override for OPML lists (use --user-agent= to clear)",
+	)
 	rootCmd.AddCommand(subscribeCmd)
 }
 
-func runSubscribe(_ *cobra.Command, args []string) error {
+func runSubscribe(cmd *cobra.Command, args []string) error {
 	targetURL := args[0]
 	cfg := GetConfig()
 
@@ -55,7 +64,11 @@ func runSubscribe(_ *cobra.Command, args []string) error {
 		return nil
 	}
 
-	result, err := manager.Subscribe(format, filename, urlsToAdd)
+	options := subscription.SubscribeOptions{}
+	if cmd.Flags().Changed("user-agent") {
+		options.UserAgent = &subscribeUserAgent
+	}
+	result, err := manager.SubscribeWithOptions(format, filename, urlsToAdd, options)
 	if err != nil {
 		return err
 	}
@@ -76,7 +89,11 @@ func runSubscribe(_ *cobra.Command, args []string) error {
 	if result.AddedCount > 0 {
 		fmt.Printf("Added %d new feed(s)\n", result.AddedCount)
 		fmt.Printf("Saved %d new feed(s) to %s\n", result.AddedCount, filename)
-	} else {
+	}
+	if result.UpdatedCount > 0 {
+		fmt.Printf("Updated %d existing feed(s) in %s\n", result.UpdatedCount, filename)
+	}
+	if result.AddedCount == 0 && result.UpdatedCount == 0 {
 		fmt.Println("No new feeds to add.")
 	}
 

--- a/docs/dev-sessions/2026-08-25-1320-opml-user-agent/notes.md
+++ b/docs/dev-sessions/2026-08-25-1320-opml-user-agent/notes.md
@@ -1,0 +1,34 @@
+# Session notes
+
+## Decisions
+
+- Used an unnamespaced `userAgent` attribute because the issue permits a
+  namespace only if necessary and the simpler form interoperates with normal
+  OPML readers.
+- Treated OPML as authoritative during every fetch. Text lists contribute URLs
+  only and never overwrite feed configuration.
+- Kept duplicate entries legal when their configuration agrees; conflicting
+  values fail before network access.
+- Preserved unknown OPML elements as namespace-aware XML tokens. Raw inner XML
+  cannot safely round-trip nested namespace declarations through Go's
+  `encoding/xml` encoder.
+
+## Review findings addressed
+
+- Directory-mode fetch plans initially dropped per-feed configuration.
+- Duplicate updates could skip earlier outlines when the last duplicate already
+  matched the requested value.
+- Nested unsubscribe needed recursive removal.
+- Missing and malformed subscription files needed distinct handling.
+- Unknown namespaced OPML extensions needed semantic round-trip preservation.
+
+## Verification
+
+- `make format`
+- `make lint` — 0 issues
+- `make test` — all packages passed
+- `make build` — Darwin arm64 build succeeded with CGO disabled
+
+The implementation is a single commit on `fix/51-opml-user-agent`. Independent
+final review found no remaining Important or Minor issues. PR #53 is open for
+Les's review: <https://github.com/lmorchard/feedspool-go/pull/53>.

--- a/docs/dev-sessions/2026-08-25-1320-opml-user-agent/plan.md
+++ b/docs/dev-sessions/2026-08-25-1320-opml-user-agent/plan.md
@@ -1,0 +1,13 @@
+# Implementation plan
+
+1. Extend OPML and feed-list models to read, update, write, and export per-feed
+   User-Agent values while preserving unknown metadata.
+2. Add subscription CLI and manager behavior for setting, updating, clearing,
+   and validating the option.
+3. Carry feed configuration through single-file and directory fetch planning,
+   reject conflicts, and synchronize the database before requests.
+4. Cover recursive outlines, duplicates, malformed files, extension metadata,
+   directory mode, and outgoing request headers with regression tests.
+5. Update the manual, run repository verification, obtain code review, and open
+   a PR that closes issue #51.
+

--- a/docs/dev-sessions/2026-08-25-1320-opml-user-agent/spec.md
+++ b/docs/dev-sessions/2026-08-25-1320-opml-user-agent/spec.md
@@ -1,0 +1,32 @@
+# OPML per-feed User-Agent support
+
+Issue: [#51](https://github.com/lmorchard/feedspool-go/issues/51)
+
+## Goal
+
+Make OPML subscription files the source of truth for each feed's optional
+HTTP User-Agent, building on the database field added by PR #50.
+
+## Approved behavior
+
+- Store the value in an unnamespaced `userAgent` attribute on feed outlines.
+- Accept `subscribe --user-agent VALUE` for OPML lists.
+- Re-subscribing updates existing matching outlines; an explicit empty value
+  clears the setting.
+- Reject `--user-agent` for text lists because they cannot represent it.
+- Before fetching, synchronize OPML values into the database, including empty
+  values, so the list remains authoritative.
+- Apply the same synchronization in directory mode.
+- Reject duplicate OPML entries with conflicting User-Agent values before any
+  network request.
+- Preserve unrelated OPML structure and extension metadata when editing.
+- Include the attribute in OPML export.
+- Do not add another database migration.
+
+## Compatibility and safety
+
+OPML files without `userAgent` continue to work and clear stale database
+values. Malformed existing subscription files must return an error rather than
+being replaced. Nested category outlines and duplicate matching outlines must
+remain structurally intact.
+

--- a/integration_test.go
+++ b/integration_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/lmorchard/feedspool-go/internal/config"
 	"github.com/lmorchard/feedspool-go/internal/database"
+	"github.com/lmorchard/feedspool-go/internal/feedlist"
 	"github.com/lmorchard/feedspool-go/internal/fetcher"
 	"github.com/lmorchard/feedspool-go/internal/renderer"
 	"github.com/lmorchard/feedspool-go/internal/sitegroup"
@@ -42,6 +43,126 @@ const integrationTestFeed = `<?xml version="1.0" encoding="UTF-8"?>
         </item>
     </channel>
 </rss>`
+
+func TestSubscribeUserAgentCLI(t *testing.T) {
+	binaryPath := buildBinaryViaMake(t)
+	filename := filepath.Join(t.TempDir(), "feeds.opml")
+	const userAgent = "Integration Reader/1.0"
+
+	output, err := runCommand(
+		binaryPath,
+		"subscribe", "--format", "opml", "--filename", filename,
+		"--user-agent", userAgent, "https://example.com/feed.xml",
+	)
+	if err != nil {
+		t.Fatalf("subscribe --user-agent failed: %v, output: %s", err, output)
+	}
+
+	list, err := feedlist.LoadFeedList(feedlist.FormatOPML, filename)
+	if err != nil {
+		t.Fatalf("LoadFeedList() error = %v", err)
+	}
+	feeds := list.GetFeeds()
+	if len(feeds) != 1 {
+		t.Fatalf("len(GetFeeds()) = %d, want 1", len(feeds))
+	}
+	if got := feeds[0].UserAgent; got != userAgent {
+		t.Errorf("subscribed UserAgent = %q, want %q", got, userAgent)
+	}
+}
+
+func TestExportPreservesUserAgent(t *testing.T) {
+	tmpDir := t.TempDir()
+	databasePath := filepath.Join(tmpDir, "feeds.db")
+	exportPath := filepath.Join(tmpDir, "feeds.opml")
+	const userAgent = "Exported Reader/1.0"
+
+	db, err := database.New(databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.InitSchema(); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.UpsertFeed(&database.Feed{
+		URL:       "https://example.com/feed.xml",
+		Title:     "Example Feed",
+		UserAgent: userAgent,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	binaryPath := buildBinaryViaMake(t)
+	output, err := runCommand(
+		binaryPath,
+		"--database", databasePath,
+		"export", "--format", "opml", exportPath,
+	)
+	if err != nil {
+		t.Fatalf("export failed: %v, output: %s", err, output)
+	}
+
+	list, err := feedlist.LoadFeedList(feedlist.FormatOPML, exportPath)
+	if err != nil {
+		t.Fatalf("LoadFeedList() error = %v", err)
+	}
+	feeds := list.GetFeeds()
+	if len(feeds) != 1 {
+		t.Fatalf("len(GetFeeds()) = %d, want 1", len(feeds))
+	}
+	if got := feeds[0].UserAgent; got != userAgent {
+		t.Errorf("exported UserAgent = %q, want %q", got, userAgent)
+	}
+}
+
+func TestDirectoryFetchUsesOPMLUserAgent(t *testing.T) {
+	const userAgent = "Directory Reader/1.0"
+	requests := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- r.Header.Get("User-Agent")
+		w.Header().Set("Content-Type", "application/rss+xml")
+		_, _ = w.Write([]byte(integrationTestFeed))
+	}))
+	defer server.Close()
+
+	tmpDir := t.TempDir()
+	listDir := filepath.Join(tmpDir, "feeds.d")
+	if err := os.Mkdir(listDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	opml := `<opml version="2.0"><body><outline xmlUrl="` + server.URL + `" userAgent="` + userAgent + `" /></body></opml>`
+	if err := os.WriteFile(filepath.Join(listDir, "protected.opml"), []byte(opml), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	databasePath := filepath.Join(tmpDir, "feeds.db")
+	db, err := database.New(databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.InitSchema(); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	binaryPath := buildBinaryViaMake(t)
+	output, err := runCommand(
+		binaryPath,
+		"--database", databasePath,
+		"fetch", "--feeds-dir", listDir, "--concurrency", "1",
+	)
+	if err != nil {
+		t.Fatalf("directory fetch failed: %v, output: %s", err, output)
+	}
+	if got := <-requests; got != userAgent {
+		t.Errorf("directory request User-Agent = %q, want %q", got, userAgent)
+	}
+}
 
 func TestIntegrationEndToEnd(t *testing.T) {
 	if testing.Short() {

--- a/internal/database/feed_repository.go
+++ b/internal/database/feed_repository.go
@@ -42,6 +42,20 @@ func (db *DB) UpsertFeed(feed *Feed) error {
 	return nil
 }
 
+// SetFeedUserAgent inserts or updates only a feed's User-Agent override.
+func (db *DB) SetFeedUserAgent(url, userAgent string) error {
+	_, err := db.conn.Exec(`
+		INSERT INTO feeds (
+			url, user_agent, last_updated, last_fetch_time, last_successful_fetch
+		) VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(url) DO UPDATE SET user_agent = excluded.user_agent
+	`, url, userAgent, time.Time{}, time.Time{}, time.Time{})
+	if err != nil {
+		return fmt.Errorf("failed to set User-Agent for feed %s: %w", url, err)
+	}
+	return nil
+}
+
 // GetFeed retrieves a feed by URL from the database.
 func (db *DB) GetFeed(url string) (*Feed, error) {
 	query := `

--- a/internal/database/feed_repository_test.go
+++ b/internal/database/feed_repository_test.go
@@ -60,6 +60,40 @@ func TestGetFeedNotFound(t *testing.T) {
 	}
 }
 
+func TestSetFeedUserAgent(t *testing.T) {
+	db := setupTestDB(t)
+	const customUserAgent = "Custom Reader/1.0"
+
+	if err := db.SetFeedUserAgent(fixtureFeedURL, customUserAgent); err != nil {
+		t.Fatalf("SetFeedUserAgent() insert error = %v", err)
+	}
+	feed, err := db.GetFeed(fixtureFeedURL)
+	if err != nil {
+		t.Fatalf("GetFeed() error = %v", err)
+	}
+	if feed == nil || feed.UserAgent != customUserAgent {
+		t.Fatalf("GetFeed() = %#v, want UserAgent %q", feed, customUserAgent)
+	}
+
+	feed.Title = fixtureFeedTitle
+	if err := db.UpsertFeed(feed); err != nil {
+		t.Fatalf("UpsertFeed() error = %v", err)
+	}
+	if err := db.SetFeedUserAgent(fixtureFeedURL, ""); err != nil {
+		t.Fatalf("SetFeedUserAgent() clear error = %v", err)
+	}
+	feed, err = db.GetFeed(fixtureFeedURL)
+	if err != nil {
+		t.Fatalf("GetFeed() after clear error = %v", err)
+	}
+	if feed.UserAgent != "" {
+		t.Errorf("cleared UserAgent = %q, want empty string", feed.UserAgent)
+	}
+	if feed.Title != fixtureFeedTitle {
+		t.Errorf("Title = %q after User-Agent update, want preserved %q", feed.Title, fixtureFeedTitle)
+	}
+}
+
 func TestGetAllFeeds(t *testing.T) {
 	db := setupTestDB(t)
 

--- a/internal/feedlist/feedlist.go
+++ b/internal/feedlist/feedlist.go
@@ -1,6 +1,7 @@
 package feedlist
 
 import (
+	"encoding/xml"
 	"fmt"
 	"io"
 	"os"
@@ -19,6 +20,30 @@ const (
 	FormatText Format = "text"
 )
 
+// Feed describes a feed and the configuration carried by its list entry.
+type Feed struct {
+	URL       string
+	UserAgent string
+}
+
+// DeduplicateFeeds preserves first-seen order and rejects conflicting configuration.
+func DeduplicateFeeds(feeds []Feed) ([]Feed, error) {
+	seen := make(map[string]Feed, len(feeds))
+	unique := make([]Feed, 0, len(feeds))
+	for _, feed := range feeds {
+		existing, found := seen[feed.URL]
+		if !found {
+			seen[feed.URL] = feed
+			unique = append(unique, feed)
+			continue
+		}
+		if existing.UserAgent != feed.UserAgent {
+			return nil, fmt.Errorf("conflicting User-Agent values for feed %s", feed.URL)
+		}
+	}
+	return unique, nil
+}
+
 // String returns the string representation of the format.
 func (f Format) String() string {
 	return string(f)
@@ -26,7 +51,10 @@ func (f Format) String() string {
 
 // FeedList interface provides unified access to different feed list formats.
 type FeedList interface {
+	GetFeeds() []Feed
 	GetURLs() []string
+	AddFeed(feed Feed) error
+	SetUserAgent(url, userAgent string) bool
 	Title() string
 	AddURL(url string) error
 	RemoveURL(url string) error
@@ -36,7 +64,6 @@ type FeedList interface {
 // OPMLFeedList wraps OPML functionality.
 type OPMLFeedList struct {
 	opml *opml.OPML
-	urls []string
 }
 
 // TextFeedList uses the text parser.
@@ -68,10 +95,10 @@ func NewFeedList(format Format) FeedList {
 	case FormatOPML:
 		return &OPMLFeedList{
 			opml: &opml.OPML{
-				Head: opml.Head{Title: "Feed List"},
-				Body: opml.Body{Outlines: []opml.Outline{}},
+				Version: "2.0",
+				Head:    opml.Head{Title: "Feed List"},
+				Body:    opml.Body{Outlines: []opml.Outline{}},
 			},
-			urls: []string{},
 		}
 	case FormatText:
 		return &TextFeedList{
@@ -108,10 +135,8 @@ func loadOPMLFeedList(reader io.Reader) (FeedList, error) {
 		return nil, err
 	}
 
-	urls := opml.ExtractFeedURLs(opmlData)
 	return &OPMLFeedList{
 		opml: opmlData,
-		urls: urls,
 	}, nil
 }
 
@@ -129,9 +154,21 @@ func loadTextFeedList(reader io.Reader) (FeedList, error) {
 
 // OPMLFeedList methods.
 
+// GetFeeds returns feed URLs and their OPML configuration.
+func (ofl *OPMLFeedList) GetFeeds() []Feed {
+	feeds := []Feed{}
+	extractOPMLFeeds(ofl.opml.Body.Outlines, &feeds)
+	return feeds
+}
+
 // GetURLs returns all URLs in the OPML feed list.
 func (ofl *OPMLFeedList) GetURLs() []string {
-	return ofl.urls
+	feeds := ofl.GetFeeds()
+	urls := make([]string, 0, len(feeds))
+	for _, feed := range feeds {
+		urls = append(urls, feed.URL)
+	}
+	return urls
 }
 
 // Title returns the OPML head title, or an empty string if it is unset.
@@ -141,48 +178,39 @@ func (ofl *OPMLFeedList) Title() string {
 
 // AddURL adds a URL to the OPML feed list.
 func (ofl *OPMLFeedList) AddURL(url string) error {
+	return ofl.AddFeed(Feed{URL: url})
+}
+
+// AddFeed adds a configured feed to the OPML feed list.
+func (ofl *OPMLFeedList) AddFeed(feed Feed) error {
 	// Check if URL already exists
-	for _, existingURL := range ofl.urls {
-		if existingURL == url {
+	for _, existingFeed := range ofl.GetFeeds() {
+		if existingFeed.URL == feed.URL {
 			return nil // URL already exists, no error
 		}
 	}
 
-	// Add to URLs slice
-	ofl.urls = append(ofl.urls, url)
-
 	// Add to OPML structure
 	outline := opml.Outline{
-		Text:    url,
-		Title:   url,
-		Type:    "rss",
-		XMLURL:  url,
-		HTMLURL: "",
+		Text:      feed.URL,
+		Title:     feed.URL,
+		Type:      "rss",
+		XMLURL:    feed.URL,
+		UserAgent: feed.UserAgent,
 	}
 	ofl.opml.Body.Outlines = append(ofl.opml.Body.Outlines, outline)
 
 	return nil
 }
 
+// SetUserAgent updates the User-Agent for an existing OPML feed entry.
+func (ofl *OPMLFeedList) SetUserAgent(url, userAgent string) bool {
+	return setOPMLUserAgent(ofl.opml.Body.Outlines, url, userAgent)
+}
+
 // RemoveURL removes a URL from the OPML feed list.
 func (ofl *OPMLFeedList) RemoveURL(url string) error {
-	// Remove from URLs slice
-	newURLs := make([]string, 0)
-	for _, existingURL := range ofl.urls {
-		if existingURL != url {
-			newURLs = append(newURLs, existingURL)
-		}
-	}
-	ofl.urls = newURLs
-
-	// Remove from OPML structure
-	newOutlines := make([]opml.Outline, 0)
-	for _, outline := range ofl.opml.Body.Outlines {
-		if outline.XMLURL != url {
-			newOutlines = append(newOutlines, outline)
-		}
-	}
-	ofl.opml.Body.Outlines = newOutlines
+	ofl.opml.Body.Outlines = removeOPMLFeed(ofl.opml.Body.Outlines, url)
 
 	return nil
 }
@@ -195,39 +223,33 @@ func (ofl *OPMLFeedList) Save(filename string) error {
 	}
 	defer file.Close()
 
-	// Write OPML XML header
-	header := `<?xml version="1.0" encoding="UTF-8"?>
-<opml version="2.0">
-    <head>
-        <title>` + ofl.opml.Head.Title + `</title>
-    </head>
-    <body>
-`
-	if _, err := file.WriteString(header); err != nil {
+	data, err := xml.MarshalIndent(ofl.opml, "", "    ")
+	if err != nil {
+		return fmt.Errorf("failed to encode OPML: %w", err)
+	}
+	if _, err := file.WriteString(xml.Header); err != nil {
 		return fmt.Errorf("failed to write OPML header: %w", err)
 	}
-
-	// Write outlines
-	for _, outline := range ofl.opml.Body.Outlines {
-		line := fmt.Sprintf(`        <outline text=%q type=%q xmlUrl=%q />%s`,
-			outline.Text, outline.Type, outline.XMLURL, "\n")
-		if _, err := file.WriteString(line); err != nil {
-			return fmt.Errorf("failed to write OPML outline: %w", err)
-		}
+	if _, err := file.Write(data); err != nil {
+		return fmt.Errorf("failed to write OPML: %w", err)
 	}
-
-	// Write OPML footer
-	footer := `    </body>
-</opml>
-`
-	if _, err := file.WriteString(footer); err != nil {
-		return fmt.Errorf("failed to write OPML footer: %w", err)
+	if _, err := file.WriteString("\n"); err != nil {
+		return fmt.Errorf("failed to finish OPML: %w", err)
 	}
 
 	return nil
 }
 
 // TextFeedList methods.
+
+// GetFeeds returns URL-only entries for a text feed list.
+func (tfl *TextFeedList) GetFeeds() []Feed {
+	feeds := make([]Feed, 0, len(tfl.urls))
+	for _, url := range tfl.urls {
+		feeds = append(feeds, Feed{URL: url})
+	}
+	return feeds
+}
 
 // GetURLs returns all URLs in the text feed list.
 func (tfl *TextFeedList) GetURLs() []string {
@@ -241,15 +263,62 @@ func (tfl *TextFeedList) Title() string {
 
 // AddURL adds a URL to the text feed list.
 func (tfl *TextFeedList) AddURL(url string) error {
+	return tfl.AddFeed(Feed{URL: url})
+}
+
+// AddFeed adds a URL-only feed to a text feed list.
+func (tfl *TextFeedList) AddFeed(feed Feed) error {
 	// Check if URL already exists
 	for _, existingURL := range tfl.urls {
-		if existingURL == url {
+		if existingURL == feed.URL {
 			return nil // URL already exists, no error
 		}
 	}
 
-	tfl.urls = append(tfl.urls, url)
+	tfl.urls = append(tfl.urls, feed.URL)
 	return nil
+}
+
+// SetUserAgent reports false because text feed lists carry URLs only.
+func (tfl *TextFeedList) SetUserAgent(_, _ string) bool {
+	return false
+}
+
+func extractOPMLFeeds(outlines []opml.Outline, feeds *[]Feed) {
+	for i := range outlines {
+		outline := &outlines[i]
+		if outline.XMLURL != "" {
+			*feeds = append(*feeds, Feed{URL: outline.XMLURL, UserAgent: outline.UserAgent})
+		}
+		extractOPMLFeeds(outline.Outlines, feeds)
+	}
+}
+
+func setOPMLUserAgent(outlines []opml.Outline, url, userAgent string) bool {
+	found := false
+	for i := range outlines {
+		if outlines[i].XMLURL == url {
+			outlines[i].UserAgent = userAgent
+			found = true
+		}
+		if setOPMLUserAgent(outlines[i].Outlines, url, userAgent) {
+			found = true
+		}
+	}
+	return found
+}
+
+func removeOPMLFeed(outlines []opml.Outline, url string) []opml.Outline {
+	kept := make([]opml.Outline, 0, len(outlines))
+	for i := range outlines {
+		outline := &outlines[i]
+		if outline.XMLURL == url {
+			continue
+		}
+		outline.Outlines = removeOPMLFeed(outline.Outlines, url)
+		kept = append(kept, *outline)
+	}
+	return kept
 }
 
 // RemoveURL removes a URL from the text feed list.

--- a/internal/feedlist/feedlist_test.go
+++ b/internal/feedlist/feedlist_test.go
@@ -1,6 +1,7 @@
 package feedlist
 
 import (
+	"encoding/xml"
 	"os"
 	"path/filepath"
 	"strings"
@@ -8,9 +9,13 @@ import (
 )
 
 const (
-	testURL1 = "https://example.com/feed.xml"
-	testURL2 = "https://another.com/rss"
-	testURL3 = "https://third.com/atom.xml"
+	testExistingUserAgent = "Existing Reader/1.0"
+	testNewUserAgent      = "New Reader/2.0"
+	testCategory          = "tech"
+	testEnabled           = "true"
+	testURL1              = "https://example.com/feed.xml"
+	testURL2              = "https://another.com/rss"
+	testURL3              = "https://third.com/atom.xml"
 )
 
 func TestDetectFormat(t *testing.T) {
@@ -259,6 +264,246 @@ func TestOPMLFeedListSaveAndLoad(t *testing.T) {
 	}
 }
 
+func TestOPMLFeedUserAgentRoundTrip(t *testing.T) {
+	const source = `<?xml version="1.0" encoding="UTF-8"?>
+<opml version="2.0">
+    <head><title>Protected Feeds</title></head>
+    <body>
+        <outline text="Category">
+            <outline text="Existing Feed" type="rss" xmlUrl="https://example.com/feed.xml" userAgent="Existing Reader/1.0" />
+        </outline>
+    </body>
+</opml>`
+
+	list, err := loadOPMLFeedList(strings.NewReader(source))
+	if err != nil {
+		t.Fatalf("loadOPMLFeedList() error = %v", err)
+	}
+	feeds := list.GetFeeds()
+	if len(feeds) != 1 {
+		t.Fatalf("len(GetFeeds()) = %d, want 1", len(feeds))
+	}
+	if got := feeds[0].UserAgent; got != testExistingUserAgent {
+		t.Errorf("GetFeeds()[0].UserAgent = %q, want %q", got, testExistingUserAgent)
+	}
+
+	if err := list.AddFeed(Feed{
+		URL:       testURL2,
+		UserAgent: testNewUserAgent,
+	}); err != nil {
+		t.Fatalf("AddFeed() error = %v", err)
+	}
+
+	filename := filepath.Join(t.TempDir(), "feeds.opml")
+	if err := list.Save(filename); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	reloaded, err := LoadFeedList(FormatOPML, filename)
+	if err != nil {
+		t.Fatalf("LoadFeedList() error = %v", err)
+	}
+	want := []Feed{
+		{URL: testURL1, UserAgent: testExistingUserAgent},
+		{URL: testURL2, UserAgent: testNewUserAgent},
+	}
+	got := reloaded.GetFeeds()
+	if len(got) != len(want) {
+		t.Fatalf("len(GetFeeds()) = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("GetFeeds()[%d] = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestOPMLFeedListSetUserAgent(t *testing.T) {
+	const source = `<opml version="2.0"><body><outline text="Category"><outline xmlUrl="https://example.com/feed.xml" userAgent="Old Reader/1.0" /></outline></body></opml>`
+
+	list, err := loadOPMLFeedList(strings.NewReader(source))
+	if err != nil {
+		t.Fatalf("loadOPMLFeedList() error = %v", err)
+	}
+	if found := list.SetUserAgent(testURL1, testNewUserAgent); !found {
+		t.Fatal("SetUserAgent() = false, want true for nested existing feed")
+	}
+	if got := list.GetFeeds()[0].UserAgent; got != testNewUserAgent {
+		t.Errorf("updated UserAgent = %q, want %q", got, testNewUserAgent)
+	}
+
+	if found := list.SetUserAgent(testURL1, ""); !found {
+		t.Fatal("SetUserAgent() = false, want true when clearing existing feed")
+	}
+	if got := list.GetFeeds()[0].UserAgent; got != "" {
+		t.Errorf("cleared UserAgent = %q, want empty string", got)
+	}
+
+	if found := list.SetUserAgent("https://missing.example/feed.xml", "Reader/1.0"); found {
+		t.Error("SetUserAgent() = true, want false for missing feed")
+	}
+}
+
+func TestOPMLFeedListSetUserAgentUpdatesDuplicateEntries(t *testing.T) {
+	const source = `<opml version="2.0"><body><outline xmlUrl="https://example.com/feed.xml" userAgent="First Reader/1.0" /><outline text="Category"><outline xmlUrl="https://example.com/feed.xml" userAgent="Second Reader/1.0" /></outline></body></opml>`
+
+	list, err := loadOPMLFeedList(strings.NewReader(source))
+	if err != nil {
+		t.Fatalf("loadOPMLFeedList() error = %v", err)
+	}
+	if found := list.SetUserAgent(testURL1, testNewUserAgent); !found {
+		t.Fatal("SetUserAgent() = false, want true")
+	}
+	feeds := list.GetFeeds()
+	if len(feeds) != 2 {
+		t.Fatalf("len(GetFeeds()) = %d, want 2", len(feeds))
+	}
+	for i, feed := range feeds {
+		if feed.UserAgent != testNewUserAgent {
+			t.Errorf("GetFeeds()[%d].UserAgent = %q, want %q", i, feed.UserAgent, testNewUserAgent)
+		}
+	}
+}
+
+func TestOPMLFeedListRemoveNestedURL(t *testing.T) {
+	const source = `<opml version="2.0"><body><outline text="Category"><outline xmlUrl="https://example.com/feed.xml" /><outline xmlUrl="https://another.com/rss" /></outline></body></opml>`
+
+	list, err := loadOPMLFeedList(strings.NewReader(source))
+	if err != nil {
+		t.Fatalf("loadOPMLFeedList() error = %v", err)
+	}
+	if err := list.RemoveURL(testURL1); err != nil {
+		t.Fatalf("RemoveURL() error = %v", err)
+	}
+	urls := list.GetURLs()
+	if len(urls) != 1 || urls[0] != testURL2 {
+		t.Errorf("GetURLs() after nested removal = %v, want [%s]", urls, testURL2)
+	}
+	opmlList := list.(*OPMLFeedList)
+	if len(opmlList.opml.Body.Outlines) != 1 || opmlList.opml.Body.Outlines[0].Text != "Category" {
+		t.Errorf("category outline was not preserved: %#v", opmlList.opml.Body.Outlines)
+	}
+}
+
+func TestOPMLUserAgentUpdatePreservesExtensionMetadata(t *testing.T) {
+	const source = `<opml version="2.0" customRoot="root-value">
+<head><title>Feeds</title><dateCreated>2026-08-25</dateCreated><ownerId scheme="opaque">owner-1</ownerId></head>
+<body customBody="body-value"><outline text="Category" category="tech" customCategory="category-value"><outline xmlUrl="https://example.com/feed.xml" userAgent="Old Reader/1.0" customFeed="feed-value"><extension enabled="true">payload</extension></outline></outline></body>
+</opml>`
+
+	list, err := loadOPMLFeedList(strings.NewReader(source))
+	if err != nil {
+		t.Fatalf("loadOPMLFeedList() error = %v", err)
+	}
+	if found := list.SetUserAgent(testURL1, testNewUserAgent); !found {
+		t.Fatal("SetUserAgent() = false, want true")
+	}
+	filename := filepath.Join(t.TempDir(), "feeds.opml")
+	if err := list.Save(filename); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got struct {
+		CustomRoot string `xml:"customRoot,attr"`
+		Head       struct {
+			DateCreated string `xml:"dateCreated"`
+			OwnerID     struct {
+				Scheme string `xml:"scheme,attr"`
+				Value  string `xml:",chardata"`
+			} `xml:"ownerId"`
+		} `xml:"head"`
+		Body struct {
+			CustomBody string `xml:"customBody,attr"`
+			Category   struct {
+				Category       string `xml:"category,attr"`
+				CustomCategory string `xml:"customCategory,attr"`
+				Feed           struct {
+					CustomFeed string `xml:"customFeed,attr"`
+					UserAgent  string `xml:"userAgent,attr"`
+					Extension  struct {
+						Enabled string `xml:"enabled,attr"`
+						Value   string `xml:",chardata"`
+					} `xml:"extension"`
+				} `xml:"outline"`
+			} `xml:"outline"`
+		} `xml:"body"`
+	}
+	if err := xml.Unmarshal(data, &got); err != nil {
+		t.Fatalf("xml.Unmarshal() error = %v", err)
+	}
+	if got.CustomRoot != "root-value" || got.Body.CustomBody != "body-value" {
+		t.Errorf("root/body extension attributes were not preserved: %#v", got)
+	}
+	if got.Head.DateCreated != "2026-08-25" || got.Head.OwnerID.Scheme != "opaque" || got.Head.OwnerID.Value != "owner-1" {
+		t.Errorf("head extension elements were not preserved: %#v", got.Head)
+	}
+	if got.Body.Category.Category != testCategory || got.Body.Category.CustomCategory != "category-value" {
+		t.Errorf("category attributes were not preserved: %#v", got.Body.Category)
+	}
+	feed := got.Body.Category.Feed
+	if feed.CustomFeed != "feed-value" || feed.UserAgent != testNewUserAgent ||
+		feed.Extension.Enabled != testEnabled || feed.Extension.Value != "payload" {
+		t.Errorf("feed extension metadata was not preserved: %#v", feed)
+	}
+}
+
+func TestOPMLUserAgentUpdatePreservesNamespacedExtensions(t *testing.T) {
+	const source = `<opml version="2.0" xmlns:ext="urn:example">
+<head><title>Feeds</title><ext:metadata ext:kind="owner"><ext:child>head payload</ext:child></ext:metadata></head>
+<body><outline xmlUrl="https://example.com/feed.xml" userAgent="Old Reader/1.0" ext:category="tech"><ext:data ext:enabled="true"><ext:child>feed payload</ext:child></ext:data></outline></body>
+</opml>`
+
+	list, err := loadOPMLFeedList(strings.NewReader(source))
+	if err != nil {
+		t.Fatalf("loadOPMLFeedList() error = %v", err)
+	}
+	if found := list.SetUserAgent(testURL1, testNewUserAgent); !found {
+		t.Fatal("SetUserAgent() = false, want true")
+	}
+	filename := filepath.Join(t.TempDir(), "feeds.opml")
+	if err := list.Save(filename); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got struct {
+		Head struct {
+			Meta struct {
+				Kind  string `xml:"urn:example kind,attr"`
+				Child string `xml:"urn:example child"`
+			} `xml:"urn:example metadata"`
+		} `xml:"head"`
+		Body struct {
+			Feed struct {
+				Category  string `xml:"urn:example category,attr"`
+				UserAgent string `xml:"userAgent,attr"`
+				Data      struct {
+					Enabled string `xml:"urn:example enabled,attr"`
+					Child   string `xml:"urn:example child"`
+				} `xml:"urn:example data"`
+			} `xml:"outline"`
+		} `xml:"body"`
+	}
+	if err := xml.Unmarshal(data, &got); err != nil {
+		t.Fatalf("xml.Unmarshal() namespaced output error = %v\n%s", err, data)
+	}
+	if got.Head.Meta.Kind != "owner" || got.Head.Meta.Child != "head payload" {
+		t.Errorf("namespaced head extension was not preserved: %#v\n%s", got.Head.Meta, data)
+	}
+	feed := got.Body.Feed
+	if feed.Category != testCategory || feed.UserAgent != testNewUserAgent ||
+		feed.Data.Enabled != testEnabled || feed.Data.Child != "feed payload" {
+		t.Errorf("namespaced feed extension was not preserved: %#v\n%s", feed, data)
+	}
+}
+
 func TestLoadNonExistentFile(t *testing.T) {
 	_, err := LoadFeedList(FormatText, "/non/existent/file.txt")
 	if err == nil {
@@ -318,5 +563,43 @@ func TestTextFeedListTitle(t *testing.T) {
 	}
 	if got := list.Title(); got != "" {
 		t.Errorf("Title() = %q, want empty string", got)
+	}
+}
+
+func TestDeduplicateFeedsRejectsConflictingUserAgents(t *testing.T) {
+	feeds := []Feed{
+		{URL: testURL1, UserAgent: "First Reader/1.0"},
+		{URL: testURL2, UserAgent: "Other Reader/1.0"},
+		{URL: testURL1, UserAgent: "Second Reader/2.0"},
+	}
+
+	_, err := DeduplicateFeeds(feeds)
+	if err == nil {
+		t.Fatal("DeduplicateFeeds() error = nil, want conflicting User-Agent error")
+	}
+	if !strings.Contains(err.Error(), testURL1) {
+		t.Errorf("DeduplicateFeeds() error = %q, want conflicting URL", err)
+	}
+}
+
+func TestDeduplicateFeedsPreservesFirstSeenOrder(t *testing.T) {
+	feeds := []Feed{
+		{URL: testURL1, UserAgent: testNewUserAgent},
+		{URL: testURL2},
+		{URL: testURL1, UserAgent: testNewUserAgent},
+	}
+
+	got, err := DeduplicateFeeds(feeds)
+	if err != nil {
+		t.Fatalf("DeduplicateFeeds() error = %v", err)
+	}
+	want := []Feed{{URL: testURL1, UserAgent: testNewUserAgent}, {URL: testURL2}}
+	if len(got) != len(want) {
+		t.Fatalf("DeduplicateFeeds() = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("DeduplicateFeeds()[%d] = %#v, want %#v", i, got[i], want[i])
+		}
 	}
 }

--- a/internal/fetcher/orchestrator.go
+++ b/internal/fetcher/orchestrator.go
@@ -86,7 +86,20 @@ func (o *Orchestrator) FetchFromFile(
 		return nil, fmt.Errorf("failed to load feed list %s: %w", filename, err)
 	}
 
-	feedURLs := list.GetURLs()
+	feeds, err := feedlist.DeduplicateFeeds(list.GetFeeds())
+	if err != nil {
+		return nil, fmt.Errorf("invalid feed list %s: %w", filename, err)
+	}
+	if format == feedlist.FormatOPML {
+		if err := o.SynchronizeFeedConfigs(feeds); err != nil {
+			return nil, err
+		}
+	}
+
+	feedURLs := make([]string, 0, len(feeds))
+	for _, feed := range feeds {
+		feedURLs = append(feedURLs, feed.URL)
+	}
 	if len(feedURLs) == 0 {
 		logrus.Infof("No feed URLs found in %s", filename)
 		return []*FetchResult{}, nil
@@ -99,6 +112,20 @@ func (o *Orchestrator) FetchFromFile(
 	}
 
 	return o.FetchFromURLs(ctx, feedURLs, opts), nil
+}
+
+// SynchronizeFeedConfigs writes authoritative OPML configuration to the database.
+func (o *Orchestrator) SynchronizeFeedConfigs(feeds []feedlist.Feed) error {
+	feeds, err := feedlist.DeduplicateFeeds(feeds)
+	if err != nil {
+		return fmt.Errorf("invalid feed configuration: %w", err)
+	}
+	for _, feed := range feeds {
+		if err := o.db.SetFeedUserAgent(feed.URL, feed.UserAgent); err != nil {
+			return fmt.Errorf("failed to synchronize feed configuration for %s: %w", feed.URL, err)
+		}
+	}
+	return nil
 }
 
 // FetchFromDatabase executes fetch from all feeds in database with optional unfurl.

--- a/internal/fetcher/orchestrator_test.go
+++ b/internal/fetcher/orchestrator_test.go
@@ -4,11 +4,16 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/lmorchard/feedspool-go/internal/config"
 	"github.com/lmorchard/feedspool-go/internal/database"
+	"github.com/lmorchard/feedspool-go/internal/feedlist"
+	"github.com/lmorchard/feedspool-go/internal/httpclient"
 )
 
 func TestFetchFromURLs(t *testing.T) {
@@ -81,5 +86,100 @@ func TestFetchFromURLsEmptyWithRemoveMissingKeepsExistingFeeds(t *testing.T) {
 	if len(urls) != 1 || urls[0] != existingFeedURL {
 		t.Errorf("GetFeedURLs() = %v, want [%s] (empty URL list + RemoveMissing must not delete existing feeds)",
 			urls, existingFeedURL)
+	}
+}
+
+func TestFetchFromFileSynchronizesUserAgent(t *testing.T) {
+	db := setupTestDatabase(t)
+	userAgents := make(chan string, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userAgents <- r.Header.Get("User-Agent")
+		w.Header().Set("Content-Type", "application/rss+xml")
+		_, _ = w.Write([]byte(testFeedXML))
+	}))
+	defer server.Close()
+
+	filename := filepath.Join(t.TempDir(), "feeds.opml")
+	writeList := func(userAgentAttribute string) {
+		t.Helper()
+		content := `<opml version="2.0"><body><outline type="rss" xmlUrl="` +
+			server.URL + `"` + userAgentAttribute + ` /></body></opml>`
+		if err := os.WriteFile(filename, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	o := NewOrchestrator(db, config.GetDefault())
+	opts := FetchOptions{
+		Timeout:     config.DefaultTimeout,
+		MaxItems:    config.DefaultMaxItems,
+		Concurrency: 1,
+		Force:       true,
+	}
+
+	const customUserAgent = "Protected Reader/1.0"
+	writeList(` userAgent="` + customUserAgent + `"`)
+	results, err := o.FetchFromFile(context.Background(), feedlist.FormatOPML, filename, opts)
+	if err != nil {
+		t.Fatalf("FetchFromFile() error = %v", err)
+	}
+	if len(results) != 1 || results[0].Error != nil {
+		t.Fatalf("FetchFromFile() results = %#v, want one successful result", results)
+	}
+	if got := <-userAgents; got != customUserAgent {
+		t.Errorf("first request User-Agent = %q, want %q", got, customUserAgent)
+	}
+
+	writeList("")
+	results, err = o.FetchFromFile(context.Background(), feedlist.FormatOPML, filename, opts)
+	if err != nil {
+		t.Fatalf("FetchFromFile() after clear error = %v", err)
+	}
+	if len(results) != 1 || results[0].Error != nil {
+		t.Fatalf("FetchFromFile() after clear results = %#v, want one successful result", results)
+	}
+	if got := <-userAgents; got != httpclient.DefaultUserAgent {
+		t.Errorf("request User-Agent after clear = %q, want default %q", got, httpclient.DefaultUserAgent)
+	}
+
+	feed, err := db.GetFeed(server.URL)
+	if err != nil {
+		t.Fatalf("GetFeed() error = %v", err)
+	}
+	if feed.UserAgent != "" {
+		t.Errorf("database UserAgent after clear = %q, want empty string", feed.UserAgent)
+	}
+}
+
+func TestFetchFromFileRejectsConflictingUserAgents(t *testing.T) {
+	db := setupTestDatabase(t)
+	var hits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "application/rss+xml")
+		_, _ = w.Write([]byte(testFeedXML))
+	}))
+	defer server.Close()
+
+	filename := filepath.Join(t.TempDir(), "feeds.opml")
+	content := `<opml version="2.0"><body>` +
+		`<outline xmlUrl="` + server.URL + `" userAgent="First Reader/1.0" />` +
+		`<outline xmlUrl="` + server.URL + `" userAgent="Second Reader/2.0" />` +
+		`</body></opml>`
+	if err := os.WriteFile(filename, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	o := NewOrchestrator(db, config.GetDefault())
+	_, err := o.FetchFromFile(context.Background(), feedlist.FormatOPML, filename, FetchOptions{
+		Timeout:     config.DefaultTimeout,
+		MaxItems:    config.DefaultMaxItems,
+		Concurrency: 1,
+	})
+	if err == nil {
+		t.Fatal("FetchFromFile() error = nil, want conflicting User-Agent error")
+	}
+	if hits.Load() != 0 {
+		t.Errorf("server received %d requests, want 0 after configuration conflict", hits.Load())
 	}
 }

--- a/internal/opml/parser.go
+++ b/internal/opml/parser.go
@@ -6,27 +6,90 @@ import (
 	"io"
 )
 
+const xmlnsNamespace = "xmlns"
+
 type OPML struct {
-	XMLName xml.Name `xml:"opml"`
-	Head    Head     `xml:"head"`
-	Body    Body     `xml:"body"`
+	XMLName    xml.Name   `xml:"opml"`
+	Version    string     `xml:"version,attr,omitempty"`
+	OtherAttrs []xml.Attr `xml:",any,attr"`
+	Head       Head       `xml:"head"`
+	Body       Body       `xml:"body"`
 }
 
 type Head struct {
-	Title string `xml:"title"`
+	Title         string       `xml:"title"`
+	OtherElements []RawElement `xml:",any"`
 }
 
 type Body struct {
-	Outlines []Outline `xml:"outline"`
+	OtherAttrs    []xml.Attr   `xml:",any,attr"`
+	Outlines      []Outline    `xml:"outline"`
+	OtherElements []RawElement `xml:",any"`
 }
 
 type Outline struct {
-	Text     string    `xml:"text,attr"`
-	Title    string    `xml:"title,attr"`
-	Type     string    `xml:"type,attr"`
-	XMLURL   string    `xml:"xmlUrl,attr"`
-	HTMLURL  string    `xml:"htmlUrl,attr"`
-	Outlines []Outline `xml:"outline"`
+	Text          string       `xml:"text,attr,omitempty"`
+	Title         string       `xml:"title,attr,omitempty"`
+	Type          string       `xml:"type,attr,omitempty"`
+	XMLURL        string       `xml:"xmlUrl,attr,omitempty"`
+	HTMLURL       string       `xml:"htmlUrl,attr,omitempty"`
+	UserAgent     string       `xml:"userAgent,attr,omitempty"`
+	OtherAttrs    []xml.Attr   `xml:",any,attr"`
+	Outlines      []Outline    `xml:"outline"`
+	OtherElements []RawElement `xml:",any"`
+}
+
+// RawElement preserves OPML extension elements that feedspool does not interpret.
+type RawElement struct {
+	XMLName xml.Name
+	Attrs   []xml.Attr  `xml:",any,attr"`
+	Tokens  []xml.Token `xml:"-"`
+}
+
+// UnmarshalXML stores namespace-aware tokens so extension elements can be
+// written back without interpreting their contents.
+func (element *RawElement) UnmarshalXML(decoder *xml.Decoder, start xml.StartElement) error {
+	element.XMLName = start.Name
+	element.Attrs = extensionAttrs(start.Attr)
+	element.Tokens = nil
+
+	depth := 1
+	for depth > 0 {
+		token, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+
+		switch value := token.(type) {
+		case xml.StartElement:
+			depth++
+			value.Attr = extensionAttrs(value.Attr)
+			element.Tokens = append(element.Tokens, xml.CopyToken(value))
+		case xml.EndElement:
+			depth--
+			if depth > 0 {
+				element.Tokens = append(element.Tokens, xml.CopyToken(value))
+			}
+		default:
+			element.Tokens = append(element.Tokens, xml.CopyToken(token))
+		}
+	}
+
+	return nil
+}
+
+// MarshalXML restores the captured extension element and its inner tokens.
+func (element *RawElement) MarshalXML(encoder *xml.Encoder, _ xml.StartElement) error {
+	start := xml.StartElement{Name: element.XMLName, Attr: extensionAttrs(element.Attrs)}
+	if err := encoder.EncodeToken(start); err != nil {
+		return err
+	}
+	for _, token := range element.Tokens {
+		if err := encoder.EncodeToken(token); err != nil {
+			return err
+		}
+	}
+	return encoder.EncodeToken(start.End())
 }
 
 func ParseOPML(reader io.Reader) (*OPML, error) {
@@ -41,7 +104,32 @@ func ParseOPML(reader io.Reader) (*OPML, error) {
 	if err := decoder.Decode(opml); err != nil {
 		return nil, fmt.Errorf("failed to parse OPML: %w", err)
 	}
+	removeNamespaceDeclarations(opml)
 	return opml, nil
+}
+
+func removeNamespaceDeclarations(document *OPML) {
+	document.OtherAttrs = extensionAttrs(document.OtherAttrs)
+	document.Body.OtherAttrs = extensionAttrs(document.Body.OtherAttrs)
+	removeOutlineNamespaceDeclarations(document.Body.Outlines)
+}
+
+func removeOutlineNamespaceDeclarations(outlines []Outline) {
+	for i := range outlines {
+		outlines[i].OtherAttrs = extensionAttrs(outlines[i].OtherAttrs)
+		removeOutlineNamespaceDeclarations(outlines[i].Outlines)
+	}
+}
+
+func extensionAttrs(attrs []xml.Attr) []xml.Attr {
+	kept := make([]xml.Attr, 0, len(attrs))
+	for _, attr := range attrs {
+		if attr.Name.Space == xmlnsNamespace || (attr.Name.Space == "" && attr.Name.Local == xmlnsNamespace) {
+			continue
+		}
+		kept = append(kept, attr)
+	}
+	return kept
 }
 
 func ExtractFeedURLs(opml *OPML) []string {
@@ -51,7 +139,8 @@ func ExtractFeedURLs(opml *OPML) []string {
 }
 
 func extractFromOutlines(outlines []Outline, urls *[]string) {
-	for _, outline := range outlines {
+	for i := range outlines {
+		outline := &outlines[i]
 		if outline.XMLURL != "" {
 			*urls = append(*urls, outline.XMLURL)
 		}

--- a/internal/opml/parser_test.go
+++ b/internal/opml/parser_test.go
@@ -56,3 +56,23 @@ func TestExtractFeedURLsEmpty(t *testing.T) {
 		t.Errorf("len(urls) = %v, want %v", len(urls), 0)
 	}
 }
+
+func TestParseOPMLUserAgent(t *testing.T) {
+	const opmlContent = `<?xml version="1.0" encoding="UTF-8"?>
+<opml version="2.0">
+    <body>
+        <outline text="Protected Feed" type="rss" xmlUrl="https://example.com/feed.xml" userAgent="Custom Reader/1.0" />
+    </body>
+</opml>`
+
+	document, err := ParseOPML(strings.NewReader(opmlContent))
+	if err != nil {
+		t.Fatalf("ParseOPML() error = %v", err)
+	}
+	if len(document.Body.Outlines) != 1 {
+		t.Fatalf("len(Body.Outlines) = %d, want 1", len(document.Body.Outlines))
+	}
+	if got := document.Body.Outlines[0].UserAgent; got != "Custom Reader/1.0" {
+		t.Errorf("Outline.UserAgent = %q, want %q", got, "Custom Reader/1.0")
+	}
+}

--- a/internal/sitegroup/render.go
+++ b/internal/sitegroup/render.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/lmorchard/feedspool-go/internal/database"
+	"github.com/lmorchard/feedspool-go/internal/feedlist"
 	"github.com/lmorchard/feedspool-go/internal/renderer"
 	"github.com/sirupsen/logrus"
 )
@@ -21,10 +22,11 @@ var ErrPartialFailure = errors.New("one or more feed lists were skipped or faile
 
 // FetchPlan is the deduped work for a directory-mode fetch.
 type FetchPlan struct {
-	Sites      []Site
-	Skipped    []Skipped
-	URLs       []string // Deduped union across every site.
-	References int      // Total URL references before dedup.
+	Sites       []Site
+	Skipped     []Skipped
+	URLs        []string        // Deduped union across every site.
+	FeedConfigs []feedlist.Feed // Deduped configuration from OPML lists.
+	References  int             // Total URL references before dedup.
 }
 
 // PlanFetch discovers the feed lists in dir and unions their URLs so a feed
@@ -36,15 +38,24 @@ func PlanFetch(dir string) (*FetchPlan, error) {
 	}
 
 	references := 0
+	feedConfigs := []feedlist.Feed{}
 	for i := range sites {
 		references += len(sites[i].URLs)
+		if sites[i].Format == feedlist.FormatOPML {
+			feedConfigs = append(feedConfigs, sites[i].Feeds...)
+		}
+	}
+	feedConfigs, err = feedlist.DeduplicateFeeds(feedConfigs)
+	if err != nil {
+		return nil, fmt.Errorf("invalid directory feed configuration: %w", err)
 	}
 
 	return &FetchPlan{
-		Sites:      sites,
-		Skipped:    skipped,
-		URLs:       UnionURLs(sites),
-		References: references,
+		Sites:       sites,
+		Skipped:     skipped,
+		URLs:        UnionURLs(sites),
+		FeedConfigs: feedConfigs,
+		References:  references,
 	}, nil
 }
 

--- a/internal/sitegroup/render_test.go
+++ b/internal/sitegroup/render_test.go
@@ -13,11 +13,14 @@ import (
 )
 
 const (
-	techOPML    = "tech.opml"
-	comicsOPML  = "comics.opml"
-	maxAge24h   = "24h"
-	techTitle   = "Tech"
-	comicsTitle = "Comics"
+	techOPML                 = "tech.opml"
+	comicsOPML               = "comics.opml"
+	oneOPML                  = "one.opml"
+	twoOPML                  = "two.opml"
+	directoryCustomUserAgent = "Custom Reader/1.0"
+	maxAge24h                = "24h"
+	techTitle                = "Tech"
+	comicsTitle              = "Comics"
 )
 
 // newTestDB creates an initialized database containing feedA and feedB, each
@@ -63,8 +66,8 @@ func newTestDB(t *testing.T) string {
 
 func TestPlanFetchDedupes(t *testing.T) {
 	dir := writeDir(t, map[string]string{
-		"one.opml": opmlWith("One", feedA, feedB),
-		"two.opml": opmlWith("Two", feedB, feedC),
+		oneOPML: opmlWith("One", feedA, feedB),
+		twoOPML: opmlWith("Two", feedB, feedC),
 	})
 
 	plan, err := PlanFetch(dir)
@@ -79,6 +82,39 @@ func TestPlanFetchDedupes(t *testing.T) {
 	}
 	if len(plan.Sites) != 2 {
 		t.Errorf("len(Sites) = %d, want 2", len(plan.Sites))
+	}
+}
+
+func TestPlanFetchCarriesOPMLUserAgents(t *testing.T) {
+	dir := writeDir(t, map[string]string{
+		oneOPML:   `<opml version="2.0"><body><outline xmlUrl="` + feedA + `" userAgent="` + directoryCustomUserAgent + `" /></body></opml>`,
+		"two.txt": feedA + "\n" + feedB + "\n",
+	})
+
+	plan, err := PlanFetch(dir)
+	if err != nil {
+		t.Fatalf("PlanFetch() error = %v", err)
+	}
+	if len(plan.FeedConfigs) != 1 {
+		t.Fatalf("len(FeedConfigs) = %d, want 1 OPML configuration", len(plan.FeedConfigs))
+	}
+	if got := plan.FeedConfigs[0]; got.URL != feedA || got.UserAgent != directoryCustomUserAgent {
+		t.Errorf("FeedConfigs[0] = %#v, want configured %s", got, feedA)
+	}
+}
+
+func TestPlanFetchRejectsConflictingOPMLUserAgents(t *testing.T) {
+	dir := writeDir(t, map[string]string{
+		oneOPML: `<opml version="2.0"><body><outline xmlUrl="` + feedA + `" userAgent="First Reader/1.0" /></body></opml>`,
+		twoOPML: `<opml version="2.0"><body><outline xmlUrl="` + feedA + `" userAgent="Second Reader/2.0" /></body></opml>`,
+	})
+
+	_, err := PlanFetch(dir)
+	if err == nil {
+		t.Fatal("PlanFetch() error = nil, want conflicting User-Agent error")
+	}
+	if !strings.Contains(err.Error(), feedA) {
+		t.Errorf("PlanFetch() error = %q, want conflicting URL", err)
 	}
 }
 

--- a/internal/sitegroup/site.go
+++ b/internal/sitegroup/site.go
@@ -19,6 +19,7 @@ type Site struct {
 	Title  string          // OPML head title, or the filename base if unset.
 	Path   string          // Full path to the feed list file.
 	Format feedlist.Format // Inferred from the file extension.
+	Feeds  []feedlist.Feed // Feed entries and any list-backed configuration.
 	URLs   []string        // Feed URLs in the list.
 }
 
@@ -121,12 +122,18 @@ func Discover(dir string) (sites []Site, skipped []Skipped, err error) {
 			title = base
 		}
 
+		feeds := list.GetFeeds()
+		urls := make([]string, 0, len(feeds))
+		for _, feed := range feeds {
+			urls = append(urls, feed.URL)
+		}
 		sites = append(sites, Site{
 			Slug:   slug,
 			Title:  title,
 			Path:   path,
 			Format: format,
-			URLs:   list.GetURLs(),
+			Feeds:  feeds,
+			URLs:   urls,
 		})
 	}
 

--- a/internal/subscription/subscription.go
+++ b/internal/subscription/subscription.go
@@ -1,10 +1,12 @@
 package subscription
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"regexp"
 	"time"
 
@@ -55,44 +57,71 @@ func (m *Manager) ValidateFormat(format string) (feedlist.Format, error) {
 	}
 }
 
-// LoadOrCreateFeedList loads an existing feed list or creates a new one if it doesn't exist.
-func (m *Manager) LoadOrCreateFeedList(feedFormat feedlist.Format, filename string) (feedlist.FeedList, bool) {
+// LoadOrCreateFeedList loads an existing feed list or creates one when the file is absent.
+func (m *Manager) LoadOrCreateFeedList(
+	feedFormat feedlist.Format, filename string,
+) (feedlist.FeedList, bool, error) {
 	list, err := feedlist.LoadFeedList(feedFormat, filename)
 	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, false, err
+		}
 		list = feedlist.NewFeedList(feedFormat)
 		logrus.Debugf("Creating new feed list: %s", filename)
-		return list, true // true = newly created
+		return list, true, nil
 	}
 	logrus.Debugf("Loaded existing feed list: %s", filename)
-	return list, false // false = loaded existing
+	return list, false, nil
 }
 
 // SubscribeResult contains the results of a subscription operation.
 type SubscribeResult struct {
-	CreatedNew bool
-	AddedCount int
-	TotalURLs  int
-	Warnings   []string
+	CreatedNew   bool
+	AddedCount   int
+	UpdatedCount int
+	TotalURLs    int
+	Warnings     []string
+}
+
+// SubscribeOptions controls metadata applied to subscribed feeds.
+type SubscribeOptions struct {
+	// UserAgent is nil when the option was not supplied. A non-nil empty
+	// string explicitly clears an existing override.
+	UserAgent *string
 }
 
 // Subscribe adds one or more URLs to a feed list.
 func (m *Manager) Subscribe(format, filename string, urls []string) (*SubscribeResult, error) {
+	return m.SubscribeWithOptions(format, filename, urls, SubscribeOptions{})
+}
+
+// SubscribeWithOptions adds or updates feeds and their list-backed configuration.
+func (m *Manager) SubscribeWithOptions(
+	format, filename string, urls []string, options SubscribeOptions,
+) (*SubscribeResult, error) {
 	feedFormat, err := m.ValidateFormat(format)
 	if err != nil {
 		return nil, err
 	}
-
-	list, createdNew := m.LoadOrCreateFeedList(feedFormat, filename)
-	addedCount, warnings := m.addURLsToList(list, urls)
-
-	result := &SubscribeResult{
-		CreatedNew: createdNew,
-		AddedCount: addedCount,
-		TotalURLs:  len(urls),
-		Warnings:   warnings,
+	if options.UserAgent != nil && feedFormat != feedlist.FormatOPML {
+		return nil, fmt.Errorf("per-feed User-Agent is supported only for OPML feed lists")
 	}
 
-	if addedCount > 0 {
+	list, createdNew, err := m.LoadOrCreateFeedList(feedFormat, filename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load feed list %s: %w", filename, err)
+	}
+	addedCount, updatedCount, warnings := m.addFeedsToList(list, urls, options)
+
+	result := &SubscribeResult{
+		CreatedNew:   createdNew,
+		AddedCount:   addedCount,
+		UpdatedCount: updatedCount,
+		TotalURLs:    len(urls),
+		Warnings:     warnings,
+	}
+
+	if addedCount > 0 || updatedCount > 0 {
 		if err := list.Save(filename); err != nil {
 			return result, fmt.Errorf("failed to save feed list: %w", err)
 		}
@@ -200,25 +229,57 @@ func (m *Manager) DiscoverFeeds(htmlURL string) ([]string, error) {
 }
 
 func (m *Manager) addURLsToList(list feedlist.FeedList, urlsToAdd []string) (addedCount int, warnings []string) {
-	existingURLs := list.GetURLs()
-	existingSet := make(map[string]bool)
-	for _, url := range existingURLs {
-		existingSet[url] = true
+	addedCount, _, warnings = m.addFeedsToList(list, urlsToAdd, SubscribeOptions{})
+	return addedCount, warnings
+}
+
+func (m *Manager) addFeedsToList(
+	list feedlist.FeedList, urlsToAdd []string, options SubscribeOptions,
+) (addedCount, updatedCount int, warnings []string) {
+	existingFeeds := make(map[string][]feedlist.Feed)
+	for _, feed := range list.GetFeeds() {
+		existingFeeds[feed.URL] = append(existingFeeds[feed.URL], feed)
 	}
 
 	for _, feedURL := range urlsToAdd {
-		if existingSet[feedURL] {
+		matches, exists := existingFeeds[feedURL]
+		if exists && (options.UserAgent == nil || allFeedsUseUserAgent(matches, *options.UserAgent)) {
 			warnings = append(warnings, fmt.Sprintf("Feed URL already exists in list: %s", feedURL))
-		} else {
-			if err := list.AddURL(feedURL); err != nil {
-				warnings = append(warnings, fmt.Sprintf("Failed to add URL %s: %v", feedURL, err))
-			} else {
-				logrus.Debugf("Added feed: %s", feedURL)
-				addedCount++
+			continue
+		}
+		if exists {
+			if list.SetUserAgent(feedURL, *options.UserAgent) {
+				updatedCount++
+				for i := range matches {
+					matches[i].UserAgent = *options.UserAgent
+				}
+				existingFeeds[feedURL] = matches
 			}
+			continue
+		}
+
+		feed := feedlist.Feed{URL: feedURL}
+		if options.UserAgent != nil {
+			feed.UserAgent = *options.UserAgent
+		}
+		if err := list.AddFeed(feed); err != nil {
+			warnings = append(warnings, fmt.Sprintf("Failed to add URL %s: %v", feedURL, err))
+			continue
+		}
+		logrus.Debugf("Added feed: %s", feedURL)
+		addedCount++
+		existingFeeds[feedURL] = []feedlist.Feed{feed}
+	}
+	return addedCount, updatedCount, warnings
+}
+
+func allFeedsUseUserAgent(feeds []feedlist.Feed, userAgent string) bool {
+	for _, feed := range feeds {
+		if feed.UserAgent != userAgent {
+			return false
 		}
 	}
-	return addedCount, warnings
+	return true
 }
 
 // parseFeedLinks extracts RSS/Atom feed URLs from HTML <link> tags.

--- a/internal/subscription/subscription_test.go
+++ b/internal/subscription/subscription_test.go
@@ -1,6 +1,7 @@
 package subscription
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -14,13 +15,14 @@ import (
 
 // Shared test fixtures, hoisted so goconst stays quiet.
 const (
-	testAtomPath    = "/feed.atom"
-	testCustomTxt   = "custom.txt"
-	testDefaultOPML = "default.opml"
-	testDefaultTxt  = "default.txt"
-	testFormatText  = "text"
-	testFormatOPML  = "opml"
-	testRSSPath     = "/feed.rss"
+	testAtomPath        = "/feed.atom"
+	testCustomUserAgent = "Custom Reader/1.0"
+	testCustomTxt       = "custom.txt"
+	testDefaultOPML     = "default.opml"
+	testDefaultTxt      = "default.txt"
+	testFormatText      = "text"
+	testFormatOPML      = "opml"
+	testRSSPath         = "/feed.rss"
 )
 
 const (
@@ -166,7 +168,10 @@ func TestLoadOrCreateFeedList(t *testing.T) {
 
 	t.Run("Create new when file doesn't exist", func(t *testing.T) {
 		filename := filepath.Join(tmpDir, "new_feeds.txt")
-		list, createdNew := manager.LoadOrCreateFeedList(feedlist.FormatText, filename)
+		list, createdNew, err := manager.LoadOrCreateFeedList(feedlist.FormatText, filename)
+		if err != nil {
+			t.Fatalf("LoadOrCreateFeedList() error = %v", err)
+		}
 
 		if list == nil {
 			t.Fatal("LoadOrCreateFeedList returned nil")
@@ -190,7 +195,10 @@ func TestLoadOrCreateFeedList(t *testing.T) {
 		existingList.AddURL(testURL1)
 		existingList.Save(filename)
 
-		list, createdNew := manager.LoadOrCreateFeedList(feedlist.FormatText, filename)
+		list, createdNew, err := manager.LoadOrCreateFeedList(feedlist.FormatText, filename)
+		if err != nil {
+			t.Fatalf("LoadOrCreateFeedList() error = %v", err)
+		}
 
 		if list == nil {
 			t.Fatal("LoadOrCreateFeedList returned nil")
@@ -310,6 +318,137 @@ func TestSubscribe(t *testing.T) {
 			t.Error("Expected error for invalid format")
 		}
 	})
+}
+
+func TestSubscribeWithUserAgent(t *testing.T) {
+	tmpDir := t.TempDir()
+	manager := New(&config.Config{})
+	filename := filepath.Join(tmpDir, "feeds.opml")
+	initialUserAgent := "Initial Reader/1.0"
+
+	result, err := manager.SubscribeWithOptions(testFormatOPML, filename, []string{testURL1}, SubscribeOptions{
+		UserAgent: &initialUserAgent,
+	})
+	if err != nil {
+		t.Fatalf("SubscribeWithOptions() error = %v", err)
+	}
+	if result.AddedCount != 1 || result.UpdatedCount != 0 {
+		t.Fatalf("result = %#v, want one added feed and no updates", result)
+	}
+
+	list, err := feedlist.LoadFeedList(feedlist.FormatOPML, filename)
+	if err != nil {
+		t.Fatalf("LoadFeedList() error = %v", err)
+	}
+	if got := list.GetFeeds()[0].UserAgent; got != initialUserAgent {
+		t.Errorf("saved UserAgent = %q, want %q", got, initialUserAgent)
+	}
+
+	updatedUserAgent := "Updated Reader/2.0"
+	result, err = manager.SubscribeWithOptions(testFormatOPML, filename, []string{testURL1}, SubscribeOptions{
+		UserAgent: &updatedUserAgent,
+	})
+	if err != nil {
+		t.Fatalf("SubscribeWithOptions() update error = %v", err)
+	}
+	if result.AddedCount != 0 || result.UpdatedCount != 1 {
+		t.Fatalf("update result = %#v, want no additions and one update", result)
+	}
+
+	clearedUserAgent := ""
+	result, err = manager.SubscribeWithOptions(testFormatOPML, filename, []string{testURL1}, SubscribeOptions{
+		UserAgent: &clearedUserAgent,
+	})
+	if err != nil {
+		t.Fatalf("SubscribeWithOptions() clear error = %v", err)
+	}
+	if result.UpdatedCount != 1 {
+		t.Fatalf("clear UpdatedCount = %d, want 1", result.UpdatedCount)
+	}
+
+	list, err = feedlist.LoadFeedList(feedlist.FormatOPML, filename)
+	if err != nil {
+		t.Fatalf("LoadFeedList() after clear error = %v", err)
+	}
+	feeds := list.GetFeeds()
+	if len(feeds) != 1 {
+		t.Fatalf("len(GetFeeds()) = %d, want 1 after updates", len(feeds))
+	}
+	if feeds[0].UserAgent != "" {
+		t.Errorf("cleared UserAgent = %q, want empty string", feeds[0].UserAgent)
+	}
+}
+
+func TestSubscribeWithUserAgentRejectsTextList(t *testing.T) {
+	manager := New(&config.Config{})
+	filename := filepath.Join(t.TempDir(), "feeds.txt")
+	userAgent := testCustomUserAgent
+
+	_, err := manager.SubscribeWithOptions(testFormatText, filename, []string{testURL1}, SubscribeOptions{
+		UserAgent: &userAgent,
+	})
+	if err == nil {
+		t.Fatal("SubscribeWithOptions() error = nil, want text-list validation error")
+	}
+	if _, statErr := os.Stat(filename); !os.IsNotExist(statErr) {
+		t.Errorf("text feed list was created despite unsupported User-Agent: stat error = %v", statErr)
+	}
+}
+
+func TestSubscribeDoesNotOverwriteMalformedFeedList(t *testing.T) {
+	manager := New(&config.Config{})
+	filename := filepath.Join(t.TempDir(), "feeds.opml")
+	original := []byte(`<opml><body><outline xmlUrl="https://existing.example/feed.xml">`)
+	if err := os.WriteFile(filename, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	userAgent := testCustomUserAgent
+
+	_, err := manager.SubscribeWithOptions(testFormatOPML, filename, []string{testURL1}, SubscribeOptions{
+		UserAgent: &userAgent,
+	})
+	if err == nil {
+		t.Fatal("SubscribeWithOptions() error = nil, want malformed OPML error")
+	}
+	after, readErr := os.ReadFile(filename)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if !bytes.Equal(after, original) {
+		t.Errorf("malformed feed list was overwritten:\n got %q\nwant %q", after, original)
+	}
+}
+
+func TestSubscribeUpdatesAllDuplicatesWhenLastAlreadyMatches(t *testing.T) {
+	manager := New(&config.Config{})
+	filename := filepath.Join(t.TempDir(), "feeds.opml")
+	desiredUserAgent := "Desired Reader/2.0"
+	content := `<opml version="2.0"><body>` +
+		`<outline xmlUrl="` + testURL1 + `" userAgent="Old Reader/1.0" />` +
+		`<outline xmlUrl="` + testURL1 + `" userAgent="` + desiredUserAgent + `" />` +
+		`</body></opml>`
+	if err := os.WriteFile(filename, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := manager.SubscribeWithOptions(testFormatOPML, filename, []string{testURL1}, SubscribeOptions{
+		UserAgent: &desiredUserAgent,
+	})
+	if err != nil {
+		t.Fatalf("SubscribeWithOptions() error = %v", err)
+	}
+	if result.UpdatedCount != 1 {
+		t.Fatalf("UpdatedCount = %d, want 1", result.UpdatedCount)
+	}
+	list, err := feedlist.LoadFeedList(feedlist.FormatOPML, filename)
+	if err != nil {
+		t.Fatalf("LoadFeedList() error = %v", err)
+	}
+	for i, feed := range list.GetFeeds() {
+		if feed.UserAgent != desiredUserAgent {
+			t.Errorf("GetFeeds()[%d].UserAgent = %q, want %q", i, feed.UserAgent, desiredUserAgent)
+		}
+	}
 }
 
 func TestUnsubscribe(t *testing.T) {


### PR DESCRIPTION
## Summary

- Makes OPML subscription lists the source of truth for optional per-feed HTTP User-Agent values.
- Adds CLI support to set, update, and clear those values so feeds that reject generic clients can be managed without direct database edits.

## Design Decisions

The value is stored as an unnamespaced `userAgent` outline attribute. OPML configuration is synchronized into the database before single-file and directory-mode fetches, including empty values that clear stale settings. Text lists remain URL-only. Duplicate OPML entries are accepted when their configuration agrees and rejected before network access when it conflicts.

Unknown OPML structure and extension metadata are preserved during edits, including nested namespaced elements. Existing malformed lists return an error rather than being replaced.

## Changes

- Extended OPML parsing, feed-list operations, export, and documentation for per-feed User-Agent values.
- Added `subscribe --user-agent`, including update and explicit-clear behavior.
- Carried feed configuration through fetch planning and synchronized it before requests.
- Added regression and integration coverage for request headers, directory mode, duplicates, nested outlines, malformed files, and extension round trips.

## Test Plan

- [x] `make format`
- [x] `make lint`
- [x] `make test`
- [x] `make build`
- [x] Independent code review with no remaining Important or Minor findings

## References

- Spec: `docs/dev-sessions/2026-08-25-1320-opml-user-agent/spec.md`
- Plan: `docs/dev-sessions/2026-08-25-1320-opml-user-agent/plan.md`
- Closes #51
