### PR TITLE
Complete agent-friendly read CLI and research skill

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -260,9 +260,10 @@ the override. Conflicting values for one URL stop the fetch.
 
 ### show
 
-List items for a single feed.
+List items for a single feed. The selector may be an exact URL or a unique URL
+substring. Ambiguous selectors fail and list their matches.
 
-**Usage:** `feedspool show <url> [flags]`
+**Usage:** `feedspool show <feed> [flags]`
 
 **Flags:**
 
@@ -297,6 +298,103 @@ List items for a single feed.
   ]
 }
 ```
+
+**Side effects:** Read-only.
+
+Database-reading commands automatically apply pending schema migrations when
+opening an older database. “Read-only” here means they do not otherwise change
+feeds, items, annotations, or metadata.
+
+### feeds
+
+List every tracked feed with its title, last fetch time, item count, and
+consecutive fetch error count.
+
+**Usage:** `feedspool feeds [flags]`
+
+| Flag | Default | Description |
+|---|---|---|
+| `--format` | `table` | `table` or `json` |
+| `--errors` | false | Show only feeds with a nonzero error count |
+
+The global `--json` flag selects JSON when `--format` is left at its default.
+JSON objects use `url`, `title`, `last_fetch_time`, `item_count`, and
+`error_count` fields.
+
+**Side effects:** Read-only.
+
+### items
+
+List items across all feeds, or narrow them by source, title, time, or
+seen/unseen annotation. The optional positional URL remains an exact-match
+shortcut; `--feed` instead performs a case-insensitive URL substring match.
+
+**Usage:** `feedspool items [exact-feed-url] [flags]`
+
+| Flag | Default | Description |
+|---|---|---|
+| `--feed` | (none) | Filter by feed URL substring |
+| `--search` | (none) | Filter by item title substring |
+| `--since` | (none) | Items first discovered after this RFC3339 timestamp |
+| `--until` | (none) | Items first discovered at or before this RFC3339 timestamp |
+| `--limit` | `0` | Maximum results (0 = all) |
+| `--sort` | `newest` | `newest` or `oldest` |
+| `--seen` | false | Only items carrying a `seen` annotation |
+| `--unseen` | false | Only items without a `seen` annotation |
+| `--mark-seen` | false | Add a `seen` annotation to returned items |
+| `--format` | `table` | `table`, `json`, or `csv` |
+| `--compact` | false | Emit compact JSON manifest fields only |
+
+An exact positional URL cannot be combined with `--feed`; `--seen` and
+`--unseen` are also mutually exclusive. The global `--json` flag selects JSON
+when `--format` is left at its default. `--compact` requires JSON and emits
+`feed_url`, `guid`, `title`, `link`, `published_date`, and `discovered_at`.
+Discovery filters use `first_seen`,
+falling back to publication time only for legacy rows without that field; this
+makes `--since` suitable for a caller-owned last-checked cursor even when a
+newly discovered post has an older publication date. Combined filters form the
+half-open cursor window `(since, until]`, so a saved `until` value can become
+the next run's `since` without repeating boundary items.
+
+```bash
+feedspool --json items --since 2026-08-25T12:00:00Z
+feedspool --json items --compact --since 2026-08-25T12:00:00Z
+feedspool items --feed example.com --search "release notes" --limit 20
+```
+
+**Side effects:** Read-only unless `--mark-seen` is set.
+
+### item
+
+Show one item selected by link or exact feed URL and GUID. Output includes the
+stored item, annotations, and any unfurl metadata (OpenGraph/Twitter data,
+image, and favicon) already present in the database. If multiple items share a
+link, the command exits nonzero and lists each matching feed URL and GUID.
+
+**Usage:** `feedspool item [link] [flags]`
+
+| Flag | Default | Description |
+|---|---|---|
+| `--format` | `table` | `table` or `json` |
+| `--feed` | (none) | Exact feed URL; requires `--guid` |
+| `--guid` | (none) | Exact item GUID; requires `--feed` |
+
+The global `--json` flag selects JSON when `--format` is left at its default.
+The command does not fetch missing unfurl data; run `unfurl <link>` first when
+needed.
+
+**Side effects:** Read-only.
+
+### status
+
+Print a one-shot orientation summary: feed count, item count, newest fetch
+attempt, number of failing feeds, and the sum of their consecutive errors.
+
+**Usage:** `feedspool status`
+
+Use global `--json` for the fields `feed_count`, `item_count`,
+`last_fetch_time`, `failing_feed_count`, and `consecutive_error_count`. The
+timestamp is `null` when no feed has been fetched.
 
 **Side effects:** Read-only.
 

--- a/cmd/feeds.go
+++ b/cmd/feeds.go
@@ -1,0 +1,114 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/lmorchard/feedspool-go/internal/database"
+	"github.com/spf13/cobra"
+)
+
+var (
+	feedsFormat string
+	feedsErrors bool
+)
+
+var feedsCmd = &cobra.Command{
+	Use:   "feeds",
+	Short: "List feeds tracked in the database",
+	Long: `List tracked feeds with their URL, title, last fetch time, item count,
+and current consecutive fetch error count.`,
+	Example: `  feedspool feeds
+  feedspool feeds --format json
+  feedspool feeds --errors
+  feedspool --json feeds`,
+	Args: cobra.NoArgs,
+	RunE: runFeeds,
+}
+
+type feedSummaryOutput struct {
+	URL           string     `json:"url"`
+	Title         string     `json:"title"`
+	LastFetchTime *time.Time `json:"last_fetch_time"`
+	ItemCount     int        `json:"item_count"`
+	ErrorCount    int        `json:"error_count"`
+}
+
+func init() {
+	feedsCmd.Flags().StringVar(&feedsFormat, "format", formatTable, "Output format (table|json)")
+	feedsCmd.Flags().BoolVar(&feedsErrors, "errors", false, "Show only feeds with fetch errors")
+	rootCmd.AddCommand(feedsCmd)
+}
+
+func runFeeds(_ *cobra.Command, _ []string) error {
+	cfg := GetConfig()
+	db, err := database.New(cfg.Database)
+	if err != nil {
+		return fmt.Errorf("failed to connect to database: %w", err)
+	}
+	defer db.Close()
+	if err := db.IsInitialized(); err != nil {
+		return err
+	}
+
+	feeds, err := db.GetFeedSummaries()
+	if err != nil {
+		return err
+	}
+	if feedsErrors {
+		failing := make([]database.FeedSummary, 0, len(feeds))
+		for _, feed := range feeds {
+			if feed.ErrorCount > 0 {
+				failing = append(failing, feed)
+			}
+		}
+		feeds = failing
+	}
+	format := feedsFormat
+	if format == formatTable && cfg.JSON {
+		format = formatJSON
+	}
+	switch format {
+	case formatJSON:
+		encoder := json.NewEncoder(os.Stdout)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(feedSummaryOutputs(feeds))
+	case formatTable:
+		return outputFeedSummaries(feeds)
+	default:
+		return fmt.Errorf("unknown format: %s", format)
+	}
+}
+
+func feedSummaryOutputs(feeds []database.FeedSummary) []feedSummaryOutput {
+	outputs := make([]feedSummaryOutput, 0, len(feeds))
+	for _, feed := range feeds {
+		output := feedSummaryOutput{
+			URL: feed.URL, Title: feed.Title, ItemCount: feed.ItemCount, ErrorCount: feed.ErrorCount,
+		}
+		if feed.LastFetchTime.Valid && !feed.LastFetchTime.Time.IsZero() {
+			lastFetch := feed.LastFetchTime.Time
+			output.LastFetchTime = &lastFetch
+		}
+		outputs = append(outputs, output)
+	}
+	return outputs
+}
+
+func outputFeedSummaries(feeds []database.FeedSummary) error {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "URL\tTITLE\tLAST FETCH\tITEMS\tERRORS")
+	fmt.Fprintln(w, "---\t-----\t----------\t-----\t------")
+	for _, feed := range feeds {
+		lastFetch := "-"
+		if feed.LastFetchTime.Valid && !feed.LastFetchTime.Time.IsZero() {
+			lastFetch = feed.LastFetchTime.Time.Format(time.RFC3339)
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%d\n",
+			feed.URL, feed.Title, lastFetch, feed.ItemCount, feed.ErrorCount)
+	}
+	return w.Flush()
+}

--- a/cmd/item.go
+++ b/cmd/item.go
@@ -3,9 +3,9 @@ package cmd
 import (
 	"database/sql"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -13,28 +13,52 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var itemFormat string
+var (
+	itemFormat string
+	itemFeed   string
+	itemGUID   string
+)
 
 var itemCmd = &cobra.Command{
-	Use:   "item <link>",
+	Use:   "item [link]",
 	Short: "Show details for a single item",
-	Args:  cobra.ExactArgs(1),
+	Long: `Show a single item selected by link, including stored unfurl metadata
+and annotations. A missing or ambiguous link exits non-zero; ambiguity errors
+identify each matching feed URL and GUID. Use --feed and --guid together to
+select an item whose link is ambiguous.`,
+	Example: `  feedspool item https://example.com/posts/one
+  feedspool item --feed https://example.com/feed.xml --guid post-one
+  feedspool --json item https://example.com/posts/one`,
+	Args: cobra.MaximumNArgs(1),
 	RunE: func(_ *cobra.Command, args []string) error {
-		return runItem(args[0])
+		return runItem(args)
 	},
 }
 
 func init() {
 	itemCmd.Flags().StringVar(&itemFormat, "format", formatTable, "Output format (table|json)")
+	itemCmd.Flags().StringVar(&itemFeed, "feed", "", "Select by exact feed URL (requires --guid)")
+	itemCmd.Flags().StringVar(&itemGUID, "guid", "", "Select by exact item GUID (requires --feed)")
 	rootCmd.AddCommand(itemCmd)
 }
 
 type ItemOutput struct {
 	*database.Item
 	Annotations []database.ItemAnnotation `json:"Annotations"`
+	Metadata    *database.URLMetadata     `json:"Metadata,omitempty"`
 }
 
-func runItem(link string) error {
+type itemSelector struct {
+	link    string
+	feedURL string
+	guid    string
+}
+
+func runItem(args []string) error {
+	selector, err := parseItemSelector(args)
+	if err != nil {
+		return err
+	}
 	cfg := GetConfig()
 	db, err := database.New(cfg.Database)
 	if err != nil {
@@ -46,25 +70,7 @@ func runItem(link string) error {
 		return err
 	}
 
-	// Fetch item
-	query := `
-		SELECT feed_url, guid, title, link, summary, published_date, first_seen
-		FROM items
-		WHERE link = ?
-		LIMIT 1
-	`
-	var item database.Item
-	err = db.GetConnection().QueryRow(query, link).Scan(
-		&item.FeedURL, &item.GUID, &item.Title, &item.Link, &item.Summary,
-		&item.PublishedDate, &item.FirstSeen,
-	)
-	if errors.Is(err, sql.ErrNoRows) {
-		return fmt.Errorf("item with link %q not found", link)
-	} else if err != nil {
-		return fmt.Errorf("failed to look up item: %w", err)
-	}
-
-	annotations, err := db.GetAnnotations(item.FeedURL, item.GUID)
+	output, err := getItemOutput(db, selector)
 	if err != nil {
 		return err
 	}
@@ -73,47 +79,156 @@ func runItem(link string) error {
 	if format == formatTable && cfg.JSON {
 		format = formatJSON
 	}
+	return outputItem(format, output)
+}
 
+func parseItemSelector(args []string) (itemSelector, error) {
+	if len(args) == 1 {
+		if itemFeed != "" || itemGUID != "" {
+			return itemSelector{}, fmt.Errorf("link cannot be combined with --feed or --guid")
+		}
+		return itemSelector{link: args[0]}, nil
+	}
+	if itemFeed == "" && itemGUID == "" {
+		return itemSelector{}, fmt.Errorf("provide a link or both --feed and --guid")
+	}
+	if itemFeed == "" || itemGUID == "" {
+		return itemSelector{}, fmt.Errorf("--feed and --guid must be used together")
+	}
+	return itemSelector{feedURL: itemFeed, guid: itemGUID}, nil
+}
+
+func getItemOutput(db *database.DB, selector itemSelector) (*ItemOutput, error) {
+	query := `
+		SELECT id, feed_url, guid, title, link, published_date, first_seen,
+			content, summary, archived, item_json
+		FROM items
+	`
+	var args []any
+	if selector.link != "" {
+		query += " WHERE link = ? ORDER BY feed_url"
+		args = append(args, selector.link)
+	} else {
+		query += " WHERE feed_url = ? AND guid = ?"
+		args = append(args, selector.feedURL, selector.guid)
+	}
+	rows, err := db.GetConnection().Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to look up item: %w", err)
+	}
+	defer rows.Close()
+
+	var items []database.Item
+	for rows.Next() {
+		var item database.Item
+		if err := rows.Scan(
+			&item.ID, &item.FeedURL, &item.GUID, &item.Title, &item.Link,
+			&item.PublishedDate, &item.FirstSeen, &item.Content, &item.Summary,
+			&item.Archived, &item.ItemJSON,
+		); err != nil {
+			return nil, fmt.Errorf("failed to scan item: %w", err)
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate matching items: %w", err)
+	}
+	if len(items) == 0 {
+		if selector.link != "" {
+			return nil, fmt.Errorf("item with link %q not found", selector.link)
+		}
+		return nil, fmt.Errorf("item with feed %q and GUID %q not found", selector.feedURL, selector.guid)
+	}
+	if len(items) > 1 {
+		matches := make([]string, 0, len(items))
+		for i := range items {
+			matches = append(matches, fmt.Sprintf("%s (%s)", items[i].FeedURL, items[i].GUID))
+		}
+		return nil, fmt.Errorf(
+			"item link %q is ambiguous; matching items: %s; select one with --feed and --guid",
+			selector.link, strings.Join(matches, ", "),
+		)
+	}
+	item := items[0]
+
+	annotations, err := db.GetAnnotations(item.FeedURL, item.GUID)
+	if err != nil {
+		return nil, err
+	}
+	metadata, err := db.GetMetadata(item.Link)
+	if err != nil {
+		return nil, err
+	}
+	return &ItemOutput{Item: &item, Annotations: annotations, Metadata: metadata}, nil
+}
+
+func outputItem(format string, output *ItemOutput) error {
 	switch format {
 	case formatJSON:
-		out := ItemOutput{
-			Item:        &item,
-			Annotations: annotations,
-		}
 		encoder := json.NewEncoder(os.Stdout)
 		encoder.SetIndent("", "  ")
-		return encoder.Encode(out)
+		return encoder.Encode(output)
 	case formatTable:
-		//nolint:forbidigo
-		fmt.Printf("Title: %s\n", item.Title)
-		//nolint:forbidigo
-		fmt.Printf("Link: %s\n", item.Link)
-		//nolint:forbidigo
-		fmt.Printf("Feed URL: %s\n", item.FeedURL)
-		//nolint:forbidigo
-		fmt.Printf("Date: %s\n", item.PublishedDate.Format(time.RFC3339))
-		if item.FirstSeen.Valid {
-			//nolint:forbidigo
-			fmt.Printf("First Seen: %s\n", item.FirstSeen.Time.Format(time.RFC3339))
-		}
-		//nolint:forbidigo
-		fmt.Printf("\nAnnotations:\n")
-		if len(annotations) == 0 {
-			//nolint:forbidigo
-			fmt.Println("  (none)")
-		} else {
-			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-			for _, a := range annotations {
-				val := ""
-				if a.Value.Valid {
-					val = a.Value.String
-				}
-				fmt.Fprintf(w, "  %s\t%s\n", a.Kind, val)
-			}
-			w.Flush()
-		}
-		return nil
+		return outputItemTable(output)
 	default:
 		return fmt.Errorf("unknown format: %s", format)
+	}
+}
+
+func outputItemTable(output *ItemOutput) error {
+	item := output.Item
+	//nolint:forbidigo // Command output.
+	fmt.Printf("Title: %s\nLink: %s\nFeed URL: %s\nDate: %s\nSummary: %s\nContent: %s\n",
+		item.Title, item.Link, item.FeedURL, item.PublishedDate.Format(time.RFC3339), item.Summary, item.Content)
+	if item.FirstSeen.Valid {
+		//nolint:forbidigo // Command output.
+		fmt.Printf("First Seen: %s\n", item.FirstSeen.Time.Format(time.RFC3339))
+	}
+	outputItemAnnotations(output.Annotations)
+	outputItemMetadata(output.Metadata)
+	return nil
+}
+
+func outputItemAnnotations(annotations []database.ItemAnnotation) {
+	//nolint:forbidigo // Command output.
+	fmt.Printf("\nAnnotations:\n")
+	if len(annotations) == 0 {
+		//nolint:forbidigo // Command output.
+		fmt.Println("  (none)")
+		return
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	for _, annotation := range annotations {
+		value := ""
+		if annotation.Value.Valid {
+			value = annotation.Value.String
+		}
+		fmt.Fprintf(w, "  %s\t%s\n", annotation.Kind, value)
+	}
+	_ = w.Flush()
+}
+
+func outputItemMetadata(metadata *database.URLMetadata) {
+	//nolint:forbidigo // Command output.
+	fmt.Printf("\nUnfurl metadata:\n")
+	if metadata == nil {
+		//nolint:forbidigo // Command output.
+		fmt.Println("  (none)")
+		return
+	}
+	printMetadataField("Title", metadata.Title)
+	printMetadataField("Description", metadata.Description)
+	printMetadataField("Image", metadata.ImageURL)
+	printMetadataField("Favicon", metadata.FaviconURL)
+	if len(metadata.Metadata) > 0 && string(metadata.Metadata) != "null" {
+		//nolint:forbidigo // Command output.
+		fmt.Printf("  Raw: %s\n", string(metadata.Metadata))
+	}
+}
+
+func printMetadataField(label string, value sql.NullString) {
+	if value.Valid {
+		//nolint:forbidigo // Command output.
+		fmt.Printf("  %s: %s\n", label, value.String)
 	}
 }

--- a/cmd/items.go
+++ b/cmd/items.go
@@ -20,29 +20,47 @@ var (
 	itemsUnseen   bool
 	itemsSeen     bool
 	itemsMarkSeen bool
+	itemsFeed     string
+	itemsSearch   string
+	itemsCompact  bool
 )
 
 var itemsCmd = &cobra.Command{
 	Use:   "items [URL]",
 	Short: "List items across feeds or for a specific feed",
-	Long:  `Lists items. If a feed URL is provided, lists items for that feed. Otherwise lists items across all feeds.`,
-	Args:  cobra.MaximumNArgs(1),
-	RunE:  runItems,
+	Long: `List items across all feeds. Pass an exact feed URL as the optional
+	argument for compatibility, or use --feed to match a URL substring.
+--since and --until filter by discovery time (first_seen) using RFC3339
+timestamps. Invalid flags and conflicting filters exit non-zero.`,
+	Example: `  feedspool items --since 2026-08-25T12:00:00Z --format json
+  feedspool --json items --feed example.com
+  feedspool --json items --compact --since 2026-08-25T12:00:00Z
+  feedspool items --search "release notes" --limit 20
+  feedspool items https://example.com/feed.xml`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runItems,
 }
 
 func init() {
 	itemsCmd.Flags().StringVar(&itemsFormat, "format", formatTable, "Output format (table|json|csv)")
 	itemsCmd.Flags().StringVar(&itemsSort, "sort", "newest", "Sort order (newest|oldest)")
 	itemsCmd.Flags().IntVar(&itemsLimit, "limit", 0, "Maximum items to return (0 for all)")
-	itemsCmd.Flags().StringVar(&itemsSince, "since", "", "Filter items since date (RFC3339)")
-	itemsCmd.Flags().StringVar(&itemsUntil, "until", "", "Filter items until date (RFC3339)")
+	itemsCmd.Flags().StringVar(&itemsSince, "since", "", "Filter items discovered after time (RFC3339)")
+	itemsCmd.Flags().StringVar(&itemsUntil, "until", "", "Filter items discovered until time (RFC3339)")
 	itemsCmd.Flags().BoolVar(&itemsUnseen, "unseen", false, "Filter to items with no seen annotation")
 	itemsCmd.Flags().BoolVar(&itemsSeen, "seen", false, "Filter to items with a seen annotation")
 	itemsCmd.Flags().BoolVar(&itemsMarkSeen, "mark-seen", false, "Mark all returned items as seen")
+	itemsCmd.Flags().StringVar(&itemsFeed, "feed", "", "Filter by feed URL substring")
+	itemsCmd.Flags().StringVar(&itemsSearch, "search", "", "Filter by item title substring")
+	itemsCmd.Flags().BoolVar(&itemsCompact, "compact", false, "Emit a compact JSON manifest")
 	rootCmd.AddCommand(itemsCmd)
 }
 
 func runItems(_ *cobra.Command, args []string) error {
+	if err := validateItemsOptions(args); err != nil {
+		return err
+	}
+
 	feedURL := ""
 	if len(args) > 0 {
 		feedURL = args[0]
@@ -65,12 +83,14 @@ func runItems(_ *cobra.Command, args []string) error {
 	}
 
 	filter := database.ItemFilter{
-		FeedURL: feedURL,
-		Limit:   itemsLimit,
-		Since:   since,
-		Until:   until,
-		Unseen:  itemsUnseen,
-		Seen:    itemsSeen,
+		FeedURL:   feedURL,
+		FeedQuery: itemsFeed,
+		Search:    itemsSearch,
+		Limit:     itemsLimit,
+		Since:     since,
+		Until:     until,
+		Unseen:    itemsUnseen,
+		Seen:      itemsSeen,
 	}
 
 	items, err := db.GetItems(&filter)
@@ -83,10 +103,8 @@ func runItems(_ *cobra.Command, args []string) error {
 	}
 
 	if itemsMarkSeen {
-		for _, item := range items {
-			if err := db.AddAnnotation(item.FeedURL, item.GUID, "seen", sql.NullString{}, sql.NullString{}); err != nil {
-				return fmt.Errorf("failed to mark seen: %w", err)
-			}
+		if err := markItemsSeen(db, items); err != nil {
+			return err
 		}
 	}
 
@@ -94,8 +112,33 @@ func runItems(_ *cobra.Command, args []string) error {
 	if format == formatTable && cfg.JSON {
 		format = formatJSON
 	}
+	if itemsCompact && format != formatJSON {
+		return fmt.Errorf("--compact requires JSON output")
+	}
 
-	return outputItemsInFormat(format, items)
+	return outputItemsInFormat(format, items, itemsCompact)
+}
+
+func validateItemsOptions(args []string) error {
+	if len(args) > 0 && itemsFeed != "" {
+		return fmt.Errorf("feed URL argument cannot be combined with --feed")
+	}
+	if itemsSeen && itemsUnseen {
+		return fmt.Errorf("--seen cannot be combined with --unseen")
+	}
+	if itemsSort != sortNewest && itemsSort != sortOldest {
+		return fmt.Errorf("unknown sort order: %s", itemsSort)
+	}
+	return nil
+}
+
+func markItemsSeen(db *database.DB, items []*database.Item) error {
+	for _, item := range items {
+		if err := db.AddAnnotation(item.FeedURL, item.GUID, "seen", sql.NullString{}, sql.NullString{}); err != nil {
+			return fmt.Errorf("failed to mark seen: %w", err)
+		}
+	}
+	return nil
 }
 
 func parseDateFiltersForItems() (since, until time.Time, err error) {
@@ -123,11 +166,34 @@ func reverseItemsList(items []*database.Item) {
 	}
 }
 
-func outputItemsInFormat(format string, items []*database.Item) error {
+type compactItemOutput struct {
+	FeedURL       string    `json:"feed_url"`
+	GUID          string    `json:"guid"`
+	Title         string    `json:"title"`
+	Link          string    `json:"link"`
+	PublishedDate time.Time `json:"published_date"`
+	DiscoveredAt  time.Time `json:"discovered_at"`
+}
+
+func outputItemsInFormat(format string, items []*database.Item, compact bool) error {
 	switch format {
 	case formatJSON:
 		encoder := json.NewEncoder(os.Stdout)
 		encoder.SetIndent("", "  ")
+		if compact {
+			outputs := make([]compactItemOutput, 0, len(items))
+			for _, item := range items {
+				discoveredAt := item.PublishedDate
+				if item.FirstSeen.Valid && !item.FirstSeen.Time.IsZero() {
+					discoveredAt = item.FirstSeen.Time
+				}
+				outputs = append(outputs, compactItemOutput{
+					FeedURL: item.FeedURL, GUID: item.GUID, Title: item.Title, Link: item.Link,
+					PublishedDate: item.PublishedDate, DiscoveredAt: discoveredAt,
+				})
+			}
+			return encoder.Encode(outputs)
+		}
 		return encoder.Encode(items)
 	case formatCSV:
 		return outputCSV(items) // Reuse existing outputCSV

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -27,11 +28,16 @@ var (
 )
 
 var showCmd = &cobra.Command{
-	Use:   "show [URL]",
+	Use:   "show <feed>",
 	Short: "Show items for a feed",
-	Long:  `Lists items for a given feed URL from the database.`,
-	Args:  cobra.ExactArgs(1),
-	RunE:  runShow,
+	Long: `List items for a feed selected by its exact URL or a unique URL
+substring. A missing or ambiguous selector exits non-zero; ambiguity errors
+list every matching URL.`,
+	Example: `  feedspool show https://example.com/feed.xml
+  feedspool show example.com
+  feedspool --json show example.com --since 2026-08-25T12:00:00Z`,
+	Args: cobra.ExactArgs(1),
+	RunE: runShow,
 }
 
 func init() {
@@ -96,19 +102,46 @@ func parseDateFilters() (since, until time.Time, err error) {
 }
 
 func getFeedAndItems(
-	db *database.DB, feedURL string, since, until time.Time,
+	db *database.DB, feedQuery string, since, until time.Time,
 ) (*database.Feed, []*database.Item, error) {
-	feed, err := db.GetFeed(feedURL)
+	feed, err := resolveFeed(db, feedQuery)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get feed: %w", err)
 	}
 
-	items, err := db.GetItemsForFeed(feedURL, showLimit, since, until)
+	items, err := db.GetItemsForFeed(feed.URL, showLimit, since, until)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get items: %w", err)
 	}
 
 	return feed, items, nil
+}
+
+func resolveFeed(db *database.DB, query string) (*database.Feed, error) {
+	feed, err := db.GetFeed(query)
+	if err != nil {
+		return nil, err
+	}
+	if feed != nil {
+		return feed, nil
+	}
+
+	matches, err := db.FindFeedsByURLSubstring(query)
+	if err != nil {
+		return nil, err
+	}
+	switch len(matches) {
+	case 0:
+		return nil, fmt.Errorf("no feed URL matches %q", query)
+	case 1:
+		return matches[0], nil
+	default:
+		urls := make([]string, 0, len(matches))
+		for _, match := range matches {
+			urls = append(urls, match.URL)
+		}
+		return nil, fmt.Errorf("feed selector %q is ambiguous; matches: %s", query, strings.Join(urls, ", "))
+	}
 }
 
 func reverseItems(items []*database.Item) {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/lmorchard/feedspool-go/internal/database"
+	"github.com/spf13/cobra"
+)
+
+type statusOutput struct {
+	FeedCount             int        `json:"feed_count"`
+	ItemCount             int        `json:"item_count"`
+	LastFetchTime         *time.Time `json:"last_fetch_time"`
+	FailingFeedCount      int        `json:"failing_feed_count"`
+	ConsecutiveErrorCount int        `json:"consecutive_error_count"`
+}
+
+var statusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Summarize feedspool database status",
+	Long: `Show feed and item counts, the most recent fetch attempt, and the
+number of failing feeds and consecutive fetch errors currently recorded.`,
+	Example: `  feedspool status
+  feedspool --json status`,
+	Args: cobra.NoArgs,
+	RunE: runStatus,
+}
+
+func init() {
+	rootCmd.AddCommand(statusCmd)
+}
+
+func runStatus(_ *cobra.Command, _ []string) error {
+	cfg := GetConfig()
+	db, err := database.New(cfg.Database)
+	if err != nil {
+		return fmt.Errorf("failed to connect to database: %w", err)
+	}
+	defer db.Close()
+	if err := db.IsInitialized(); err != nil {
+		return err
+	}
+
+	status, err := db.GetSpoolStatus()
+	if err != nil {
+		return err
+	}
+	output := statusOutput{
+		FeedCount:             status.FeedCount,
+		ItemCount:             status.ItemCount,
+		FailingFeedCount:      status.FailingFeedCount,
+		ConsecutiveErrorCount: status.ConsecutiveErrorCount,
+	}
+	if status.LastFetchTime.Valid && !status.LastFetchTime.Time.IsZero() {
+		lastFetch := status.LastFetchTime.Time
+		output.LastFetchTime = &lastFetch
+	}
+
+	if cfg.JSON {
+		encoder := json.NewEncoder(os.Stdout)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(output)
+	}
+
+	lastFetch := "never"
+	if output.LastFetchTime != nil {
+		lastFetch = output.LastFetchTime.Format(time.RFC3339)
+	}
+	//nolint:forbidigo // Command output.
+	fmt.Printf("Feeds: %d\nItems: %d\nLast fetch: %s\nFeeds with errors: %d\nConsecutive errors: %d\n",
+		output.FeedCount, output.ItemCount, lastFetch,
+		output.FailingFeedCount, output.ConsecutiveErrorCount)
+	return nil
+}

--- a/docs/dev-sessions/2026-08-25-1400-agent-cli/notes.md
+++ b/docs/dev-sessions/2026-08-25-1400-agent-cli/notes.md
@@ -1,0 +1,126 @@
+# Session notes
+
+## Starting state
+
+- Branch: `fix/40-agent-cli`, based on `origin/main` at `01c8298`.
+- `items`, `item`, annotations, and seen/unseen options landed before this
+  session in PR #52.
+- Missing issue scope: `feeds`, `status`, `items --feed`, `items --search`,
+  fuzzy `show`, unfurl metadata in `item`, help/JSON audit, and research skill.
+
+## Design notes
+
+- Preserve the optional exact feed URL argument on `items` for compatibility;
+  reject using it together with `--feed`.
+- `items --feed` filters all matching feeds. Only `show` requires a unique
+  fuzzy match.
+- Keep one cross-compatible `SKILL.md` rather than duplicate Anthropic and
+  Hermes instructions.
+
+## External reference check
+
+GitHub repository search confirmed the referenced Hermes skill currently lives
+at `skills/research/blogwatcher/SKILL.md`. Fetching its full contents then hit
+GitHub's rate guard twice, so that retrieval path was stopped. The issue body
+already contains the workflow details needed here.
+
+## Skill baseline finding
+
+Without skill guidance, a fresh agent correctly discovered that the existing
+`items --since` filtered publication time and therefore rejected it as an
+unsafe cursor for newly discovered, back-dated posts. It substituted persistent
+seen/unseen annotations, contrary to the issue's stateless cursor design. The
+CLI query is being corrected to filter `first_seen` (with a legacy publication
+fallback) before the skill is written.
+
+The corrected query uses the half-open window `(since, until]`, avoiding both
+missed back-dated discoveries and repeated boundary items. In the forward test,
+a fresh agent used the complete unfiltered manifest, treated feed/title filters
+as secondary views, inspected links through `item`, and advanced the external
+cursor only after accounting for the manifest. The skill was tightened once to
+avoid adding seen-annotation writes unless the user requests persistent read
+state.
+
+## Verification
+
+- Skill baseline and two forward-test passes completed.
+- `quick_validate.py skills/feedspool-research` — valid.
+- `make format` — clean.
+- `make lint` — 0 issues.
+- `make test` — all packages passed.
+- `make build` — Darwin arm64 build succeeded with CGO disabled.
+
+## Review findings addressed
+
+- Discovery cursor filtering originally relied on SQLite text comparison for
+  mixed-offset timestamps. Filtering now compares parsed `time.Time` values in
+  Go, and newly written fetch timestamps are canonical UTC.
+- `item <link>` originally trusted the issue's claim that links were unique,
+  though the schema does not enforce that. Duplicate links now return a
+  deterministic ambiguity error listing their feeds.
+- Never-fetched zero timestamps now serialize as JSON `null` and display as
+  `never`/`-`, rather than year 0001.
+- Status finds the latest parsed fetch instant rather than ordering mixed-zone
+  timestamp strings.
+- The skill now describes the fetch summary's aggregate error count accurately.
+
+## Outcome
+
+Independent final review found no remaining Important or Minor issues. PR #54
+is open for Les's review: <https://github.com/lmorchard/feedspool-go/pull/54>.
+
+## Post-review production-data findings
+
+- A copied production database contained 453 feeds and 19,750 items. An
+  811-item daily JSON manifest was 5.8 MB because it included content and raw
+  item JSON; the new compact manifest is 325 KB and completed in 0.45 seconds
+  on the same copy.
+- The database contained 864 duplicate-link groups, including 557 groups
+  duplicated within one feed. Link ambiguity therefore needs an exact
+  feed-URL/GUID selector, not only better diagnostics.
+- Status's previous `error_count: 256` represented the sum of counters across
+  15 failing feeds. The output now exposes both quantities.
+- Concurrent read commands reproduced `failed to set journal mode: database is
+  locked (261)` because each connection unconditionally sets WAL mode. This is
+  pre-existing and tracked separately in issue #57.
+- SQLite could not parse 302 legacy Go timestamp strings in the production
+  copy. Discovery-window SQL predicates therefore pass unparseable timestamps
+  through as candidates and preserve the exact Go comparison.
+
+## Newsletter skill baseline
+
+A fresh agent without newsletter guidance produced a useful digest but
+silently omitted 31 newly discovered older posts, improvised duplicate and
+original-source policy, and guessed the length and tone. The new skill makes
+those decisions explicit, including a labeled Rediscovered section, while
+leaving scheduling and delivery to the caller.
+
+The first forward test handled all 1,054 rows, deduplicated 987 unique links,
+classified 162 older publications, produced a Rediscovered section, and
+returned the safe window-end cursor. It also showed that even compact JSON can
+be too large for direct context and reproduced the concurrent-open lock. The
+skill now defines whole-set structured accounting and sequential CLI commands.
+A fresh-agent recheck then described the intended reconciliation process and
+cursor conditions without ambiguity.
+
+## Post-review verification
+
+- Focused red-green tests covered status semantics, `feeds --errors`, compact
+  manifests, exact feed/GUID item selection, and indexed discovery queries.
+- `make format` completed.
+- `make lint` reported 0 issues.
+- `make test` passed all packages.
+- `make build BINARY=/tmp/feedspool-pr54-final` succeeded.
+- `git diff --check` passed.
+- Both skills passed equivalent frontmatter/name/placeholder checks with the
+  local Ruby YAML parser. The bundled `quick_validate.py` could not start
+  because both installed copies lack their `PyYAML` dependency.
+
+## Final PR state
+
+- Rebasing onto `origin/main` at `008af4a` preserved PR #53's OPML User-Agent
+  work; a fresh-context code review found no remaining code issues afterward.
+- PR #54's body documents the refinements and newsletter skill. All review
+  threads have an in-thread resolution or rationale.
+- GitHub Actions passed after the code rebase. The worktree remains in place
+  for further PR feedback.

--- a/docs/dev-sessions/2026-08-25-1400-agent-cli/plan.md
+++ b/docs/dev-sessions/2026-08-25-1400-agent-cli/plan.md
@@ -1,0 +1,19 @@
+# Implementation plan
+
+1. Add failing database tests for feed summaries, status totals, fuzzy feed
+   matching, and item title/feed substring filters.
+2. Implement the minimal repository queries and types that satisfy those tests.
+3. Add failing CLI/integration tests for `feeds`, `status`, fuzzy `show`, item
+   filters, item metadata, root JSON behavior, and error messages.
+4. Implement and document the read-side commands without removing existing CLI
+   compatibility.
+5. Baseline-test the research workflow without a skill, write the smallest
+   `SKILL.md` that closes observed gaps, validate it, and forward-test it.
+6. Update the manual, run repository gates, obtain independent review, and open
+   a PR that closes issue #40.
+7. Address PR review findings and add compact manifests, actionable duplicate
+   selection, and clearer feed-health output using focused red-green cycles.
+8. Baseline-test, write, validate, and forward-test a daily-newsletter skill
+   against a copied production database.
+9. Record the pre-existing concurrent database-open failure as a separate
+   issue rather than expanding this PR.

--- a/docs/dev-sessions/2026-08-25-1400-agent-cli/spec.md
+++ b/docs/dev-sessions/2026-08-25-1400-agent-cli/spec.md
@@ -1,0 +1,66 @@
+# Agent-friendly read CLI and research skill
+
+Issue: [#40](https://github.com/lmorchard/feedspool-go/issues/40)
+
+## Goal
+
+Complete feedspool's read-side CLI so an agent can orient itself, find new or
+relevant items, inspect one result, and maintain its own stateless cursor.
+Bundle a concise `SKILL.md` that demonstrates that workflow.
+
+## Existing behavior to retain
+
+The current `main` already provides `items`, `item`, and seen/unseen annotations.
+Keep those commands and their positional compatibility while filling the
+remaining issue checklist.
+
+## Command behavior
+
+- `feeds` lists URL, title, last fetch time, item count, and error count in
+  table or JSON form.
+- `items` adds `--feed <URL substring>` and `--search <title substring>` while
+  retaining its optional exact-URL positional argument. Existing time, limit,
+  sort, seen/unseen, CSV, and JSON behavior remains.
+- `show <feed>` accepts an exact URL or a unique URL substring. Ambiguous
+  substrings fail and list the matching URLs.
+- `item <link>` includes stored unfurl metadata when present and supports table
+  or JSON output.
+- `status` reports feed count, item count, most recent fetch attempt, and the
+  sum of consecutive fetch errors currently recorded across feeds.
+- Root `--json` selects JSON for every database-reading command above unless an
+  explicit non-default format is requested.
+- Help text documents discovery, examples, and ambiguity/error behavior.
+
+## Research skill
+
+Add one conventional, self-contained `skills/feedspool-research/SKILL.md`.
+Both Anthropic-style skills and the referenced Hermes repository use a
+`SKILL.md`, so one artifact can document the common CLI workflow without
+maintaining ecosystem-specific copies.
+
+The skill teaches agents to:
+
+1. run `status --json` and `feeds --json` for orientation;
+2. refresh with `fetch --json` when authorized;
+3. query `items --since <RFC3339> --json` using a caller-owned cursor;
+4. narrow with `--feed` or `--search`;
+5. inspect promising links with `item <link> --json`;
+6. advance the cursor only after successfully handling the result set.
+
+Read/unread state remains optional and is not substituted for the caller-owned
+cursor. Subscribe/unsubscribe behavior remains out of scope.
+
+## Post-review refinements
+
+- `items --compact` emits a small, flat JSON cursor manifest without content,
+  summaries, or raw item JSON.
+- `item --feed <exact URL> --guid <GUID>` resolves links that occur more than
+  once, including duplicates within one feed.
+- `status` distinguishes the number of failing feeds from the sum of their
+  consecutive error counters; `feeds --errors` lists only those feeds.
+- Discovery-window queries use a SQLite index as a conservative prefilter and
+  retain exact Go time comparisons for mixed-offset and legacy timestamps.
+- Read-workflow documentation discloses automatic schema migrations.
+- A separate `feedspool-daily-newsletter` skill turns a complete cursor window
+  into a subject and Markdown email body. Scheduling and delivery remain out
+  of scope.

--- a/integration_test.go
+++ b/integration_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"database/sql"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -325,6 +327,276 @@ func TestIntegrationEndToEnd(t *testing.T) {
 
 		if !strings.Contains(output, "feedspool") {
 			t.Errorf("Version output should contain program name, got: %s", output)
+		}
+	})
+}
+
+func TestAgentFriendlyReadCLI(t *testing.T) {
+	const (
+		alphaGUID       = "alpha-go"
+		alphaTitle      = "Practical Go Agents"
+		ambiguousMarker = "ambiguous"
+		betaCopyGUID    = "beta-copy"
+		feedFlag        = "--feed"
+		fullItemBody    = "Full item body"
+		guidFlag        = "--guid"
+	)
+
+	binaryPath := buildBinary(t)
+	dbPath := filepath.Join(t.TempDir(), "feeds.db")
+	db, err := database.New(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.InitSchema(); err != nil {
+		t.Fatal(err)
+	}
+
+	latestFetch := time.Date(2026, 8, 25, 13, 0, 0, 0, time.UTC)
+	alphaURL := "https://alpha.example/feed.xml"
+	betaURL := "https://beta.example/feed.xml"
+	for _, feed := range []*database.Feed{
+		{URL: alphaURL, Title: "Alpha Feed", LastFetchTime: latestFetch, LastSuccessfulFetch: latestFetch},
+		{URL: betaURL, Title: "Beta Feed", ErrorCount: 2, LastError: "timeout"},
+	} {
+		if err := db.UpsertFeed(feed); err != nil {
+			t.Fatal(err)
+		}
+	}
+	itemLink := "https://alpha.example/posts/go-agents"
+	for _, item := range []*database.Item{
+		{
+			FeedURL: alphaURL, GUID: alphaGUID, Title: alphaTitle, Link: itemLink,
+			PublishedDate: latestFetch.Add(-time.Hour), Summary: "Agent patterns", Content: fullItemBody,
+		},
+		{
+			FeedURL: betaURL, GUID: "beta-rust", Title: "Rust Notes",
+			Link: "https://beta.example/posts/rust", PublishedDate: latestFetch.Add(-2 * time.Hour),
+		},
+	} {
+		if err := db.UpsertItem(item); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := db.UpsertMetadata(&database.URLMetadata{
+		URL:         itemLink,
+		Title:       sql.NullString{String: "Unfurled title", Valid: true},
+		Description: sql.NullString{String: "Unfurled description", Valid: true},
+		ImageURL:    sql.NullString{String: "https://alpha.example/image.png", Valid: true},
+		FaviconURL:  sql.NullString{String: "https://alpha.example/favicon.ico", Valid: true},
+		Metadata:    database.JSON(`{"og:type":"article"}`),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("feeds JSON", func(t *testing.T) {
+		output, err := runCommand(binaryPath, "--database", dbPath, "--json", "feeds")
+		if err != nil {
+			t.Fatalf("feeds failed: %v\n%s", err, output)
+		}
+		var feeds []struct {
+			URL           string  `json:"url"`
+			LastFetchTime *string `json:"last_fetch_time"`
+			ItemCount     int     `json:"item_count"`
+		}
+		if err := json.Unmarshal([]byte(output), &feeds); err != nil {
+			t.Fatalf("feeds returned invalid JSON: %v\n%s", err, output)
+		}
+		if len(feeds) != 2 || feeds[0].URL != alphaURL || feeds[0].ItemCount != 1 ||
+			feeds[0].LastFetchTime == nil || feeds[1].LastFetchTime != nil {
+			t.Errorf("feeds output = %#v", feeds)
+		}
+	})
+
+	t.Run("feeds with errors JSON", func(t *testing.T) {
+		output, err := runCommand(binaryPath, "--database", dbPath, "--json", "feeds", "--errors")
+		if err != nil {
+			t.Fatalf("feeds --errors failed: %v\n%s", err, output)
+		}
+		var feeds []struct {
+			URL        string `json:"url"`
+			ErrorCount int    `json:"error_count"`
+		}
+		if err := json.Unmarshal([]byte(output), &feeds); err != nil {
+			t.Fatalf("feeds --errors returned invalid JSON: %v\n%s", err, output)
+		}
+		if len(feeds) != 1 || feeds[0].URL != betaURL || feeds[0].ErrorCount != 2 {
+			t.Errorf("feeds --errors output = %#v", feeds)
+		}
+	})
+
+	t.Run("status JSON", func(t *testing.T) {
+		output, err := runCommand(binaryPath, "--database", dbPath, "--json", "status")
+		if err != nil {
+			t.Fatalf("status failed: %v\n%s", err, output)
+		}
+		var status struct {
+			FeedCount             int     `json:"feed_count"`
+			ItemCount             int     `json:"item_count"`
+			LastFetchTime         *string `json:"last_fetch_time"`
+			FailingFeedCount      int     `json:"failing_feed_count"`
+			ConsecutiveErrorCount int     `json:"consecutive_error_count"`
+		}
+		if err := json.Unmarshal([]byte(output), &status); err != nil {
+			t.Fatalf("status returned invalid JSON: %v\n%s", err, output)
+		}
+		if status.FeedCount != 2 || status.ItemCount != 2 || status.FailingFeedCount != 1 ||
+			status.ConsecutiveErrorCount != 2 || status.LastFetchTime == nil {
+			t.Errorf("status output = %#v", status)
+		}
+	})
+
+	t.Run("item filters", func(t *testing.T) {
+		output, err := runCommand(
+			binaryPath, "--database", dbPath, "--json", "items", "--feed", "ALPHA.EXAMPLE", "--search", "go",
+		)
+		if err != nil {
+			t.Fatalf("items failed: %v\n%s", err, output)
+		}
+		var items []database.Item
+		if err := json.Unmarshal([]byte(output), &items); err != nil {
+			t.Fatalf("items returned invalid JSON: %v\n%s", err, output)
+		}
+		if len(items) != 1 || items[0].GUID != alphaGUID {
+			t.Errorf("items output = %#v", items)
+		}
+	})
+
+	t.Run("compact item manifest", func(t *testing.T) {
+		output, err := runCommand(
+			binaryPath, "--database", dbPath, "--json", "items", "--compact", "--feed", "alpha.example",
+		)
+		if err != nil {
+			t.Fatalf("compact items failed: %v\n%s", err, output)
+		}
+		var items []struct {
+			FeedURL       string `json:"feed_url"`
+			GUID          string `json:"guid"`
+			Title         string `json:"title"`
+			Link          string `json:"link"`
+			PublishedDate string `json:"published_date"`
+			DiscoveredAt  string `json:"discovered_at"`
+		}
+		if err := json.Unmarshal([]byte(output), &items); err != nil {
+			t.Fatalf("compact items returned invalid JSON: %v\n%s", err, output)
+		}
+		if len(items) != 1 || items[0].FeedURL != alphaURL || items[0].GUID != alphaGUID ||
+			items[0].Title != alphaTitle || items[0].Link != itemLink ||
+			items[0].PublishedDate == "" || items[0].DiscoveredAt == "" {
+			t.Errorf("compact items output = %#v", items)
+		}
+		if strings.Contains(output, `"Content"`) || strings.Contains(output, `"ItemJSON"`) {
+			t.Errorf("compact items included full item fields: %s", output)
+		}
+	})
+
+	t.Run("fuzzy show", func(t *testing.T) {
+		output, err := runCommand(binaryPath, "--database", dbPath, "show", "alpha.example")
+		if err != nil {
+			t.Fatalf("fuzzy show failed: %v\n%s", err, output)
+		}
+		if !strings.Contains(output, alphaTitle) {
+			t.Errorf("fuzzy show output = %s", output)
+		}
+
+		output, err = runCommand(binaryPath, "--database", dbPath, "show", "example")
+		if err == nil {
+			t.Fatalf("ambiguous show succeeded: %s", output)
+		}
+		for _, want := range []string{ambiguousMarker, alphaURL, betaURL} {
+			if !strings.Contains(output, want) {
+				t.Errorf("ambiguous show output missing %q: %s", want, output)
+			}
+		}
+	})
+
+	t.Run("item metadata JSON", func(t *testing.T) {
+		output, err := runCommand(binaryPath, "--database", dbPath, "--json", "item", itemLink)
+		if err != nil {
+			t.Fatalf("item failed: %v\n%s", err, output)
+		}
+		var item struct {
+			Metadata *database.URLMetadata `json:"Metadata"`
+			Content  string
+		}
+		if err := json.Unmarshal([]byte(output), &item); err != nil {
+			t.Fatalf("item returned invalid JSON: %v\n%s", err, output)
+		}
+		if item.Metadata == nil || !item.Metadata.ImageURL.Valid || item.Content != fullItemBody {
+			t.Errorf("item metadata output = %#v\n%s", item.Metadata, output)
+		}
+	})
+
+	t.Run("ambiguous item link", func(t *testing.T) {
+		db, err := database.New(dbPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := db.UpsertItem(&database.Item{
+			FeedURL: betaURL,
+			GUID:    betaCopyGUID,
+			Title:   "Syndicated copy",
+			Link:    itemLink,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		output, err := runCommand(binaryPath, "--database", dbPath, "--json", "item", itemLink)
+		if err == nil {
+			t.Fatalf("ambiguous item lookup succeeded: %s", output)
+		}
+		for _, want := range []string{
+			ambiguousMarker, alphaURL, alphaGUID, betaURL, betaCopyGUID, feedFlag, guidFlag,
+		} {
+			if !strings.Contains(output, want) {
+				t.Errorf("ambiguous item output missing %q: %s", want, output)
+			}
+		}
+	})
+
+	t.Run("item identity selector", func(t *testing.T) {
+		output, err := runCommand(
+			binaryPath, "--database", dbPath, "--json", "item", feedFlag, alphaURL, guidFlag, alphaGUID,
+		)
+		if err != nil {
+			t.Fatalf("item identity lookup failed: %v\n%s", err, output)
+		}
+		var item struct {
+			FeedURL string `json:"FeedURL"`
+			GUID    string `json:"GUID"`
+			Content string `json:"Content"`
+		}
+		if err := json.Unmarshal([]byte(output), &item); err != nil {
+			t.Fatalf("item identity lookup returned invalid JSON: %v\n%s", err, output)
+		}
+		if item.FeedURL != alphaURL || item.GUID != alphaGUID || item.Content != fullItemBody {
+			t.Errorf("item identity output = %#v", item)
+		}
+	})
+
+	t.Run("help discovery", func(t *testing.T) {
+		output, err := runCommand(binaryPath, "items", "--help")
+		if err != nil {
+			t.Fatalf("items help failed: %v\n%s", err, output)
+		}
+		for _, want := range []string{"Examples:", "--feed", "--search", "RFC3339"} {
+			if !strings.Contains(output, want) {
+				t.Errorf("items help missing %q: %s", want, output)
+			}
+		}
+
+		output, err = runCommand(binaryPath, "item", "--help")
+		if err != nil {
+			t.Fatalf("item help failed: %v\n%s", err, output)
+		}
+		if !strings.Contains(output, ambiguousMarker) || !strings.Contains(output, "non-zero") {
+			t.Errorf("item help omits ambiguity exit behavior: %s", output)
 		}
 	})
 }

--- a/internal/database/feed_repository.go
+++ b/internal/database/feed_repository.go
@@ -116,6 +116,127 @@ func (db *DB) GetAllFeeds() ([]*Feed, error) {
 	return feeds, nil
 }
 
+// GetFeedSummaries retrieves tracked feeds with item and fetch statistics.
+func (db *DB) GetFeedSummaries() ([]FeedSummary, error) {
+	query := `
+		SELECT f.url, f.title, f.last_fetch_time, COUNT(i.id), f.error_count
+		FROM feeds f
+		LEFT JOIN items i ON i.feed_url = f.url
+		GROUP BY f.url
+		ORDER BY f.url
+	`
+	rows, err := db.conn.Query(query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get feed summaries: %w", err)
+	}
+	defer rows.Close()
+
+	summaries := []FeedSummary{}
+	for rows.Next() {
+		var summary FeedSummary
+		if err := rows.Scan(
+			&summary.URL,
+			&summary.Title,
+			&summary.LastFetchTime,
+			&summary.ItemCount,
+			&summary.ErrorCount,
+		); err != nil {
+			return nil, fmt.Errorf("failed to scan feed summary: %w", err)
+		}
+		if summary.LastFetchTime.Valid && summary.LastFetchTime.Time.IsZero() {
+			summary.LastFetchTime = sql.NullTime{}
+		}
+		summaries = append(summaries, summary)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating feed summaries: %w", err)
+	}
+	return summaries, nil
+}
+
+// GetSpoolStatus retrieves aggregate feed, item, and fetch health counts.
+func (db *DB) GetSpoolStatus() (*SpoolStatus, error) {
+	query := `
+		SELECT
+			(SELECT COUNT(*) FROM feeds),
+			(SELECT COUNT(*) FROM items),
+			(SELECT COUNT(*) FROM feeds WHERE error_count > 0),
+			(SELECT COALESCE(SUM(error_count), 0) FROM feeds)
+	`
+	var status SpoolStatus
+	if err := db.conn.QueryRow(query).Scan(
+		&status.FeedCount,
+		&status.ItemCount,
+		&status.FailingFeedCount,
+		&status.ConsecutiveErrorCount,
+	); err != nil {
+		return nil, fmt.Errorf("failed to get spool status: %w", err)
+	}
+	rows, err := db.conn.Query("SELECT last_fetch_time FROM feeds WHERE last_fetch_time IS NOT NULL")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get fetch times: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var candidate sql.NullTime
+		if err := rows.Scan(&candidate); err != nil {
+			return nil, fmt.Errorf("failed to scan fetch time: %w", err)
+		}
+		if candidate.Valid && !candidate.Time.IsZero() &&
+			(!status.LastFetchTime.Valid || candidate.Time.After(status.LastFetchTime.Time)) {
+			status.LastFetchTime = candidate
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate fetch times: %w", err)
+	}
+	return &status, nil
+}
+
+// FindFeedsByURLSubstring retrieves feeds whose URLs contain query.
+func (db *DB) FindFeedsByURLSubstring(query string) ([]*Feed, error) {
+	statement := `
+		SELECT url, title, description, last_updated, etag, last_modified,
+			last_fetch_time, last_successful_fetch, error_count, user_agent,
+			last_error, latest_item_date, feed_json
+		FROM feeds
+		WHERE instr(lower(url), lower(?)) > 0
+		ORDER BY url
+	`
+	rows, err := db.conn.Query(statement, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find feeds: %w", err)
+	}
+	defer rows.Close()
+
+	feeds := []*Feed{}
+	for rows.Next() {
+		feed := &Feed{}
+		if err := rows.Scan(
+			&feed.URL,
+			&feed.Title,
+			&feed.Description,
+			&feed.LastUpdated,
+			&feed.ETag,
+			&feed.LastModified,
+			&feed.LastFetchTime,
+			&feed.LastSuccessfulFetch,
+			&feed.ErrorCount,
+			&feed.UserAgent,
+			&feed.LastError,
+			&feed.LatestItemDate,
+			&feed.FeedJSON,
+		); err != nil {
+			return nil, fmt.Errorf("failed to scan matching feed: %w", err)
+		}
+		feeds = append(feeds, feed)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating matching feeds: %w", err)
+	}
+	return feeds, nil
+}
+
 // DeleteFeed deletes a feed and all its associated items from the database.
 func (db *DB) DeleteFeed(url string) error {
 	_, err := db.conn.Exec("DELETE FROM feeds WHERE url = ?", url)

--- a/internal/database/feed_repository_test.go
+++ b/internal/database/feed_repository_test.go
@@ -1,8 +1,16 @@
 package database
 
 import (
+	"database/sql"
 	"testing"
 	"time"
+)
+
+const (
+	testAlphaFeedURL   = "https://alpha.example/feed.xml"
+	testBetaFeedURL    = "https://beta.example/feed.xml"
+	testExampleNetFeed = "https://example.net/rss"
+	testAlphaGUID      = "alpha-go"
 )
 
 func TestUpsertAndGetFeed(t *testing.T) {
@@ -131,5 +139,114 @@ func TestGetAllFeeds(t *testing.T) {
 	// Check ordering (should be by URL)
 	if retrieved[0].URL != fixtureFeedURL1 {
 		t.Errorf("First feed URL = %v, want %v", retrieved[0].URL, fixtureFeedURL1)
+	}
+}
+
+func TestGetFeedSummaries(t *testing.T) {
+	db := setupTestDB(t)
+	lastFetch := time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+	feeds := []*Feed{
+		{URL: testAlphaFeedURL, Title: "Alpha", LastFetchTime: lastFetch, ErrorCount: 2},
+		{URL: testBetaFeedURL, Title: "Beta"},
+	}
+	for _, feed := range feeds {
+		if err := db.UpsertFeed(feed); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, item := range []*Item{
+		{FeedURL: feeds[0].URL, GUID: "alpha-1", Title: "One"},
+		{FeedURL: feeds[0].URL, GUID: "alpha-2", Title: "Two"},
+	} {
+		if err := db.UpsertItem(item); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	summaries, err := db.GetFeedSummaries()
+	if err != nil {
+		t.Fatalf("GetFeedSummaries() error = %v", err)
+	}
+	if len(summaries) != 2 {
+		t.Fatalf("GetFeedSummaries() returned %d rows, want 2", len(summaries))
+	}
+	if summaries[0].URL != feeds[0].URL || summaries[0].ItemCount != 2 ||
+		summaries[0].ErrorCount != 2 || !summaries[0].LastFetchTime.Valid ||
+		!summaries[0].LastFetchTime.Time.Equal(lastFetch) {
+		t.Errorf("first summary = %#v", summaries[0])
+	}
+	if summaries[1].URL != feeds[1].URL || summaries[1].ItemCount != 0 || summaries[1].LastFetchTime.Valid {
+		t.Errorf("second summary = %#v", summaries[1])
+	}
+}
+
+func TestGetSpoolStatus(t *testing.T) {
+	db := setupTestDB(t)
+	latestFetch := time.Date(2026, 8, 25, 13, 0, 0, 0, time.UTC)
+	feeds := []*Feed{
+		{URL: testAlphaFeedURL, LastFetchTime: latestFetch.Add(-time.Hour), ErrorCount: 1},
+		{URL: testBetaFeedURL, LastFetchTime: latestFetch, ErrorCount: 2},
+	}
+	for _, feed := range feeds {
+		if err := db.UpsertFeed(feed); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := db.UpsertItem(&Item{FeedURL: feeds[0].URL, GUID: "one"}); err != nil {
+		t.Fatal(err)
+	}
+
+	status, err := db.GetSpoolStatus()
+	if err != nil {
+		t.Fatalf("GetSpoolStatus() error = %v", err)
+	}
+	if status.FeedCount != 2 || status.ItemCount != 1 || status.FailingFeedCount != 2 ||
+		status.ConsecutiveErrorCount != 3 {
+		t.Errorf("GetSpoolStatus() = %#v", status)
+	}
+	if !status.LastFetchTime.Valid || !status.LastFetchTime.Time.Equal(latestFetch) {
+		t.Errorf("LastFetchTime = %#v, want %v", status.LastFetchTime, latestFetch)
+	}
+
+	empty := setupTestDB(t)
+	if err := empty.UpsertFeed(&Feed{URL: "https://never-fetched.example/feed.xml"}); err != nil {
+		t.Fatal(err)
+	}
+	emptyStatus, err := empty.GetSpoolStatus()
+	if err != nil {
+		t.Fatalf("empty GetSpoolStatus() error = %v", err)
+	}
+	if emptyStatus.LastFetchTime != (sql.NullTime{}) {
+		t.Errorf("empty LastFetchTime = %#v, want invalid", emptyStatus.LastFetchTime)
+	}
+}
+
+func TestFindFeedsByURLSubstring(t *testing.T) {
+	db := setupTestDB(t)
+	for _, url := range []string{
+		fixtureFeedURL,
+		testExampleNetFeed,
+		"https://other.test/feed",
+	} {
+		if err := db.UpsertFeed(&Feed{URL: url}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	matches, err := db.FindFeedsByURLSubstring("EXAMPLE")
+	if err != nil {
+		t.Fatalf("FindFeedsByURLSubstring() error = %v", err)
+	}
+	if len(matches) != 2 || matches[0].URL != fixtureFeedURL ||
+		matches[1].URL != testExampleNetFeed {
+		t.Errorf("FindFeedsByURLSubstring() = %#v", matches)
+	}
+
+	literal, err := db.FindFeedsByURLSubstring("%.com")
+	if err != nil {
+		t.Fatalf("literal FindFeedsByURLSubstring() error = %v", err)
+	}
+	if len(literal) != 0 {
+		t.Errorf("literal FindFeedsByURLSubstring() = %#v, want no wildcard matches", literal)
 	}
 }

--- a/internal/database/item_repository.go
+++ b/internal/database/item_repository.go
@@ -2,11 +2,18 @@ package database
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
 )
+
+const discoveryTimeExpression = `julianday(CASE
+	WHEN first_seen IS NULL OR substr(CAST(first_seen AS TEXT), 1, 10) = '0001-01-01'
+	THEN published_date
+	ELSE first_seen
+END)`
 
 // UpsertItem inserts or updates an item record in the database.
 func (db *DB) UpsertItem(item *Item) error {
@@ -287,22 +294,64 @@ func (db *DB) getItemsForFeeds(feedURLMap map[string]bool, start, end time.Time)
 }
 
 type ItemFilter struct {
-	FeedURL string
-	Limit   int
-	Since   time.Time
-	Until   time.Time
-	Unseen  bool
-	Seen    bool
+	FeedURL   string
+	FeedQuery string
+	Search    string
+	Limit     int
+	Since     time.Time
+	Until     time.Time
+	Unseen    bool
+	Seen      bool
 }
 
 // GetItems retrieves items with filtering options.
 func (db *DB) GetItems(filter *ItemFilter) ([]*Item, error) {
-	query := `
+	query, args, filterTimesInGo := buildItemsQuery(filter)
+	rows, err := db.conn.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get items: %w", err)
+	}
+	defer rows.Close()
+
+	var items []*Item
+	for rows.Next() {
+		var item Item
+		if err := rows.Scan(
+			&item.ID, &item.FeedURL, &item.GUID, &item.Title, &item.Link,
+			&item.PublishedDate, &item.FirstSeen, &item.Content, &item.Summary,
+			&item.Archived, &item.ItemJSON,
+		); err != nil {
+			return nil, fmt.Errorf("failed to scan item: %w", err)
+		}
+		if !itemInDiscoveryWindow(&item, filter.Since, filter.Until) {
+			continue
+		}
+		items = append(items, &item)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating over items: %w", err)
+	}
+
+	if filterTimesInGo {
+		sort.SliceStable(items, func(i, j int) bool {
+			return items[i].PublishedDate.After(items[j].PublishedDate)
+		})
+		if filter.Limit > 0 && len(items) > filter.Limit {
+			items = items[:filter.Limit]
+		}
+	}
+
+	return items, nil
+}
+
+func buildItemsQuery(filter *ItemFilter) (query string, args []interface{}, filterTimesInGo bool) {
+	filterTimesInGo = !filter.Since.IsZero() || !filter.Until.IsZero()
+	query = `
 		SELECT i.id, i.feed_url, i.guid, i.title, i.link, i.published_date, i.first_seen,
 			i.content, i.summary, i.archived, i.item_json
 		FROM items i
 	`
-	var args []interface{}
 	var conditions []string
 
 	if filter.Unseen {
@@ -323,49 +372,47 @@ func (db *DB) GetItems(filter *ItemFilter) ([]*Item, error) {
 		conditions = append(conditions, "i.feed_url = ?")
 		args = append(args, filter.FeedURL)
 	}
+	if filter.FeedQuery != "" {
+		conditions = append(conditions, "instr(lower(i.feed_url), lower(?)) > 0")
+		args = append(args, filter.FeedQuery)
+	}
+	if filter.Search != "" {
+		conditions = append(conditions, "instr(lower(i.title), lower(?)) > 0")
+		args = append(args, filter.Search)
+	}
 	if !filter.Since.IsZero() {
-		conditions = append(conditions, "i.published_date >= ?")
-		args = append(args, filter.Since)
+		conditions = append(conditions, fmt.Sprintf(
+			"(%[1]s IS NULL OR %[1]s >= julianday(?))", discoveryTimeExpression,
+		))
+		args = append(args, filter.Since.Format(time.RFC3339Nano))
 	}
 	if !filter.Until.IsZero() {
-		conditions = append(conditions, "i.published_date <= ?")
-		args = append(args, filter.Until)
+		conditions = append(conditions, fmt.Sprintf(
+			"(%[1]s IS NULL OR %[1]s <= julianday(?))", discoveryTimeExpression,
+		))
+		args = append(args, filter.Until.Format(time.RFC3339Nano))
 	}
-
 	if len(conditions) > 0 {
-		//nolint:gosec // conditions are safely constructed internally
 		query += " WHERE " + strings.Join(conditions, " AND ")
 	}
 
-	query += " ORDER BY i.published_date DESC"
-
-	if filter.Limit > 0 {
-		query += sqlLimitClause
-		args = append(args, filter.Limit)
-	}
-
-	rows, err := db.conn.Query(query, args...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get items: %w", err)
-	}
-	defer rows.Close()
-
-	var items []*Item
-	for rows.Next() {
-		var item Item
-		if err := rows.Scan(
-			&item.ID, &item.FeedURL, &item.GUID, &item.Title, &item.Link,
-			&item.PublishedDate, &item.FirstSeen, &item.Content, &item.Summary,
-			&item.Archived, &item.ItemJSON,
-		); err != nil {
-			return nil, fmt.Errorf("failed to scan item: %w", err)
+	if !filterTimesInGo {
+		query += " ORDER BY i.published_date DESC"
+		if filter.Limit > 0 {
+			query += sqlLimitClause
+			args = append(args, filter.Limit)
 		}
-		items = append(items, &item)
 	}
+	return query, args, filterTimesInGo
+}
 
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("error iterating over items: %w", err)
+func itemInDiscoveryWindow(item *Item, since, until time.Time) bool {
+	discoveredAt := item.PublishedDate
+	if item.FirstSeen.Valid && !item.FirstSeen.Time.IsZero() {
+		discoveredAt = item.FirstSeen.Time
 	}
-
-	return items, nil
+	if !since.IsZero() && !discoveredAt.After(since) {
+		return false
+	}
+	return until.IsZero() || !discoveredAt.After(until)
 }

--- a/internal/database/item_repository_test.go
+++ b/internal/database/item_repository_test.go
@@ -1,6 +1,8 @@
 package database
 
 import (
+	"database/sql"
+	"strings"
 	"testing"
 	"time"
 )
@@ -373,5 +375,101 @@ func TestDeleteArchivedItems(t *testing.T) {
 
 	if totalCount != 2 { // not-archived + recent-archived
 		t.Errorf("Total items in DB = %d, want 2", totalCount)
+	}
+}
+
+func TestGetItemsWithFeedAndTitleSubstringFilters(t *testing.T) {
+	db := setupTestDB(t)
+	discoveredAt := time.Date(2026, 8, 25, 14, 0, 0, 0, time.FixedZone("PDT", -7*60*60))
+	feeds := []string{
+		testAlphaFeedURL,
+		testBetaFeedURL,
+	}
+	for _, feedURL := range feeds {
+		if err := db.UpsertFeed(&Feed{URL: feedURL}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	items := []*Item{
+		{
+			FeedURL: feeds[0], GUID: testAlphaGUID, Title: "Practical Go Patterns",
+			PublishedDate: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+			FirstSeen:     sql.NullTime{Time: discoveredAt, Valid: true},
+		},
+		{FeedURL: feeds[0], GUID: "alpha-rust", Title: "Rust Notes"},
+		{FeedURL: feeds[1], GUID: "beta-go", Title: "Go Release"},
+	}
+	for _, item := range items {
+		if err := db.UpsertItem(item); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := db.GetItems(&ItemFilter{FeedQuery: "ALPHA.EXAMPLE", Search: "go"})
+	if err != nil {
+		t.Fatalf("GetItems() error = %v", err)
+	}
+	if len(got) != 1 || got[0].GUID != testAlphaGUID {
+		t.Errorf("GetItems() = %#v, want alpha-go", got)
+	}
+
+	newlyDiscovered, err := db.GetItems(&ItemFilter{
+		Since: discoveredAt.UTC().Add(-time.Minute),
+		Until: discoveredAt.UTC(),
+	})
+	if err != nil {
+		t.Fatalf("discovery-time GetItems() error = %v", err)
+	}
+	if len(newlyDiscovered) != 1 || newlyDiscovered[0].GUID != testAlphaGUID {
+		t.Errorf("discovery-time GetItems() = %#v, want back-dated alpha-go", newlyDiscovered)
+	}
+	atCursor, err := db.GetItems(&ItemFilter{Since: discoveredAt.UTC()})
+	if err != nil {
+		t.Fatalf("boundary GetItems() error = %v", err)
+	}
+	if len(atCursor) != 0 {
+		t.Errorf("boundary GetItems() returned %d items, want half-open cursor window", len(atCursor))
+	}
+
+	literal, err := db.GetItems(&ItemFilter{Search: "%"})
+	if err != nil {
+		t.Fatalf("literal GetItems() error = %v", err)
+	}
+	if len(literal) != 0 {
+		t.Errorf("literal GetItems() returned %d wildcard matches, want 0", len(literal))
+	}
+}
+
+func TestGetItemsDiscoveryWindowUsesIndex(t *testing.T) {
+	db := setupTestDB(t)
+	query, args, filterTimesInGo := buildItemsQuery(&ItemFilter{
+		Since: time.Date(2026, 8, 24, 0, 0, 0, 0, time.UTC),
+		Until: time.Date(2026, 8, 25, 0, 0, 0, 0, time.UTC),
+	})
+	if !filterTimesInGo {
+		t.Fatal("discovery window must retain the exact Go time comparison")
+	}
+
+	rows, err := db.conn.Query("EXPLAIN QUERY PLAN "+query, args...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+
+	var plan strings.Builder
+	for rows.Next() {
+		var id, parent, unused int
+		var detail string
+		if err := rows.Scan(&id, &parent, &unused, &detail); err != nil {
+			t.Fatal(err)
+		}
+		plan.WriteString(detail)
+		plan.WriteByte('\n')
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(plan.String(), "idx_items_discovery_time") {
+		t.Fatalf("discovery query plan does not use discovery index:\n%s", plan.String())
 	}
 }

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -14,7 +14,8 @@ const (
 	migrationVersion4   = 4 // Add first_seen column to items
 	migrationVersion5   = 5 // Add user_agent column to feeds
 	migrationVersion6   = 6 // Add item_annotations table
-	maxMigrationVersion = migrationVersion6
+	migrationVersion7   = 7 // Add discovery-time query index
+	maxMigrationVersion = migrationVersion7
 )
 
 // getMigrations returns the database migration scripts.
@@ -54,6 +55,10 @@ func getMigrations() map[int]string {
 		);
 		CREATE INDEX IF NOT EXISTS idx_item_annotations_lookup ON item_annotations(feed_url, item_guid, kind);
 		CREATE INDEX IF NOT EXISTS idx_item_annotations_kind   ON item_annotations(kind, created_at);`,
+		migrationVersion7: fmt.Sprintf(
+			"CREATE INDEX IF NOT EXISTS idx_items_discovery_time ON items(%s);",
+			discoveryTimeExpression,
+		),
 	}
 }
 

--- a/internal/database/models.go
+++ b/internal/database/models.go
@@ -44,6 +44,24 @@ type Feed struct {
 	FeedJSON            JSON         `db:"feed_json"`
 }
 
+// FeedSummary contains the fields needed to list tracked feeds.
+type FeedSummary struct {
+	URL           string       `json:"url"`
+	Title         string       `json:"title"`
+	LastFetchTime sql.NullTime `json:"-"`
+	ItemCount     int          `json:"item_count"`
+	ErrorCount    int          `json:"error_count"`
+}
+
+// SpoolStatus summarizes the current database contents and fetch health.
+type SpoolStatus struct {
+	FeedCount             int          `json:"feed_count"`
+	ItemCount             int          `json:"item_count"`
+	LastFetchTime         sql.NullTime `json:"-"`
+	FailingFeedCount      int          `json:"failing_feed_count"`
+	ConsecutiveErrorCount int          `json:"consecutive_error_count"`
+}
+
 type Item struct {
 	ID            int64        `db:"id"`
 	FeedURL       string       `db:"feed_url"`

--- a/internal/fetcher/fetcher.go
+++ b/internal/fetcher/fetcher.go
@@ -129,8 +129,9 @@ func (f *Fetcher) processParsedFeed(
 
 	feed.ETag = resp.Header.Get("ETag")
 	feed.LastModified = resp.Header.Get("Last-Modified")
-	feed.LastFetchTime = time.Now()
-	feed.LastSuccessfulFetch = time.Now()
+	now := time.Now().UTC()
+	feed.LastFetchTime = now
+	feed.LastSuccessfulFetch = now
 	feed.ErrorCount = 0
 	feed.LastError = ""
 
@@ -219,7 +220,7 @@ func (f *Fetcher) processFeedItems(gofeedData *gofeed.Feed, feedURL string) (int
 
 		// Set first_seen timestamp for new items, or load it for existing items
 		if isNewItem {
-			item.FirstSeen = sql.NullTime{Time: time.Now(), Valid: true}
+			item.FirstSeen = sql.NullTime{Time: time.Now().UTC(), Valid: true}
 		} else {
 			// Load first_seen from database for existing items (needed as fallback)
 			existingFirstSeen, err := f.getItemFirstSeen(feedURL, item.GUID)
@@ -368,8 +369,9 @@ func (f *Fetcher) isValidURL(urlStr string) bool {
 
 func (f *Fetcher) handleCachedFeed(result *FetchResult, existingFeed *database.Feed) *FetchResult {
 	if existingFeed != nil {
-		existingFeed.LastFetchTime = time.Now()
-		existingFeed.LastSuccessfulFetch = time.Now()
+		now := time.Now().UTC()
+		existingFeed.LastFetchTime = now
+		existingFeed.LastSuccessfulFetch = now
 		if upsertErr := f.db.UpsertFeed(existingFeed); upsertErr != nil {
 			logrus.WithError(upsertErr).Warn("Failed to update feed in database")
 		}
@@ -383,7 +385,7 @@ func (f *Fetcher) updateFeedError(feed *database.Feed, errorMsg string) {
 	if feed != nil {
 		feed.ErrorCount++
 		feed.LastError = errorMsg
-		feed.LastFetchTime = time.Now()
+		feed.LastFetchTime = time.Now().UTC()
 		if err := f.db.UpsertFeed(feed); err != nil {
 			logrus.WithError(err).Warn("Failed to update feed error in database")
 		}

--- a/skills/feedspool-daily-newsletter/SKILL.md
+++ b/skills/feedspool-daily-newsletter/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: feedspool-daily-newsletter
+description: Use when preparing a morning email newsletter or recurring daily digest from a feedspool database.
+---
+
+# Feedspool Daily Newsletter
+
+Produce a suggested email subject and a polished Markdown body. Scheduling and
+delivery remain the caller's responsibility.
+
+## Establish the window
+
+Use the last successfully handled RFC3339 cursor as `LAST_CHECKED`. Capture a
+UTC `WINDOW_END` after any authorized refresh. If no cursor exists, use the
+previous 24 hours and disclose that fallback outside the email body.
+
+Opening an older database may apply migrations. Use a copy when the source must
+remain byte-for-byte unchanged. Do not fetch, unfurl, annotate, schedule, or
+send email unless separately authorized. Run feedspool commands sequentially;
+concurrent processes can currently contend during database setup.
+
+```bash
+feedspool --database "$DB" --json status
+feedspool --database "$DB" --json items --compact \
+  --since "$LAST_CHECKED" --until "$WINDOW_END"
+```
+
+Query the complete `(LAST_CHECKED, WINDOW_END]` discovery window without a
+limit. If status reports failing feeds, use `feeds --errors --json` and mention
+material coverage gaps after the newsletter.
+
+When the compact manifest is still too large for direct context, process it as
+structured data before sampling. Inventory the total rows, unique links,
+duplicate groups, and publication-age buckets. “Handled” means every record
+participated in that accounting and the editorial selection rules; it does not
+mean quoting every record into the prompt.
+
+## Edit the edition
+
+Treat discovery time and publication time separately. A newly discovered old
+post belongs in a clearly labeled “Rediscovered” section when it remains worth
+sharing; do not present it as current news or silently discard it.
+
+Deduplicate identical links and overlapping coverage. Prefer the original
+reporting or primary source; use aggregators only when they add useful context.
+Inspect the strongest candidates through `item --json`. When a link is
+ambiguous, use `item --feed "$FEED_URL" --guid "$GUID" --json`. Base claims on
+stored material and distinguish synthesis from source reporting.
+
+Use known reader interests and prior feedback when available. Otherwise aim
+for a varied, high-signal edition of roughly 600–1,000 words:
+
+1. A specific subject naming two or three leading threads.
+2. A two- to four-sentence opening synthesis.
+3. Three to five thematic sections that connect related stories rather than
+   listing every item independently.
+4. A short “Worth a look” section for distinctive items that do not form a
+   theme.
+5. A “Rediscovered” section only when the window contains worthwhile older
+   material.
+
+Link every discussed item to its source. Omit low-signal repetition. Do not use
+seen annotations as the newsletter cursor and do not mark items seen.
+
+## Return state
+
+Return the suggested subject and Markdown body, followed outside the body by
+`NEXT_CURSOR=<WINDOW_END>`. Advance the cursor only after the complete manifest
+has been handled and the edition has been produced. An empty window may yield a
+brief no-news edition and still advance the cursor.

--- a/skills/feedspool-research/SKILL.md
+++ b/skills/feedspool-research/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: feedspool-research
+description: Use when researching, monitoring, or summarizing new items from a feedspool database across repeated agent runs.
+---
+
+# Feedspool Research
+
+Use a caller-owned RFC3339 cursor to make repeated checks stateless and
+complete. Run `feedspool <command> --help` when local flags differ from these
+examples.
+
+## Orient
+
+Opening an older database may apply pending schema migrations. Work from a
+copy when the source must remain byte-for-byte unchanged. Run feedspool
+commands sequentially; concurrent processes can currently contend during
+database setup.
+
+```bash
+feedspool --database "$DB" --json status
+```
+
+Run `fetch --json` only when the user asked to refresh or authorized its
+network and database writes. Report `failing_feed_count` and
+`consecutive_error_count`; when failures exist, inspect them with:
+
+```bash
+feedspool --database "$DB" --json feeds --errors
+```
+
+## Check a cursor window
+
+After refresh completes, capture `WINDOW_END` from a UTC clock with full
+RFC3339 precision. Query the complete window before narrowing it:
+
+```bash
+feedspool --database "$DB" --json items --compact \
+  --since "$LAST_CHECKED" --until "$WINDOW_END"
+```
+
+This window is `(LAST_CHECKED, WINDOW_END]` over discovery time (`first_seen`),
+not publication time. A back-dated post discovered now is therefore new.
+
+Do not use `--limit` for the complete cursor manifest. `--feed` and `--search`
+are useful secondary views when the manifest is large:
+
+```bash
+feedspool --database "$DB" --json items \
+  --since "$LAST_CHECKED" --until "$WINDOW_END" \
+  --feed example.com --search Go
+```
+
+Inspect promising links with:
+
+```bash
+feedspool --database "$DB" --json item "$LINK"
+```
+
+The result includes stored unfurl metadata. If it is missing, run `unfurl`
+only with authorization for a network request and database write.
+
+If a link is ambiguous, select the manifest's exact feed URL and GUID:
+
+```bash
+feedspool --database "$DB" --json item --feed "$FEED_URL" --guid "$GUID"
+```
+
+## Commit state
+
+Set `LAST_CHECKED = WINDOW_END` only after every item in the complete manifest
+has been handled. If work stops after a filtered or limited subset, keep the
+old cursor. Seen/unseen annotations may support a user workflow, but they do
+not replace this caller-owned cursor. Do not mark items seen unless the user
+also wants persistent read state.


### PR DESCRIPTION
## Summary

- Completes feedspool's read-side CLI so agents can orient, query complete discovery windows, narrow results, and inspect stored item metadata without querying SQLite directly.
- Adds compact manifests, actionable duplicate selection, clearer feed-health output, and an indexed discovery-time prefilter that preserves exact mixed-offset handling.
- Bundles research and daily-newsletter skills; the latter produces a suggested subject, Markdown body, coverage note, and safe next cursor while leaving scheduling and email delivery to the caller.

## Design decisions

`items --since/--until` uses the half-open discovery-time window `(since, until]`, based on `first_seen` with a legacy publication-time fallback. SQLite uses an expression index as a conservative candidate filter; unparseable legacy timestamps pass through, and Go performs the authoritative instant comparison.

`items --compact` preserves the full manifest while omitting content, summaries, and raw item JSON. Existing full JSON remains unchanged. `item <link>` still works; ambiguous links can now be selected exactly with `item --feed <URL> --guid <GUID>`.

`status` distinguishes failing-feed count from the aggregate consecutive-error count, and `feeds --errors` lists only affected feeds. Skill documentation discloses automatic migrations and recommends sequential CLI commands pending #57.

The newsletter skill inventories the complete window, deduplicates overlapping coverage, distinguishes current from rediscovered items, prefers primary sources, and advances the cursor only after whole-set accounting and successful composition.

## Changes

- Added `feeds`, `feeds --errors`, and `status` with table and global JSON output.
- Added `items --feed`, `items --search`, `items --compact`, safe discovery cursors, validation, and improved help.
- Added fuzzy feed addressing to `show`; full detail output and feed/GUID identity selection to `item`.
- Added migration 7 with a discovery-time expression index while retaining exact Go filtering.
- Normalized new fetch timestamps to UTC and handled mixed-zone, unparseable legacy, and never-fetched values safely.
- Added database and end-to-end regression coverage, manual documentation, `feedspool-research`, and `feedspool-daily-newsletter`.

## Test plan

- [x] Focused red-green tests for new CLI and database behavior
- [x] Newsletter baseline, forward test, and fresh-agent recheck against a copied production database
- [x] Equivalent skill frontmatter/name/placeholder validation (bundled validator is blocked locally by its missing PyYAML dependency)
- [x] `make format`
- [x] `make lint` — 0 issues
- [x] `make test` — all packages pass after rebasing onto current `main`
- [x] `make build`
- [x] Independent review; stale-base finding fixed by rebase, no remaining code findings

## References

- Spec: `docs/dev-sessions/2026-08-25-1400-agent-cli/spec.md`
- Plan: `docs/dev-sessions/2026-08-25-1400-agent-cli/plan.md`
- Follow-up database-lock issue: #57
- Closes #40
