### PR TITLE
Add HTML scraper feed type

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -179,9 +179,14 @@ from a webpage.
 | `--filename` | (config) | Path to subscription file |
 | `--discover` | false | Treat URL as a webpage; parse its HTML for `<link>` feed references |
 | `--user-agent` | (unset) | Set the feed's User-Agent override in an OPML list; use `--user-agent=` to clear it |
+| `--type` | (unset) | Set the OPML parser type to `rss` or `scrape` |
+| `--selector` | (unset) | CSS selector required with `--type scrape` |
 
-`--user-agent` works only with OPML lists. Re-subscribing to an existing URL
-updates its `userAgent` outline attribute instead of adding a duplicate.
+Per-feed options work only with OPML lists. Re-subscribing to an existing URL
+updates its outline attributes instead of adding a duplicate. A scrape feed
+requires both `--type scrape` and a non-empty `--selector`; setting `--type rss`
+clears an existing selector. Scraping is explicit and cannot be combined with
+`--discover`.
 
 **Side effects:** Creates the subscription file if it does not exist; adds or
 updates the URL. Makes a network request only when `--discover` is set. Does
@@ -194,6 +199,7 @@ feedspool subscribe https://example.com/feed.xml
 feedspool subscribe --discover https://example.com/blog
 feedspool subscribe --format opml --filename feeds.opml https://example.com/feed.xml
 feedspool subscribe --format opml --filename feeds.opml --user-agent "Custom Reader/1.0" https://example.com/feed.xml
+feedspool subscribe --format opml --filename feeds.opml --type scrape --selector "article.post" https://example.com/archive
 ```
 
 ### unsubscribe
@@ -241,8 +247,29 @@ Fetch feed content. Has three modes depending on arguments.
 longer in the live feed as archived. May delete feed rows when
 `--remove-missing` is used. If `--with-unfurl` is set, also writes
 `url_metadata`. Before fetching OPML lists, including directory mode, copies
-each outline's `userAgent` value into the feed row; a missing attribute clears
-the override. Conflicting values for one URL stop the fetch.
+each outline's `userAgent`, `type`, and `selector` values into the feed row;
+missing values restore the defaults. Conflicting values for one URL stop the
+fetch.
+
+#### HTML scrape feeds
+
+An OPML outline can treat an HTML page as a feed:
+
+```xml
+<outline type="scrape"
+         xmlUrl="https://example.com/archive"
+         selector="article.post" />
+```
+
+The normal HTTP path still handles User-Agent overrides, ETag, Last-Modified,
+timeouts, and `--force`. After a 200 response, feedspool applies the selector,
+uses a matched or nearby `<a>` element, resolves relative links, deduplicates
+them, and stores feed-shaped items. Link text is the preferred title, followed
+by the link's `title` attribute and the matched element's text.
+
+Scrape is a first-class parser type, not a fallback when RSS parsing fails.
+Scraped items have no `published_date`; feedspool uses `first_seen` for time
+filters and ordering. Text feed lists remain URL-only RSS lists.
 
 **JSON output (`--json`):**
 
@@ -596,8 +623,9 @@ Write all feeds currently in the database to a subscription file.
 
 **Usage:** `feedspool export <filename> --format <opml|text>`
 
-OPML exports include each feed's `userAgent` override. Text lists contain URLs
-only.
+OPML exports include each feed's `userAgent`, `type`, and `selector`
+configuration. Text lists contain URLs only, so exporting a scrape feed as text
+does not preserve its parser configuration.
 
 **Side effects:** Overwrites the target file.
 
@@ -828,8 +856,11 @@ One row per feed URL.
 | `last_fetch_time` | DATETIME | Last fetch attempt (success or failure) |
 | `last_successful_fetch` | DATETIME | Last 200 OK |
 | `error_count` | INTEGER | Consecutive errors; reset on success |
+| `user_agent` | TEXT | Optional per-feed request User-Agent |
+| `type` | TEXT | `rss` (default) or `scrape` |
+| `scrape_selector` | TEXT | CSS selector for a scrape feed |
 | `last_error` | TEXT | Last error message |
-| `latest_item_date` | DATETIME | Most recent item's clamped `published_date` |
+| `latest_item_date` | DATETIME | Most recent clamped `published_date`, falling back to `first_seen` |
 | `feed_json` | JSON | Full parsed feed structure |
 
 ### `items`
@@ -844,7 +875,7 @@ flagged `archived=1` rather than deleted.
 | `guid` | TEXT | Normalized GUID; see [GUID dedup](#guid-deduplication) |
 | `title` | TEXT | |
 | `link` | TEXT | Item URL |
-| `published_date` | DATETIME | *Clamped*; see [date clamping](#published-date-clamping) |
+| `published_date` | DATETIME | Nullable; *clamped* when present, otherwise `first_seen` is used |
 | `content` | TEXT | Full content (HTML entities decoded) |
 | `summary` | TEXT | Description/summary |
 | `archived` | BOOLEAN | `1` once item disappears from the live feed |
@@ -1024,11 +1055,12 @@ touch the database. The database accumulates whatever you fetch. To bring
 the DB back in line with the subscription list, run `purge --format <fmt>
 --filename <file>` (or `fetch --remove-missing`).
 
-OPML outlines may carry a per-feed `userAgent` attribute. An OPML-backed fetch
-synchronizes that attribute before making requests. Directory mode does the
-same across all OPML files and rejects conflicting values for one URL. Removing
-the attribute restores feedspool's default User-Agent on the next fetch. Text
-lists cannot store per-feed User-Agent overrides.
+OPML outlines may carry per-feed `userAgent`, `type`, and `selector` attributes.
+An OPML-backed fetch synchronizes those attributes before making requests.
+Directory mode does the same across all OPML files and rejects conflicting
+values for one URL. Removing `userAgent` restores feedspool's default
+User-Agent; removing `type` restores RSS parsing. Text lists cannot store
+per-feed configuration.
 
 ### What `purge` actually deletes
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # feedspool
 
-A CLI tool for managing RSS/Atom feeds with SQLite storage and static website generation.
+A CLI tool for managing RSS/Atom and HTML-scraped feeds with SQLite storage and static website generation.
 
 ## Features
 
@@ -26,6 +26,7 @@ Further feature highlights:
 - Static HTML site generation with responsive design, dark mode, and rich metadata
 - Multi-site builds from a directory of feed lists, with a shared deduped fetch
 - RSS/Atom feed autodiscovery from HTML pages
+- Explicit HTML scrape feeds driven by OPML CSS selectors
 - Export database feeds to OPML or text formats
 - SQLite database storage with feed history
 - Multiple output formats (table, JSON, CSV)

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -77,8 +77,10 @@ func runExport(_ *cobra.Command, args []string) error {
 	// Add all feeds and any metadata supported by the target format.
 	for _, feed := range feeds {
 		if err := list.AddFeed(feedlist.Feed{
-			URL:       feed.URL,
-			UserAgent: feed.UserAgent,
+			URL:            feed.URL,
+			UserAgent:      feed.UserAgent,
+			Type:           feed.Type,
+			ScrapeSelector: feed.ScrapeSelector,
 		}); err != nil {
 			return fmt.Errorf("failed to add URL %s to feed list: %w", feed.URL, err)
 		}

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -256,6 +256,9 @@ func runDirFetch(
 	if err := orchestrator.SynchronizeFeedConfigs(plan.FeedConfigs); err != nil {
 		return err
 	}
+	if err := orchestrator.SynchronizeFeedParserConfigs(plan.ParserConfigs); err != nil {
+		return err
+	}
 
 	results := orchestrator.FetchFromURLs(ctx, plan.URLs, opts)
 

--- a/cmd/item.go
+++ b/cmd/item.go
@@ -99,39 +99,19 @@ func parseItemSelector(args []string) (itemSelector, error) {
 }
 
 func getItemOutput(db *database.DB, selector itemSelector) (*ItemOutput, error) {
-	query := `
-		SELECT id, feed_url, guid, title, link, published_date, first_seen,
-			content, summary, archived, item_json
-		FROM items
-	`
-	var args []any
+	var items []*database.Item
+	var err error
 	if selector.link != "" {
-		query += " WHERE link = ? ORDER BY feed_url"
-		args = append(args, selector.link)
+		items, err = db.GetItemsByLink(selector.link)
 	} else {
-		query += " WHERE feed_url = ? AND guid = ?"
-		args = append(args, selector.feedURL, selector.guid)
+		var item *database.Item
+		item, err = db.GetItem(selector.feedURL, selector.guid)
+		if item != nil {
+			items = append(items, item)
+		}
 	}
-	rows, err := db.GetConnection().Query(query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to look up item: %w", err)
-	}
-	defer rows.Close()
-
-	var items []database.Item
-	for rows.Next() {
-		var item database.Item
-		if err := rows.Scan(
-			&item.ID, &item.FeedURL, &item.GUID, &item.Title, &item.Link,
-			&item.PublishedDate, &item.FirstSeen, &item.Content, &item.Summary,
-			&item.Archived, &item.ItemJSON,
-		); err != nil {
-			return nil, fmt.Errorf("failed to scan item: %w", err)
-		}
-		items = append(items, item)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("failed to iterate matching items: %w", err)
 	}
 	if len(items) == 0 {
 		if selector.link != "" {
@@ -159,7 +139,7 @@ func getItemOutput(db *database.DB, selector itemSelector) (*ItemOutput, error) 
 	if err != nil {
 		return nil, err
 	}
-	return &ItemOutput{Item: &item, Annotations: annotations, Metadata: metadata}, nil
+	return &ItemOutput{Item: item, Annotations: annotations, Metadata: metadata}, nil
 }
 
 func outputItem(format string, output *ItemOutput) error {
@@ -179,7 +159,7 @@ func outputItemTable(output *ItemOutput) error {
 	item := output.Item
 	//nolint:forbidigo // Command output.
 	fmt.Printf("Title: %s\nLink: %s\nFeed URL: %s\nDate: %s\nSummary: %s\nContent: %s\n",
-		item.Title, item.Link, item.FeedURL, item.PublishedDate.Format(time.RFC3339), item.Summary, item.Content)
+		item.Title, item.Link, item.FeedURL, item.EffectiveDate().Format(time.RFC3339), item.Summary, item.Content)
 	if item.FirstSeen.Valid {
 		//nolint:forbidigo // Command output.
 		fmt.Printf("First Seen: %s\n", item.FirstSeen.Time.Format(time.RFC3339))

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -177,7 +177,7 @@ func outputTable(items []*database.Item) error {
 	fmt.Fprintln(w, "----\t-----\t----")
 
 	for _, item := range items {
-		date := item.PublishedDate.Format("2006-01-02 15:04")
+		date := item.EffectiveDate().Format("2006-01-02 15:04")
 		title := item.Title
 		if len(title) > 60 {
 			title = title[:57] + "..."
@@ -207,7 +207,7 @@ func outputCSV(items []*database.Item) error {
 
 	for _, item := range items {
 		record := []string{
-			item.PublishedDate.Format(time.RFC3339),
+			item.EffectiveDate().Format(time.RFC3339),
 			item.Title,
 			item.Link,
 			item.Summary,

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/lmorchard/feedspool-go/internal/subscription"
 	"github.com/spf13/cobra"
@@ -12,6 +13,8 @@ var (
 	subscribeFilename  string
 	subscribeDiscover  bool
 	subscribeUserAgent string
+	subscribeFeedType  string
+	subscribeSelector  string
 )
 
 var subscribeCmd = &cobra.Command{
@@ -25,6 +28,8 @@ Examples:
   feedspool subscribe https://example.com/feed.xml
   feedspool subscribe --user-agent "Custom Reader/1.0" https://example.com/feed.xml
   feedspool subscribe --user-agent= https://example.com/feed.xml
+  feedspool subscribe --type scrape --selector "article.card" https://example.com/archive
+  feedspool subscribe --type rss https://example.com/feed.xml
   feedspool subscribe --discover https://example.com/blog
   feedspool subscribe --format text --filename feeds.txt https://example.com/feed.xml`,
 	Args: cobra.ExactArgs(1),
@@ -41,6 +46,8 @@ func init() {
 		"",
 		"Per-feed User-Agent override for OPML lists (use --user-agent= to clear)",
 	)
+	subscribeCmd.Flags().StringVar(&subscribeFeedType, "type", "", "Feed parser type for OPML lists (rss or scrape)")
+	subscribeCmd.Flags().StringVar(&subscribeSelector, "selector", "", "CSS selector for a scrape feed")
 	rootCmd.AddCommand(subscribeCmd)
 }
 
@@ -55,19 +62,19 @@ func runSubscribe(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	urlsToAdd, err := getURLsToAdd(manager, targetURL, subscribeDiscover)
+	options, err := buildSubscribeOptions(cmd)
 	if err != nil {
 		return err
 	}
 
+	urlsToAdd, err := getURLsToAdd(manager, targetURL, subscribeDiscover)
+	if err != nil {
+		return err
+	}
 	if len(urlsToAdd) == 0 {
 		return nil
 	}
 
-	options := subscription.SubscribeOptions{}
-	if cmd.Flags().Changed("user-agent") {
-		options.UserAgent = &subscribeUserAgent
-	}
 	result, err := manager.SubscribeWithOptions(format, filename, urlsToAdd, options)
 	if err != nil {
 		return err
@@ -98,6 +105,24 @@ func runSubscribe(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func buildSubscribeOptions(cmd *cobra.Command) (subscription.SubscribeOptions, error) {
+	options := subscription.SubscribeOptions{}
+	if cmd.Flags().Changed("user-agent") {
+		options.UserAgent = &subscribeUserAgent
+	}
+	if cmd.Flags().Changed("type") {
+		options.FeedType = &subscribeFeedType
+	}
+	if cmd.Flags().Changed("selector") {
+		options.ScrapeSelector = &subscribeSelector
+	}
+	if subscribeDiscover && options.FeedType != nil &&
+		strings.EqualFold(strings.TrimSpace(*options.FeedType), "scrape") {
+		return options, fmt.Errorf("--discover cannot be combined with --type scrape")
+	}
+	return options, nil
 }
 
 func getURLsToAdd(manager *subscription.Manager, targetURL string, discover bool) ([]string, error) {

--- a/docs/dev-sessions/2026-08-25-1428-html-scraper/notes.md
+++ b/docs/dev-sessions/2026-08-25-1428-html-scraper/notes.md
@@ -1,0 +1,51 @@
+# Session notes
+
+## Context
+
+- Branch: `feat/38-html-scraper`
+- Worktree: `.claude/worktrees/issue-38-html-scraper`
+- Base: `main`. The branch was initially stacked on PR #53 because both issues change authoritative per-feed OPML configuration. It was later rebased onto `486e6e7` after PR #54 merged.
+- Pull request: https://github.com/lmorchard/feedspool-go/pull/55
+- PR #54 for issue #40 is merged.
+
+## Decisions
+
+- OPML carries `type` and `selector` attributes. Text lists remain URL-only/RSS-only, following the explicit option chosen for related issue #37.
+- Missing and legacy non-scrape OPML types remain effective RSS feeds.
+- Scraping is an explicit parser type, never an automatic fallback from a failed RSS parse.
+- Scraped items intentionally have no publication date and use `first_seen`.
+
+## Current state
+
+Implementation and independent review are complete. PR #55 is rebased directly onto `main` and ready to amend and push.
+
+## Implemented
+
+- Added the pure `internal/scraper` parser with MIT attribution, selector validation, nearby-link discovery, relative URL resolution, title fallbacks, and deduplication.
+- Added OPML `type` and `selector` metadata, conflict detection, subscription updates, CLI flags, and OPML export support. Text lists remain URL-only RSS lists.
+- Added migration 8 and repository support for `feeds.type` and `feeds.scrape_selector`; migration 7 remains PR #54's discovery-time index.
+- Added migration 9 to normalize parseable legacy item timestamps to UTC RFC3339 and create global and per-feed scraper-aware effective-date indexes.
+- Added scrape dispatch after the shared HTTP/cache layer. Scraped items use resolved links as GUIDs and share max-item, first-seen, archive, and unfurl handling with RSS items.
+- Store missing scraped publication dates as SQL `NULL`; item time filters, ordering, purge selection, rendering queries, and unfurl selection fall back to `first_seen`.
+- Normalize stored item dates and every SQLite time boundary to UTC so offset-bearing RFC3339 filters remain chronological rather than lexical.
+- Updated README and operator manual coverage.
+- Moved exact link and feed/GUID item lookup into the item repository while preserving ambiguous-link CLI errors and nullable publication dates.
+- Kept discovery-window queries on the discovery-time index after SQLite began preferring the new effective-date ordering index.
+- Changed effective-date filtering and ordering from lexical timestamp comparisons to chronological SQLite Julian dates. Unparseable legacy dates are excluded from bounded reads and retained by destructive purges.
+
+## Verification
+
+- `make format` — passed.
+- `make lint` — passed with 0 issues.
+- `make test` — passed for all packages after final changes.
+- `make build BINARY=/tmp/feedspool-pr55` — passed.
+- `git diff --check` — passed.
+
+## Review
+
+- Independent review initially found cache invalidation, nullable-date consumers, redirect-relative links, text/OPML precedence, UTC timestamp boundaries, and an item JSON inconsistency.
+- Each finding received a focused regression and fix. The final review reported no remaining Important or Minor findings and marked the branch ready to merge.
+- GitHub follow-up review requested moving item lookup SQL into the repository and indexing `COALESCE(published_date, first_seen)`; both changes have focused regression coverage.
+- The PR #54 merge produced four content conflicts: `cmd/item.go`, `internal/database/item_repository.go`, `internal/database/item_repository_test.go`, and `internal/database/migrations.go`. All were resolved while preserving both feature sets.
+- The final independent pass found that a raw `COALESCE` index still compared mixed-offset legacy timestamps lexically and did not cover the common per-feed plan. Focused regressions now cover chronological offset handling, conservative purge behavior, migration normalization, and the composite query plan.
+- The narrow re-review reported no remaining Important or Minor findings. It confirmed the global, per-feed, and discovery query plans use their intended indexes without a temporary per-feed sort.

--- a/docs/dev-sessions/2026-08-25-1428-html-scraper/plan.md
+++ b/docs/dev-sessions/2026-08-25-1428-html-scraper/plan.md
@@ -1,0 +1,8 @@
+# Implementation plan
+
+1. Add failing parser tests and implement the pure scraper package.
+2. Add failing feed-list and subscription tests, then extend OPML-backed feed configuration and CLI flags.
+3. Add failing database migration/repository tests, then persist feed type and selector.
+4. Add failing fetcher/orchestrator tests, then dispatch scrape feeds through the existing HTTP and item pipeline.
+5. Update user documentation and examples.
+6. Run focused and full verification, request independent review, and open a stacked PR against PR #53's branch.

--- a/docs/dev-sessions/2026-08-25-1428-html-scraper/spec.md
+++ b/docs/dev-sessions/2026-08-25-1428-html-scraper/spec.md
@@ -1,0 +1,35 @@
+# HTML scraper feed type
+
+Issue: https://github.com/lmorchard/feedspool-go/issues/38
+
+## Goal
+
+Allow an OPML entry to declare an HTML page as a `scrape` feed with a CSS selector. Fetching that entry should reuse feedspool's HTTP/cache path, extract stable article links, and store synthesized items through the existing item lifecycle.
+
+## Design
+
+- Extend feed configuration with `Type` (`rss` or `scrape`) and `ScrapeSelector`.
+- Treat a missing OPML type, and legacy non-`scrape` OPML types, as `rss` for backward compatibility.
+- Store scrape configuration as `type` and `scrape_selector` columns on `feeds`; OPML remains authoritative when fetched from a file or directory.
+- Keep text lists URL-only, consistent with the decision made for per-feed User-Agent metadata in #37/#51. Text-list entries therefore remain RSS feeds.
+- Add `subscribe --type scrape --selector '<css>'` for creating or updating scrape entries. Scrape subscriptions require OPML and a non-empty selector. `--type rss` clears an existing selector.
+- Add a pure `internal/scraper.Parse(io.Reader, baseURL, selector)` parser. It resolves relative URLs, uses the matched link or nearest ancestor link, deduplicates by resolved URL, and derives titles from link text, link `title`, then matched-element text.
+- Dispatch only after the shared HTTP response is obtained. RSS uses gofeed; scrape uses the new parser.
+- Synthesized items use their resolved link as the stable GUID, have no publication date, and rely on `first_seen` for ordering.
+- Preserve conditional requests, per-feed User-Agent overrides, max-item limits, archiving, and optional unfurling for scrape feeds.
+
+## Compatibility and errors
+
+- Existing databases migrate without changing existing feeds' effective RSS behavior.
+- A scrape feed without a selector fails before parsing with a clear error.
+- Invalid CSS selectors return a wrapped parse error and do not replace prior items.
+- Duplicate entries with conflicting type or selector configuration fail before any requests, as User-Agent conflicts already do.
+- Direct `fetch URL` remains RSS unless that URL already has persisted scrape configuration.
+
+## Verification
+
+- Unit tests for parser extraction, title fallbacks, relative resolution, deduplication, invalid selectors, and no matches.
+- Feed-list and subscription tests for OPML round trips, updates, validation, and configuration conflicts.
+- Migration/repository tests for new columns and exact configuration synchronization.
+- Fetcher/orchestrator tests for scrape dispatch, headers/cache behavior, first-seen dates, item limits, and config synchronization.
+- `make format`, `make lint`, `make test`, and `make build`.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/lmorchard/feedspool-go
 go 1.25.0
 
 require (
+	github.com/PuerkitoBio/goquery v1.5.1
+	github.com/andybalholm/cascadia v1.1.0
 	github.com/mmcdole/gofeed v1.1.3
 	github.com/otiai10/opengraph/v2 v2.1.0
 	github.com/sirupsen/logrus v1.8.1
@@ -13,8 +15,6 @@ require (
 )
 
 require (
-	github.com/PuerkitoBio/goquery v1.5.1 // indirect
-	github.com/andybalholm/cascadia v1.1.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect

--- a/integration_test.go
+++ b/integration_test.go
@@ -46,6 +46,8 @@ const integrationTestFeed = `<?xml version="1.0" encoding="UTF-8"?>
     </channel>
 </rss>`
 
+const integrationScrapeSelector = "article.post"
+
 func TestSubscribeUserAgentCLI(t *testing.T) {
 	binaryPath := buildBinaryViaMake(t)
 	filename := filepath.Join(t.TempDir(), "feeds.opml")
@@ -73,6 +75,33 @@ func TestSubscribeUserAgentCLI(t *testing.T) {
 	}
 }
 
+func TestSubscribeScrapeCLI(t *testing.T) {
+	binaryPath := buildBinaryViaMake(t)
+	filename := filepath.Join(t.TempDir(), "feeds.opml")
+	const selector = "article.card > h2"
+
+	output, err := runCommand(
+		binaryPath,
+		"subscribe", "--format", "opml", "--filename", filename,
+		"--type", "scrape", "--selector", selector, "https://example.com/archive",
+	)
+	if err != nil {
+		t.Fatalf("subscribe --type scrape failed: %v, output: %s", err, output)
+	}
+
+	list, err := feedlist.LoadFeedList(feedlist.FormatOPML, filename)
+	if err != nil {
+		t.Fatalf("LoadFeedList() error = %v", err)
+	}
+	feeds := list.GetFeeds()
+	if len(feeds) != 1 {
+		t.Fatalf("len(GetFeeds()) = %d, want 1", len(feeds))
+	}
+	if feeds[0].Type != feedlist.FeedTypeScrape || feeds[0].ScrapeSelector != selector {
+		t.Errorf("subscribed feed = %#v, want scrape selector %q", feeds[0], selector)
+	}
+}
+
 func TestExportPreservesUserAgent(t *testing.T) {
 	tmpDir := t.TempDir()
 	databasePath := filepath.Join(tmpDir, "feeds.db")
@@ -87,9 +116,11 @@ func TestExportPreservesUserAgent(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := db.UpsertFeed(&database.Feed{
-		URL:       "https://example.com/feed.xml",
-		Title:     "Example Feed",
-		UserAgent: userAgent,
+		URL:            "https://example.com/feed.xml",
+		Title:          "Example Feed",
+		UserAgent:      userAgent,
+		Type:           database.FeedTypeScrape,
+		ScrapeSelector: integrationScrapeSelector,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -117,6 +148,81 @@ func TestExportPreservesUserAgent(t *testing.T) {
 	}
 	if got := feeds[0].UserAgent; got != userAgent {
 		t.Errorf("exported UserAgent = %q, want %q", got, userAgent)
+	}
+	if feeds[0].Type != feedlist.FeedTypeScrape || feeds[0].ScrapeSelector != integrationScrapeSelector {
+		t.Errorf("exported parser config = %#v, want scrape selector", feeds[0])
+	}
+}
+
+func TestScrapedItemCLIUsesFirstSeenDate(t *testing.T) {
+	tmpDir := t.TempDir()
+	databasePath := filepath.Join(tmpDir, "feeds.db")
+	const (
+		feedURL = "https://example.com/archive"
+		itemURL = "https://example.com/article"
+	)
+	firstSeen := time.Date(2026, time.August, 25, 20, 30, 0, 0, time.UTC)
+
+	db, err := database.New(databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.InitSchema(); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.UpsertFeed(&database.Feed{
+		URL:            feedURL,
+		Title:          "Scraped Feed",
+		Type:           database.FeedTypeScrape,
+		ScrapeSelector: integrationScrapeSelector,
+		LatestItemDate: sql.NullTime{Time: firstSeen, Valid: true},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.UpsertItem(&database.Item{
+		FeedURL:   feedURL,
+		GUID:      itemURL,
+		Title:     "Scraped item",
+		Link:      itemURL,
+		FirstSeen: sql.NullTime{Time: firstSeen, Valid: true},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	binaryPath := buildBinaryViaMake(t)
+	showOutput, err := runCommand(binaryPath, "--database", databasePath, "show", feedURL)
+	if err != nil {
+		t.Fatalf("show failed: %v, output: %s", err, showOutput)
+	}
+	if !strings.Contains(showOutput, "2026-08-25 20:30") {
+		t.Errorf("show output does not use first_seen: %s", showOutput)
+	}
+
+	itemOutput, err := runCommand(binaryPath, "--database", databasePath, "item", itemURL)
+	if err != nil {
+		t.Fatalf("item failed: %v, output: %s", err, itemOutput)
+	}
+	if !strings.Contains(itemOutput, "Date: 2026-08-25T20:30:00Z") {
+		t.Errorf("item output does not use first_seen: %s", itemOutput)
+	}
+
+	itemJSONOutput, err := runCommand(
+		binaryPath, "--database", databasePath, "item", "--format", "json", itemURL,
+	)
+	if err != nil {
+		t.Fatalf("item --format json failed: %v, output: %s", err, itemJSONOutput)
+	}
+	var itemJSON struct {
+		PublishedDate time.Time
+	}
+	if err := json.Unmarshal([]byte(itemJSONOutput), &itemJSON); err != nil {
+		t.Fatalf("decode item JSON: %v, output: %s", err, itemJSONOutput)
+	}
+	if !itemJSON.PublishedDate.IsZero() {
+		t.Errorf("item JSON PublishedDate = %v, want absent publication date", itemJSON.PublishedDate)
 	}
 }
 

--- a/internal/database/feed_repository.go
+++ b/internal/database/feed_repository.go
@@ -9,12 +9,21 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+func normalizeFeedParserConfig(feedType, scrapeSelector string) (normalizedType, normalizedSelector string) {
+	if strings.EqualFold(strings.TrimSpace(feedType), FeedTypeScrape) {
+		return FeedTypeScrape, strings.TrimSpace(scrapeSelector)
+	}
+	return FeedTypeRSS, ""
+}
+
 // UpsertFeed inserts or updates a feed record in the database.
 func (db *DB) UpsertFeed(feed *Feed) error {
+	feedType, scrapeSelector := normalizeFeedParserConfig(feed.Type, feed.ScrapeSelector)
 	query := `
 		INSERT INTO feeds (url, title, description, last_updated, etag, last_modified,
-			last_fetch_time, last_successful_fetch, error_count, user_agent, last_error, latest_item_date, feed_json)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			last_fetch_time, last_successful_fetch, error_count, user_agent, type, scrape_selector,
+			last_error, latest_item_date, feed_json)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(url) DO UPDATE SET
 			title = excluded.title,
 			description = excluded.description,
@@ -25,6 +34,8 @@ func (db *DB) UpsertFeed(feed *Feed) error {
 			last_successful_fetch = excluded.last_successful_fetch,
 			error_count = excluded.error_count,
 			user_agent = COALESCE(NULLIF(excluded.user_agent, ''), feeds.user_agent),
+			type = excluded.type,
+			scrape_selector = excluded.scrape_selector,
 			last_error = excluded.last_error,
 			latest_item_date = COALESCE(excluded.latest_item_date, feeds.latest_item_date),
 			feed_json = excluded.feed_json
@@ -33,12 +44,66 @@ func (db *DB) UpsertFeed(feed *Feed) error {
 	_, err := db.conn.Exec(query,
 		feed.URL, feed.Title, feed.Description, feed.LastUpdated, feed.ETag,
 		feed.LastModified, feed.LastFetchTime, feed.LastSuccessfulFetch,
-		feed.ErrorCount, feed.UserAgent, feed.LastError, feed.LatestItemDate, feed.FeedJSON)
+		feed.ErrorCount, feed.UserAgent, feedType, scrapeSelector,
+		feed.LastError, feed.LatestItemDate, feed.FeedJSON)
 	if err != nil {
 		return fmt.Errorf("failed to upsert feed: %w", err)
 	}
 
 	logrus.Debugf("Upserted feed: %s", feed.URL)
+	return nil
+}
+
+// SetFeedConfig inserts or exactly updates authoritative list-backed configuration.
+func (db *DB) SetFeedConfig(url, feedType, scrapeSelector, userAgent string) error {
+	feedType, scrapeSelector = normalizeFeedParserConfig(feedType, scrapeSelector)
+	_, err := db.conn.Exec(`
+		INSERT INTO feeds (
+			url, user_agent, type, scrape_selector, last_updated, last_fetch_time, last_successful_fetch
+		) VALUES (?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(url) DO UPDATE SET
+			user_agent = excluded.user_agent,
+			type = excluded.type,
+			scrape_selector = excluded.scrape_selector,
+			etag = CASE WHEN feeds.type != excluded.type OR feeds.scrape_selector != excluded.scrape_selector
+				THEN '' ELSE feeds.etag END,
+			last_modified = CASE WHEN feeds.type != excluded.type OR feeds.scrape_selector != excluded.scrape_selector
+				THEN '' ELSE feeds.last_modified END,
+			last_fetch_time = CASE WHEN feeds.type != excluded.type OR feeds.scrape_selector != excluded.scrape_selector
+				THEN excluded.last_fetch_time ELSE feeds.last_fetch_time END,
+			last_successful_fetch = CASE WHEN feeds.type != excluded.type OR feeds.scrape_selector != excluded.scrape_selector
+				THEN excluded.last_successful_fetch ELSE feeds.last_successful_fetch END
+	`, url, userAgent, feedType, scrapeSelector, time.Time{}, time.Time{}, time.Time{})
+	if err != nil {
+		return fmt.Errorf("failed to set configuration for feed %s: %w", url, err)
+	}
+	return nil
+}
+
+// SetFeedParserConfig updates parser configuration while preserving User-Agent.
+// Changing parser semantics invalidates validators and freshness timestamps so
+// the next fetch must parse a complete response with the new configuration.
+func (db *DB) SetFeedParserConfig(url, feedType, scrapeSelector string) error {
+	feedType, scrapeSelector = normalizeFeedParserConfig(feedType, scrapeSelector)
+	_, err := db.conn.Exec(`
+		INSERT INTO feeds (
+			url, type, scrape_selector, last_updated, last_fetch_time, last_successful_fetch
+		) VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(url) DO UPDATE SET
+			type = excluded.type,
+			scrape_selector = excluded.scrape_selector,
+			etag = CASE WHEN feeds.type != excluded.type OR feeds.scrape_selector != excluded.scrape_selector
+				THEN '' ELSE feeds.etag END,
+			last_modified = CASE WHEN feeds.type != excluded.type OR feeds.scrape_selector != excluded.scrape_selector
+				THEN '' ELSE feeds.last_modified END,
+			last_fetch_time = CASE WHEN feeds.type != excluded.type OR feeds.scrape_selector != excluded.scrape_selector
+				THEN excluded.last_fetch_time ELSE feeds.last_fetch_time END,
+			last_successful_fetch = CASE WHEN feeds.type != excluded.type OR feeds.scrape_selector != excluded.scrape_selector
+				THEN excluded.last_successful_fetch ELSE feeds.last_successful_fetch END
+	`, url, feedType, scrapeSelector, time.Time{}, time.Time{}, time.Time{})
+	if err != nil {
+		return fmt.Errorf("failed to set parser configuration for feed %s: %w", url, err)
+	}
 	return nil
 }
 
@@ -60,7 +125,8 @@ func (db *DB) SetFeedUserAgent(url, userAgent string) error {
 func (db *DB) GetFeed(url string) (*Feed, error) {
 	query := `
 		SELECT url, title, description, last_updated, etag, last_modified,
-			last_fetch_time, last_successful_fetch, error_count, user_agent, last_error, latest_item_date, feed_json
+			last_fetch_time, last_successful_fetch, error_count, user_agent, type, scrape_selector,
+			last_error, latest_item_date, feed_json
 		FROM feeds WHERE url = ?
 	`
 
@@ -68,7 +134,8 @@ func (db *DB) GetFeed(url string) (*Feed, error) {
 	err := db.conn.QueryRow(query, url).Scan(
 		&feed.URL, &feed.Title, &feed.Description, &feed.LastUpdated, &feed.ETag,
 		&feed.LastModified, &feed.LastFetchTime, &feed.LastSuccessfulFetch,
-		&feed.ErrorCount, &feed.UserAgent, &feed.LastError, &feed.LatestItemDate, &feed.FeedJSON,
+		&feed.ErrorCount, &feed.UserAgent, &feed.Type, &feed.ScrapeSelector,
+		&feed.LastError, &feed.LatestItemDate, &feed.FeedJSON,
 	)
 
 	if err == sql.ErrNoRows {
@@ -85,7 +152,8 @@ func (db *DB) GetFeed(url string) (*Feed, error) {
 func (db *DB) GetAllFeeds() ([]*Feed, error) {
 	query := `
 		SELECT url, title, description, last_updated, etag, last_modified,
-			last_fetch_time, last_successful_fetch, error_count, user_agent, last_error, latest_item_date, feed_json
+			last_fetch_time, last_successful_fetch, error_count, user_agent, type, scrape_selector,
+			last_error, latest_item_date, feed_json
 		FROM feeds ORDER BY url
 	`
 
@@ -101,7 +169,8 @@ func (db *DB) GetAllFeeds() ([]*Feed, error) {
 		err := rows.Scan(
 			&feed.URL, &feed.Title, &feed.Description, &feed.LastUpdated, &feed.ETag,
 			&feed.LastModified, &feed.LastFetchTime, &feed.LastSuccessfulFetch,
-			&feed.ErrorCount, &feed.UserAgent, &feed.LastError, &feed.LatestItemDate, &feed.FeedJSON,
+			&feed.ErrorCount, &feed.UserAgent, &feed.Type, &feed.ScrapeSelector,
+			&feed.LastError, &feed.LatestItemDate, &feed.FeedJSON,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan feed: %w", err)
@@ -274,12 +343,15 @@ func (db *DB) GetFeedURLs() ([]string, error) {
 
 // GetFeedsWithItemsByTimeRange gets feeds and their items within a specific time range.
 func (db *DB) GetFeedsWithItemsByTimeRange(start, end time.Time, feedURLs []string) ([]Feed, map[string][]Item, error) {
+	start = start.UTC()
+	end = end.UTC()
+
 	// Build feeds query
 	// Use latest_item_date to determine if feed has recent items, falling back to last_updated
 	feedsQuery := `
 		SELECT f.url, f.title, f.description, f.last_updated, f.etag, f.last_modified,
-			f.last_fetch_time, f.last_successful_fetch, f.error_count, f.user_agent, 
-			f.last_error, f.latest_item_date, f.feed_json
+			f.last_fetch_time, f.last_successful_fetch, f.error_count, f.user_agent,
+			f.type, f.scrape_selector, f.last_error, f.latest_item_date, f.feed_json
 		FROM feeds f
 		WHERE COALESCE(f.latest_item_date, f.last_updated) >= ?
 			AND COALESCE(f.latest_item_date, f.last_updated) <= ?
@@ -321,7 +393,8 @@ func (db *DB) GetFeedsWithItemsByTimeRange(start, end time.Time, feedURLs []stri
 		err := rows.Scan(
 			&feed.URL, &feed.Title, &feed.Description, &feed.LastUpdated, &feed.ETag,
 			&feed.LastModified, &feed.LastFetchTime, &feed.LastSuccessfulFetch,
-			&feed.ErrorCount, &feed.UserAgent, &feed.LastError, &feed.LatestItemDate, &feed.FeedJSON,
+			&feed.ErrorCount, &feed.UserAgent, &feed.Type, &feed.ScrapeSelector,
+			&feed.LastError, &feed.LatestItemDate, &feed.FeedJSON,
 		)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to scan feed: %w", err)
@@ -405,7 +478,8 @@ func (db *DB) GetFeedsWithItemsMinimum(
 func (db *DB) getFeedsFiltered(feedURLs []string) ([]Feed, error) {
 	query := `
 		SELECT url, title, description, last_updated, etag, last_modified,
-			last_fetch_time, last_successful_fetch, error_count, user_agent, last_error, latest_item_date, feed_json
+			last_fetch_time, last_successful_fetch, error_count, user_agent, type, scrape_selector,
+			last_error, latest_item_date, feed_json
 		FROM feeds
 	`
 	args := []interface{}{}
@@ -440,7 +514,8 @@ func (db *DB) getFeedsFiltered(feedURLs []string) ([]Feed, error) {
 		err := rows.Scan(
 			&feed.URL, &feed.Title, &feed.Description, &feed.LastUpdated, &feed.ETag,
 			&feed.LastModified, &feed.LastFetchTime, &feed.LastSuccessfulFetch,
-			&feed.ErrorCount, &feed.UserAgent, &feed.LastError, &feed.LatestItemDate, &feed.FeedJSON,
+			&feed.ErrorCount, &feed.UserAgent, &feed.Type, &feed.ScrapeSelector,
+			&feed.LastError, &feed.LatestItemDate, &feed.FeedJSON,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan feed: %w", err)
@@ -460,16 +535,18 @@ func (db *DB) getFeedsFiltered(feedURLs []string) ([]Feed, error) {
 // This ensures active feeds show all new items, while quiet feeds still show recent history.
 func (db *DB) getItemsForFeedWithMinimum(feedURL string, start, end time.Time, minItems int) ([]Item, error) {
 	// First, get items within the timespan
-	timespanQuery := `
-		SELECT id, feed_url, guid, title, link, published_date,
+	timespanQuery := fmt.Sprintf(`
+		SELECT id, feed_url, guid, title, link, published_date, first_seen,
 			content, summary, archived, item_json
 		FROM items
 		WHERE feed_url = ?
-			AND published_date >= ? AND published_date <= ?
-		ORDER BY published_date DESC
-	`
+			AND %[1]s IS NOT NULL
+			AND %[1]s >= julianday(?)
+			AND %[1]s <= julianday(?)
+		ORDER BY %[1]s DESC
+	`, effectiveDateExpression)
 
-	rows, err := db.conn.Query(timespanQuery, feedURL, start, end)
+	rows, err := db.conn.Query(timespanQuery, feedURL, formatDatabaseTime(start), formatDatabaseTime(end))
 	if err != nil {
 		return nil, fmt.Errorf("failed to query timespan items: %w", err)
 	}
@@ -480,7 +557,8 @@ func (db *DB) getItemsForFeedWithMinimum(feedURL string, start, end time.Time, m
 		item := Item{}
 		err := rows.Scan(
 			&item.ID, &item.FeedURL, &item.GUID, &item.Title, &item.Link,
-			&item.PublishedDate, &item.Content, &item.Summary, &item.Archived,
+			scanNullableTime(&item.PublishedDate), &item.FirstSeen,
+			&item.Content, &item.Summary, &item.Archived,
 			&item.ItemJSON,
 		)
 		if err != nil {
@@ -501,11 +579,11 @@ func (db *DB) getItemsForFeedWithMinimum(feedURL string, start, end time.Time, m
 	// Otherwise, get additional recent items to reach minItems
 	// Query for recent items that we might not have already
 	recentQuery := `
-		SELECT id, feed_url, guid, title, link, published_date,
+		SELECT id, feed_url, guid, title, link, published_date, first_seen,
 			content, summary, archived, item_json
 		FROM items
 		WHERE feed_url = ?
-		ORDER BY published_date DESC
+		ORDER BY ` + effectiveDateExpression + ` DESC
 		LIMIT ?
 	`
 
@@ -527,7 +605,8 @@ func (db *DB) getItemsForFeedWithMinimum(feedURL string, start, end time.Time, m
 		item := Item{}
 		err := rows2.Scan(
 			&item.ID, &item.FeedURL, &item.GUID, &item.Title, &item.Link,
-			&item.PublishedDate, &item.Content, &item.Summary, &item.Archived,
+			scanNullableTime(&item.PublishedDate), &item.FirstSeen,
+			&item.Content, &item.Summary, &item.Archived,
 			&item.ItemJSON,
 		)
 		if err != nil {

--- a/internal/database/feed_repository_test.go
+++ b/internal/database/feed_repository_test.go
@@ -22,7 +22,7 @@ func TestUpsertAndGetFeed(t *testing.T) {
 		Description:  "Test Description",
 		LastUpdated:  time.Now().UTC().Truncate(time.Second),
 		ETag:         "test-etag",
-		LastModified: "Mon, 01 Jan 2024 00:00:00 GMT",
+		LastModified: fixtureLastModified,
 		FeedJSON:     JSON(`{"title": "Test Feed"}`),
 	}
 
@@ -102,6 +102,82 @@ func TestSetFeedUserAgent(t *testing.T) {
 	}
 }
 
+func TestSetFeedConfig(t *testing.T) {
+	db := setupTestDB(t)
+	const (
+		feedType  = "scrape"
+		selector  = "article.card"
+		userAgent = "Scrape Reader/1.0"
+	)
+
+	if err := db.SetFeedConfig(fixtureFeedURL, feedType, selector, userAgent); err != nil {
+		t.Fatalf("SetFeedConfig() insert error = %v", err)
+	}
+	feed, err := db.GetFeed(fixtureFeedURL)
+	if err != nil {
+		t.Fatalf("GetFeed() error = %v", err)
+	}
+	if feed == nil || feed.Type != feedType || feed.ScrapeSelector != selector || feed.UserAgent != userAgent {
+		t.Fatalf("GetFeed() = %#v, want persisted scrape configuration", feed)
+	}
+
+	feed.Title = fixtureFeedTitle
+	if err := db.UpsertFeed(feed); err != nil {
+		t.Fatalf("UpsertFeed() error = %v", err)
+	}
+	if err := db.SetFeedConfig(fixtureFeedURL, "rss", "", ""); err != nil {
+		t.Fatalf("SetFeedConfig() update error = %v", err)
+	}
+	feed, err = db.GetFeed(fixtureFeedURL)
+	if err != nil {
+		t.Fatalf("GetFeed() after update error = %v", err)
+	}
+	if feed.Type != "rss" || feed.ScrapeSelector != "" || feed.UserAgent != "" {
+		t.Errorf("updated feed config = %#v, want cleared RSS configuration", feed)
+	}
+	if feed.Title != fixtureFeedTitle {
+		t.Errorf("Title = %q after config update, want preserved %q", feed.Title, fixtureFeedTitle)
+	}
+}
+
+func TestSetFeedConfigInvalidatesCacheWhenParserChanges(t *testing.T) {
+	db := setupTestDB(t)
+	recentFetch := time.Now().UTC().Truncate(time.Second)
+	feed := &Feed{
+		URL:            fixtureFeedURL,
+		Type:           FeedTypeScrape,
+		ScrapeSelector: ".old",
+		ETag:           "old-etag",
+		LastModified:   fixtureLastModified,
+		LastFetchTime:  recentFetch,
+	}
+	if err := db.UpsertFeed(feed); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.SetFeedConfig(fixtureFeedURL, FeedTypeScrape, ".old", "Reader/2.0"); err != nil {
+		t.Fatal(err)
+	}
+	unchanged, err := db.GetFeed(fixtureFeedURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unchanged.ETag != feed.ETag || !unchanged.LastFetchTime.Equal(recentFetch) {
+		t.Errorf("unchanged parser config invalidated cache: %#v", unchanged)
+	}
+
+	if err := db.SetFeedConfig(fixtureFeedURL, FeedTypeScrape, ".new", "Reader/2.0"); err != nil {
+		t.Fatal(err)
+	}
+	changed, err := db.GetFeed(fixtureFeedURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed.ETag != "" || changed.LastModified != "" || !changed.LastFetchTime.IsZero() {
+		t.Errorf("changed parser config retained cache state: %#v", changed)
+	}
+}
+
 func TestGetAllFeeds(t *testing.T) {
 	db := setupTestDB(t)
 
@@ -143,11 +219,15 @@ func TestGetAllFeeds(t *testing.T) {
 }
 
 func TestGetFeedSummaries(t *testing.T) {
+	const (
+		alphaTitle = "Alpha"
+		betaTitle  = "Beta"
+	)
 	db := setupTestDB(t)
 	lastFetch := time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
 	feeds := []*Feed{
-		{URL: testAlphaFeedURL, Title: "Alpha", LastFetchTime: lastFetch, ErrorCount: 2},
-		{URL: testBetaFeedURL, Title: "Beta"},
+		{URL: testAlphaFeedURL, Title: alphaTitle, LastFetchTime: lastFetch, ErrorCount: 2},
+		{URL: testBetaFeedURL, Title: betaTitle},
 	}
 	for _, feed := range feeds {
 		if err := db.UpsertFeed(feed); err != nil {

--- a/internal/database/item_repository.go
+++ b/internal/database/item_repository.go
@@ -15,8 +15,27 @@ const discoveryTimeExpression = `julianday(CASE
 	ELSE first_seen
 END)`
 
+const effectiveDateExpression = `julianday(COALESCE(published_date, first_seen))`
+
+const aliasedEffectiveDateExpression = `julianday(COALESCE(i.published_date, i.first_seen))`
+
+const (
+	effectiveDateSinceClause = " AND " + effectiveDateExpression +
+		" IS NOT NULL AND " + effectiveDateExpression + " >= julianday(?)"
+	effectiveDateUntilClause = " AND " + effectiveDateExpression +
+		" IS NOT NULL AND " + effectiveDateExpression + " <= julianday(?)"
+)
+
 // UpsertItem inserts or updates an item record in the database.
 func (db *DB) UpsertItem(item *Item) error {
+	var publishedDate interface{}
+	if !item.PublishedDate.IsZero() {
+		publishedDate = formatDatabaseTime(item.PublishedDate)
+	}
+	var firstSeen interface{}
+	if item.FirstSeen.Valid {
+		firstSeen = formatDatabaseTime(item.FirstSeen.Time)
+	}
 	query := `
 		INSERT INTO items (feed_url, guid, title, link, published_date, first_seen,
 			content, summary, archived, item_json)
@@ -31,7 +50,7 @@ func (db *DB) UpsertItem(item *Item) error {
 	`
 
 	_, err := db.conn.Exec(query,
-		item.FeedURL, item.GUID, item.Title, item.Link, item.PublishedDate, item.FirstSeen,
+		item.FeedURL, item.GUID, item.Title, item.Link, publishedDate, firstSeen,
 		item.Content, item.Summary, item.Archived, item.ItemJSON)
 	if err != nil {
 		return fmt.Errorf("failed to upsert item: %w", err)
@@ -39,6 +58,59 @@ func (db *DB) UpsertItem(item *Item) error {
 
 	logrus.Debugf("Upserted item: %s - %s", item.FeedURL, item.GUID)
 	return nil
+}
+
+// GetItemsByLink retrieves every item with the exact link in deterministic order.
+func (db *DB) GetItemsByLink(link string) ([]*Item, error) {
+	return db.queryItems(`
+		SELECT id, feed_url, guid, title, link, published_date, first_seen,
+			content, summary, archived, item_json
+		FROM items
+		WHERE link = ?
+		ORDER BY feed_url, guid
+	`, link)
+}
+
+// GetItem retrieves an item by its feed URL and GUID, or nil if it does not exist.
+func (db *DB) GetItem(feedURL, guid string) (*Item, error) {
+	items, err := db.queryItems(`
+		SELECT id, feed_url, guid, title, link, published_date, first_seen,
+			content, summary, archived, item_json
+		FROM items
+		WHERE feed_url = ? AND guid = ?
+	`, feedURL, guid)
+	if err != nil {
+		return nil, err
+	}
+	if len(items) == 0 {
+		return nil, nil
+	}
+	return items[0], nil
+}
+
+func (db *DB) queryItems(query string, args ...any) ([]*Item, error) {
+	rows, err := db.conn.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query items: %w", err)
+	}
+	defer rows.Close()
+
+	var items []*Item
+	for rows.Next() {
+		item := &Item{}
+		if err := rows.Scan(
+			&item.ID, &item.FeedURL, &item.GUID, &item.Title, &item.Link,
+			scanNullableTime(&item.PublishedDate), &item.FirstSeen, &item.Content, &item.Summary,
+			&item.Archived, &item.ItemJSON,
+		); err != nil {
+			return nil, fmt.Errorf("failed to scan item: %w", err)
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate items: %w", err)
+	}
+	return items, nil
 }
 
 // GetItemsForFeed retrieves items for a specific feed with optional filtering by time range and limit.
@@ -52,16 +124,16 @@ func (db *DB) GetItemsForFeed(feedURL string, limit int, since, until time.Time)
 	args := []interface{}{feedURL}
 
 	if !since.IsZero() {
-		query += " AND published_date >= ?"
-		args = append(args, since)
+		query += effectiveDateSinceClause
+		args = append(args, formatDatabaseTime(since))
 	}
 
 	if !until.IsZero() {
-		query += " AND published_date <= ?"
-		args = append(args, until)
+		query += effectiveDateUntilClause
+		args = append(args, formatDatabaseTime(until))
 	}
 
-	query += " ORDER BY published_date DESC"
+	query += " ORDER BY " + effectiveDateExpression + " DESC"
 
 	if limit > 0 {
 		query += sqlLimitClause
@@ -79,7 +151,7 @@ func (db *DB) GetItemsForFeed(feedURL string, limit int, since, until time.Time)
 		item := &Item{}
 		err := rows.Scan(
 			&item.ID, &item.FeedURL, &item.GUID, &item.Title, &item.Link,
-			&item.PublishedDate, &item.FirstSeen, &item.Content, &item.Summary, &item.Archived,
+			scanNullableTime(&item.PublishedDate), &item.FirstSeen, &item.Content, &item.Summary, &item.Archived,
 			&item.ItemJSON,
 		)
 		if err != nil {
@@ -135,8 +207,9 @@ func (db *DB) MarkItemsArchived(feedURL string, activeGUIDs []string) error {
 
 // DeleteArchivedItems deletes archived items older than the specified time.
 func (db *DB) DeleteArchivedItems(olderThan time.Time) (int64, error) {
-	query := "DELETE FROM items WHERE archived = 1 AND published_date < ?"
-	result, err := db.conn.Exec(query, olderThan)
+	query := "DELETE FROM items WHERE archived = 1 AND " + effectiveDateExpression +
+		" IS NOT NULL AND " + effectiveDateExpression + " < julianday(?)"
+	result, err := db.conn.Exec(query, formatDatabaseTime(olderThan))
 	if err != nil {
 		return 0, fmt.Errorf("failed to delete archived items: %w", err)
 	}
@@ -182,7 +255,7 @@ func (db *DB) deleteArchivedItemsForFeed(feedURL string, olderThan time.Time, mi
 	protectedQuery := `
 		SELECT id FROM items
 		WHERE feed_url = ?
-		ORDER BY published_date DESC
+		ORDER BY ` + effectiveDateExpression + ` DESC
 		LIMIT ?
 	`
 	rows, err := db.conn.Query(protectedQuery, feedURL, minItems)
@@ -211,7 +284,7 @@ func (db *DB) deleteArchivedItemsForFeed(feedURL string, olderThan time.Time, mi
 
 	// Build DELETE query excluding protected items
 	placeholders := make([]string, len(protectedIDs))
-	args := []interface{}{feedURL, olderThan}
+	args := []interface{}{feedURL, formatDatabaseTime(olderThan)}
 	for i, id := range protectedIDs {
 		placeholders[i] = "?"
 		args = append(args, id)
@@ -222,9 +295,10 @@ func (db *DB) deleteArchivedItemsForFeed(feedURL string, olderThan time.Time, mi
 		DELETE FROM items
 		WHERE feed_url = ?
 		  AND archived = 1
-		  AND published_date < ?
-		  AND id NOT IN (%s)
-	`, strings.Join(placeholders, ","))
+		  AND %[1]s IS NOT NULL
+		  AND %[1]s < julianday(?)
+		  AND id NOT IN (%[2]s)
+	`, effectiveDateExpression, strings.Join(placeholders, ","))
 
 	result, err := db.conn.Exec(deleteQuery, args...)
 	if err != nil {
@@ -254,7 +328,7 @@ func (db *DB) getItemsForFeeds(feedURLMap map[string]bool, start, end time.Time)
 		placeholders[i] = "?"
 		args = append(args, url)
 	}
-	args = append(args, start, end)
+	args = append(args, formatDatabaseTime(start), formatDatabaseTime(end))
 
 	//nolint:gosec // Safe: only formatting placeholder count, not user input
 	query := fmt.Sprintf(`
@@ -262,9 +336,11 @@ func (db *DB) getItemsForFeeds(feedURLMap map[string]bool, start, end time.Time)
 			content, summary, archived, item_json
 		FROM items
 		WHERE feed_url IN (%s)
-			AND published_date >= ? AND published_date <= ?
-		ORDER BY feed_url, published_date DESC
-	`, strings.Join(placeholders, ","))
+			AND %[2]s IS NOT NULL
+			AND %[2]s >= julianday(?)
+			AND %[2]s <= julianday(?)
+		ORDER BY feed_url, %[2]s DESC
+	`, strings.Join(placeholders, ","), effectiveDateExpression)
 
 	rows, err := db.conn.Query(query, args...)
 	if err != nil {
@@ -277,7 +353,7 @@ func (db *DB) getItemsForFeeds(feedURLMap map[string]bool, start, end time.Time)
 		item := Item{}
 		err := rows.Scan(
 			&item.ID, &item.FeedURL, &item.GUID, &item.Title, &item.Link,
-			&item.PublishedDate, &item.FirstSeen, &item.Content, &item.Summary, &item.Archived,
+			scanNullableTime(&item.PublishedDate), &item.FirstSeen, &item.Content, &item.Summary, &item.Archived,
 			&item.ItemJSON,
 		)
 		if err != nil {
@@ -318,7 +394,7 @@ func (db *DB) GetItems(filter *ItemFilter) ([]*Item, error) {
 		var item Item
 		if err := rows.Scan(
 			&item.ID, &item.FeedURL, &item.GUID, &item.Title, &item.Link,
-			&item.PublishedDate, &item.FirstSeen, &item.Content, &item.Summary,
+			scanNullableTime(&item.PublishedDate), &item.FirstSeen, &item.Content, &item.Summary,
 			&item.Archived, &item.ItemJSON,
 		); err != nil {
 			return nil, fmt.Errorf("failed to scan item: %w", err)
@@ -335,7 +411,7 @@ func (db *DB) GetItems(filter *ItemFilter) ([]*Item, error) {
 
 	if filterTimesInGo {
 		sort.SliceStable(items, func(i, j int) bool {
-			return items[i].PublishedDate.After(items[j].PublishedDate)
+			return items[i].EffectiveDate().After(items[j].EffectiveDate())
 		})
 		if filter.Limit > 0 && len(items) > filter.Limit {
 			items = items[:filter.Limit]
@@ -347,11 +423,14 @@ func (db *DB) GetItems(filter *ItemFilter) ([]*Item, error) {
 
 func buildItemsQuery(filter *ItemFilter) (query string, args []interface{}, filterTimesInGo bool) {
 	filterTimesInGo = !filter.Since.IsZero() || !filter.Until.IsZero()
+	fromClause := "FROM items i"
+	if filterTimesInGo {
+		fromClause += " INDEXED BY idx_items_discovery_time"
+	}
 	query = `
 		SELECT i.id, i.feed_url, i.guid, i.title, i.link, i.published_date, i.first_seen,
 			i.content, i.summary, i.archived, i.item_json
-		FROM items i
-	`
+		` + fromClause + "\n"
 	var conditions []string
 
 	if filter.Unseen {
@@ -396,8 +475,8 @@ func buildItemsQuery(filter *ItemFilter) (query string, args []interface{}, filt
 		query += " WHERE " + strings.Join(conditions, " AND ")
 	}
 
+	query += " ORDER BY " + aliasedEffectiveDateExpression + " DESC"
 	if !filterTimesInGo {
-		query += " ORDER BY i.published_date DESC"
 		if filter.Limit > 0 {
 			query += sqlLimitClause
 			args = append(args, filter.Limit)

--- a/internal/database/item_repository_test.go
+++ b/internal/database/item_repository_test.go
@@ -58,6 +58,77 @@ func TestUpsertAndGetItem(t *testing.T) {
 	}
 }
 
+func TestGetItemsByLinkAndIdentity(t *testing.T) {
+	const (
+		alphaFeedURL = "https://alpha.example/feed"
+		alphaGUID    = "alpha-guid"
+		alphaTitle   = "Alpha"
+		betaFeedURL  = "https://beta.example/feed"
+		betaGUID     = "beta-guid"
+		betaTitle    = "Beta"
+		sharedLink   = "https://example.com/shared"
+	)
+	db := setupTestDB(t)
+	for _, feedURL := range []string{alphaFeedURL, betaFeedURL} {
+		if err := db.UpsertFeed(&Feed{URL: feedURL, Title: feedURL}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	firstSeen := time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+	items := []*Item{
+		{
+			FeedURL:   betaFeedURL,
+			GUID:      betaGUID,
+			Title:     betaTitle,
+			Link:      sharedLink,
+			FirstSeen: sql.NullTime{Time: firstSeen, Valid: true},
+		},
+		{
+			FeedURL:       alphaFeedURL,
+			GUID:          alphaGUID,
+			Title:         alphaTitle,
+			Link:          sharedLink,
+			PublishedDate: firstSeen.Add(-time.Hour),
+		},
+	}
+	for _, item := range items {
+		if err := db.UpsertItem(item); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	matches, err := db.GetItemsByLink(sharedLink)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 2 {
+		t.Fatalf("GetItemsByLink() returned %d items, want 2", len(matches))
+	}
+	if matches[0].GUID != alphaGUID || matches[1].GUID != betaGUID {
+		t.Fatalf("GetItemsByLink() order = [%s, %s], want [alpha-guid, beta-guid]",
+			matches[0].GUID, matches[1].GUID)
+	}
+	if !matches[1].PublishedDate.IsZero() || !matches[1].EffectiveDate().Equal(firstSeen) {
+		t.Errorf("scraped item dates = published %v, effective %v", matches[1].PublishedDate, matches[1].EffectiveDate())
+	}
+
+	item, err := db.GetItem(betaFeedURL, betaGUID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if item == nil || item.Title != betaTitle {
+		t.Fatalf("GetItem() = %#v, want beta item", item)
+	}
+	missing, err := db.GetItem(betaFeedURL, "missing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if missing != nil {
+		t.Fatalf("GetItem() missing = %#v, want nil", missing)
+	}
+}
+
 func TestUpsertItemDateStability(t *testing.T) {
 	const updatedTitle = "Updated Title"
 
@@ -216,6 +287,100 @@ func TestGetItemsForFeedWithFilters(t *testing.T) {
 
 	if retrieved[0].GUID != testItem3GUID {
 		t.Errorf("Filtered item GUID = %v, want %s", retrieved[0].GUID, testItem3GUID)
+	}
+}
+
+func TestGetItemsForFeedUsesUTCFirstSeenFallback(t *testing.T) {
+	db := setupTestDB(t)
+	if err := db.UpsertFeed(&Feed{URL: fixtureFeedURL, Title: fixtureFeedTitle}); err != nil {
+		t.Fatal(err)
+	}
+	firstSeen := time.Date(2026, time.August, 25, 20, 0, 0, 0, time.UTC)
+	if err := db.UpsertItem(&Item{
+		FeedURL:   fixtureFeedURL,
+		GUID:      fixtureGUID,
+		Title:     testItemTitle,
+		Link:      fixtureItemLink,
+		FirstSeen: sql.NullTime{Time: firstSeen, Valid: true},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	localZone := time.FixedZone("PDT", -7*60*60)
+	since := time.Date(2026, time.August, 25, 12, 30, 0, 0, localZone)
+	until := time.Date(2026, time.August, 25, 13, 30, 0, 0, localZone)
+	items, err := db.GetItemsForFeed(
+		fixtureFeedURL,
+		0,
+		since,
+		until,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("len(GetItemsForFeed()) = %d, want 1 across timezone offsets", len(items))
+	}
+	if got := items[0].EffectiveDate(); got.Location() != time.UTC || got.Hour() != 20 {
+		t.Errorf("EffectiveDate() = %v, want 20:00 UTC", got)
+	}
+
+	filtered, err := db.GetItems(&ItemFilter{Since: since, Until: until})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(filtered) != 1 {
+		t.Fatalf("len(GetItems()) = %d, want 1 across timezone offsets", len(filtered))
+	}
+}
+
+func TestEffectiveDateQueriesHandleLegacyOffsetsConservatively(t *testing.T) {
+	const afterCutoffGUID = "after-cutoff"
+	db := setupTestDB(t)
+	if err := db.UpsertFeed(&Feed{URL: fixtureFeedURL, Title: fixtureFeedTitle}); err != nil {
+		t.Fatal(err)
+	}
+	for _, item := range []struct {
+		guid          string
+		publishedDate string
+	}{
+		{guid: "before-cutoff", publishedDate: "2026-08-25T12:00:00-07:00"},
+		{guid: afterCutoffGUID, publishedDate: "2026-08-25T13:00:00-07:00"},
+		{guid: "unparseable", publishedDate: "not-a-date"},
+	} {
+		_, err := db.conn.Exec(`
+			INSERT INTO items (feed_url, guid, published_date, archived)
+			VALUES (?, ?, ?, 1)
+		`, fixtureFeedURL, item.guid, item.publishedDate)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cutoff := time.Date(2026, 8, 25, 19, 45, 0, 0, time.UTC)
+	items, err := db.GetItemsForFeed(fixtureFeedURL, 0, cutoff, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 1 || items[0].GUID != afterCutoffGUID {
+		t.Fatalf("GetItemsForFeed() = %#v, want only after-cutoff; unparseable dates cannot be placed in a window", items)
+	}
+
+	deleted, err := db.DeleteArchivedItems(cutoff)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deleted != 1 {
+		t.Fatalf("DeleteArchivedItems() deleted %d items, want only before-cutoff", deleted)
+	}
+	var remaining int
+	if err := db.conn.QueryRow(`
+		SELECT COUNT(*) FROM items WHERE guid IN ('after-cutoff', 'unparseable')
+	`).Scan(&remaining); err != nil {
+		t.Fatal(err)
+	}
+	if remaining != 2 {
+		t.Fatalf("remaining protected items = %d, want 2", remaining)
 	}
 }
 
@@ -471,5 +636,36 @@ func TestGetItemsDiscoveryWindowUsesIndex(t *testing.T) {
 	}
 	if !strings.Contains(plan.String(), "idx_items_discovery_time") {
 		t.Fatalf("discovery query plan does not use discovery index:\n%s", plan.String())
+	}
+}
+
+func TestGetItemsEffectiveDateOrderingUsesIndex(t *testing.T) {
+	db := setupTestDB(t)
+	rows, err := db.conn.Query(`
+		EXPLAIN QUERY PLAN
+		SELECT id FROM items
+		WHERE feed_url = ?
+		ORDER BY julianday(COALESCE(published_date, first_seen)) DESC
+	`, fixtureFeedURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+
+	var plan strings.Builder
+	for rows.Next() {
+		var id, parent, unused int
+		var detail string
+		if err := rows.Scan(&id, &parent, &unused, &detail); err != nil {
+			t.Fatal(err)
+		}
+		plan.WriteString(detail)
+		plan.WriteByte('\n')
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(plan.String(), "idx_items_feed_effective_date") || strings.Contains(plan.String(), "USE TEMP B-TREE") {
+		t.Fatalf("per-feed effective-date query plan does not use composite index:\n%s", plan.String())
 	}
 }

--- a/internal/database/metadata_repository.go
+++ b/internal/database/metadata_repository.go
@@ -96,7 +96,7 @@ func (db *DB) GetURLsNeedingFetch(limit int, retryAfter time.Duration) ([]string
 				AND um.last_fetch_at < ?  -- And enough time has passed
 			)
 		)
-		ORDER BY i.published_date DESC
+		ORDER BY ` + aliasedEffectiveDateExpression + ` DESC
 	`
 
 	args := []interface{}{retryTime}

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -15,7 +15,9 @@ const (
 	migrationVersion5   = 5 // Add user_agent column to feeds
 	migrationVersion6   = 6 // Add item_annotations table
 	migrationVersion7   = 7 // Add discovery-time query index
-	maxMigrationVersion = migrationVersion7
+	migrationVersion8   = 8 // Add feed parser type and scrape selector
+	migrationVersion9   = 9 // Add effective-date query index
+	maxMigrationVersion = migrationVersion9
 )
 
 // getMigrations returns the database migration scripts.
@@ -58,6 +60,13 @@ func getMigrations() map[int]string {
 		migrationVersion7: fmt.Sprintf(
 			"CREATE INDEX IF NOT EXISTS idx_items_discovery_time ON items(%s);",
 			discoveryTimeExpression,
+		),
+		migrationVersion8: `ALTER TABLE feeds ADD COLUMN type TEXT NOT NULL DEFAULT 'rss';
+		ALTER TABLE feeds ADD COLUMN scrape_selector TEXT NOT NULL DEFAULT '';`,
+		migrationVersion9: fmt.Sprintf(
+			`CREATE INDEX IF NOT EXISTS idx_items_effective_date ON items(%[1]s);
+			CREATE INDEX IF NOT EXISTS idx_items_feed_effective_date ON items(feed_url, %[1]s);`,
+			effectiveDateExpression,
 		),
 	}
 }
@@ -107,7 +116,7 @@ func (db *DB) RunMigrations() error {
 	appliedCount := 0
 	for version := currentVersion + 1; version <= maxMigrationVersion; version++ {
 		if _, exists := migrations[version]; exists {
-			logrus.Infof("Applying migration %d: Adding latest_item_date column", version)
+			logrus.Infof("Applying migration %d", version)
 			if err := db.applySpecificMigration(version); err != nil {
 				return err
 			}
@@ -138,6 +147,10 @@ func (db *DB) applySpecificMigration(version int) error {
 		return db.applyMigration5()
 	case migrationVersion6:
 		return db.applyMigration6()
+	case migrationVersion8:
+		return db.applyMigration8()
+	case migrationVersion9:
+		return db.applyMigration9()
 	default:
 		// For any new migrations, just apply them directly
 		migrations := getMigrations()
@@ -318,4 +331,125 @@ func (db *DB) applyMigration6() error {
 
 	migrations := getMigrations()
 	return db.ApplyMigration(migrationVersion6, migrations[migrationVersion6])
+}
+
+// applyMigration8 adds feed parser configuration columns.
+func (db *DB) applyMigration8() error {
+	tx, err := db.conn.Begin()
+	if err != nil {
+		return fmt.Errorf("failed to begin migration %d: %w", migrationVersion8, err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			if rollbackErr := tx.Rollback(); rollbackErr != nil {
+				logrus.WithError(rollbackErr).Warn("Failed to rollback migration")
+			}
+		}
+	}()
+
+	columns := []struct {
+		name string
+		sql  string
+	}{
+		{name: "type", sql: `ALTER TABLE feeds ADD COLUMN type TEXT NOT NULL DEFAULT 'rss'`},
+		{name: "scrape_selector", sql: `ALTER TABLE feeds ADD COLUMN scrape_selector TEXT NOT NULL DEFAULT ''`},
+	}
+	for _, column := range columns {
+		var count int
+		if err := tx.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('feeds') WHERE name = ?`, column.name).
+			Scan(&count); err != nil {
+			return fmt.Errorf("failed to check %s column: %w", column.name, err)
+		}
+		if count == 0 {
+			if _, err := tx.Exec(column.sql); err != nil {
+				return fmt.Errorf("failed to add %s column: %w", column.name, err)
+			}
+		}
+	}
+
+	if _, err := tx.Exec("INSERT INTO schema_migrations (version) VALUES (?)", migrationVersion8); err != nil {
+		return fmt.Errorf("failed to record migration %d: %w", migrationVersion8, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit migration %d: %w", migrationVersion8, err)
+	}
+	committed = true
+	return nil
+}
+
+// applyMigration9 normalizes legacy item timestamps before indexing chronological queries.
+func (db *DB) applyMigration9() error {
+	tx, err := db.conn.Begin()
+	if err != nil {
+		return fmt.Errorf("failed to begin migration %d: %w", migrationVersion9, err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			if rollbackErr := tx.Rollback(); rollbackErr != nil {
+				logrus.WithError(rollbackErr).Warn("Failed to rollback migration")
+			}
+		}
+	}()
+
+	type itemTimestamps struct {
+		rowID         int64
+		publishedDate interface{}
+		firstSeen     interface{}
+	}
+	rows, err := tx.Query(`SELECT rowid, published_date, first_seen FROM items`)
+	if err != nil {
+		return fmt.Errorf("failed to read item timestamps: %w", err)
+	}
+	defer rows.Close()
+	var records []itemTimestamps
+	for rows.Next() {
+		var record itemTimestamps
+		if err := rows.Scan(&record.rowID, &record.publishedDate, &record.firstSeen); err != nil {
+			return fmt.Errorf("failed to scan item timestamps: %w", err)
+		}
+		records = append(records, record)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("failed to iterate item timestamps: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("failed to close item timestamp rows: %w", err)
+	}
+
+	for _, record := range records {
+		publishedDate := normalizedMigrationTime(record.publishedDate)
+		firstSeen := normalizedMigrationTime(record.firstSeen)
+		if _, err := tx.Exec(
+			`UPDATE items SET published_date = ?, first_seen = ? WHERE rowid = ?`,
+			publishedDate, firstSeen, record.rowID,
+		); err != nil {
+			return fmt.Errorf("failed to normalize item timestamps: %w", err)
+		}
+	}
+
+	migration := getMigrations()[migrationVersion9]
+	if _, err := tx.Exec(migration); err != nil {
+		return fmt.Errorf("failed to create effective-date indexes: %w", err)
+	}
+	if _, err := tx.Exec("INSERT INTO schema_migrations (version) VALUES (?)", migrationVersion9); err != nil {
+		return fmt.Errorf("failed to record migration %d: %w", migrationVersion9, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit migration %d: %w", migrationVersion9, err)
+	}
+	committed = true
+	return nil
+}
+
+func normalizedMigrationTime(value interface{}) interface{} {
+	if value == nil {
+		return nil
+	}
+	timestamp, err := parseDatabaseTime(value)
+	if err != nil {
+		return value
+	}
+	return formatDatabaseTime(timestamp)
 }

--- a/internal/database/migrations_test.go
+++ b/internal/database/migrations_test.go
@@ -259,6 +259,13 @@ func TestRunMigrationsOnProperlyInitializedDatabase(t *testing.T) {
 
 func TestRunMigrationsOnExistingDatabase(t *testing.T) {
 	db := setupOldDatabase(t)
+	if _, err := db.conn.Exec(`
+		INSERT INTO feeds (url, title) VALUES ('https://legacy.example/feed', 'Legacy');
+		INSERT INTO items (feed_url, guid, published_date)
+		VALUES ('https://legacy.example/feed', 'legacy-item', '2026-08-25 13:00:00 -0700 PDT');
+	`); err != nil {
+		t.Fatal(err)
+	}
 
 	// Verify the old schema doesn't have latest_item_date column
 	var colCount int
@@ -301,6 +308,29 @@ func TestRunMigrationsOnExistingDatabase(t *testing.T) {
 
 	if colCount != 1 {
 		t.Errorf("After migration, should have latest_item_date column, but found %d", colCount)
+	}
+
+	for _, column := range []string{"type", "scrape_selector"} {
+		err = db.conn.QueryRow(`
+			SELECT COUNT(*) FROM pragma_table_info('feeds') WHERE name = ?
+		`, column).Scan(&colCount)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if colCount != 1 {
+			t.Errorf("After migration, should have %s column, but found %d", column, colCount)
+		}
+	}
+
+	var normalized int
+	if err := db.conn.QueryRow(`
+		SELECT julianday(published_date) IS NOT NULL
+		FROM items WHERE guid = 'legacy-item'
+	`).Scan(&normalized); err != nil {
+		t.Fatal(err)
+	}
+	if normalized != 1 {
+		t.Error("legacy publication date was not normalized for chronological SQLite queries")
 	}
 
 	// Verify we can insert data into the new column

--- a/internal/database/models.go
+++ b/internal/database/models.go
@@ -13,6 +13,9 @@ import (
 )
 
 const (
+	FeedTypeRSS    = "rss"
+	FeedTypeScrape = "scrape"
+
 	// MinReasonableItemDate is the minimum date we consider reasonable for feed items.
 	// Items with dates before this are likely due to:
 	// - Missing or malformed dates in feeds
@@ -39,6 +42,8 @@ type Feed struct {
 	LastSuccessfulFetch time.Time    `db:"last_successful_fetch"`
 	ErrorCount          int          `db:"error_count"`
 	UserAgent           string       `db:"user_agent"`
+	Type                string       `db:"type"`
+	ScrapeSelector      string       `db:"scrape_selector"`
 	LastError           string       `db:"last_error"`
 	LatestItemDate      sql.NullTime `db:"latest_item_date"`
 	FeedJSON            JSON         `db:"feed_json"`
@@ -74,6 +79,17 @@ type Item struct {
 	Summary       string       `db:"summary"`
 	Archived      bool         `db:"archived"`
 	ItemJSON      JSON         `db:"item_json"`
+}
+
+// EffectiveDate returns PublishedDate, falling back to when the item was first seen.
+func (item *Item) EffectiveDate() time.Time {
+	if !item.PublishedDate.IsZero() {
+		return item.PublishedDate.UTC()
+	}
+	if item.FirstSeen.Valid {
+		return item.FirstSeen.Time.UTC()
+	}
+	return time.Time{}
 }
 
 type URLMetadata struct {
@@ -183,6 +199,30 @@ func ItemFromGofeed(gi *gofeed.Item, feedURL string) (*Item, error) {
 	}
 
 	return item, nil
+}
+
+// ItemFromScrape converts a link extracted from HTML into a database item.
+// Scraped items intentionally leave PublishedDate unset so FirstSeen controls ordering.
+func ItemFromScrape(title, link, feedURL string) (*Item, error) {
+	itemJSON, err := json.Marshal(struct {
+		Title string `json:"title"`
+		Link  string `json:"link"`
+	}{Title: title, Link: link})
+	if err != nil {
+		return nil, err
+	}
+
+	guid := link
+	if guid == "" {
+		guid = generateGUID(link, title)
+	}
+	return &Item{
+		FeedURL:  feedURL,
+		GUID:     guid,
+		Title:    html.UnescapeString(title),
+		Link:     link,
+		ItemJSON: JSON(itemJSON),
+	}, nil
 }
 
 func generateGUID(link, title string) string {

--- a/internal/database/models_test.go
+++ b/internal/database/models_test.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"database/sql"
 	"encoding/json"
 	"testing"
 	"time"
@@ -14,6 +15,7 @@ const (
 	fixtureFeedURL1     = "https://example1.com/feed.xml"
 	fixtureItemLink     = "https://example.com/item"
 	fixtureFeedTitle    = "Test Feed"
+	fixtureLastModified = "Mon, 01 Jan 2024 00:00:00 GMT"
 	fixtureItemContent  = "Test content"
 	fixtureItemSummary  = "Test summary"
 	fixtureGUID         = "test-guid"
@@ -387,6 +389,39 @@ func TestItemFromGofeedNoGUID(t *testing.T) {
 	item2, _ := ItemFromGofeed(gofeedItem, fixtureFeedURL)
 	if item.GUID != item2.GUID {
 		t.Errorf("Generated GUID should be consistent: %v != %v", item.GUID, item2.GUID)
+	}
+}
+
+func TestItemFromScrapeLeavesPublicationDateUnset(t *testing.T) {
+	item, err := ItemFromScrape("Scraped article", fixtureItemLink, fixtureFeedURL)
+	if err != nil {
+		t.Fatalf("ItemFromScrape() error = %v", err)
+	}
+	if item.FeedURL != fixtureFeedURL || item.Title != "Scraped article" || item.Link != fixtureItemLink {
+		t.Errorf("ItemFromScrape() = %#v", item)
+	}
+	if item.GUID != fixtureItemLink {
+		t.Errorf("GUID = %q, want stable link %q", item.GUID, fixtureItemLink)
+	}
+	if !item.PublishedDate.IsZero() {
+		t.Errorf("PublishedDate = %v, want zero time", item.PublishedDate)
+	}
+	if len(item.ItemJSON) == 0 {
+		t.Error("ItemJSON is empty")
+	}
+}
+
+func TestItemEffectiveDateFallsBackToFirstSeen(t *testing.T) {
+	firstSeen := time.Now().In(time.FixedZone("test offset", -7*60*60)).Truncate(time.Second)
+	item := Item{FirstSeen: sql.NullTime{Time: firstSeen, Valid: true}}
+	if got := item.EffectiveDate(); !got.Equal(firstSeen) || got.Location() != time.UTC {
+		t.Errorf("EffectiveDate() = %v, want first_seen instant in UTC", got)
+	}
+
+	published := firstSeen.Add(-time.Hour)
+	item.PublishedDate = published
+	if got := item.EffectiveDate(); !got.Equal(published) || got.Location() != time.UTC {
+		t.Errorf("EffectiveDate() = %v, want published_date instant in UTC", got)
 	}
 }
 

--- a/internal/database/schema.sql
+++ b/internal/database/schema.sql
@@ -11,6 +11,8 @@ CREATE TABLE IF NOT EXISTS feeds (
     last_successful_fetch DATETIME,
     error_count INTEGER NOT NULL DEFAULT 0,
     user_agent TEXT NOT NULL DEFAULT '',
+    type TEXT NOT NULL DEFAULT 'rss',
+    scrape_selector TEXT NOT NULL DEFAULT '',
     last_error TEXT NOT NULL DEFAULT '',
     latest_item_date DATETIME,
     feed_json JSON

--- a/internal/database/time_utils.go
+++ b/internal/database/time_utils.go
@@ -1,12 +1,74 @@
 package database
 
 import (
+	"database/sql"
 	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
 )
+
+type nullableTimeDestination struct {
+	destination *time.Time
+}
+
+func scanNullableTime(destination *time.Time) sql.Scanner {
+	return &nullableTimeDestination{destination: destination}
+}
+
+func (scanner *nullableTimeDestination) Scan(value interface{}) error {
+	*scanner.destination = time.Time{}
+	if value == nil {
+		return nil
+	}
+	timestamp, err := parseDatabaseTime(value)
+	if err != nil {
+		return err
+	}
+	*scanner.destination = timestamp
+	return nil
+}
+
+func parseDatabaseTime(value interface{}) (time.Time, error) {
+	if timestamp, ok := value.(time.Time); ok {
+		return timestamp, nil
+	}
+
+	var text string
+	switch value := value.(type) {
+	case string:
+		text = value
+	case []byte:
+		text = string(value)
+	default:
+		var nullable sql.NullTime
+		if err := nullable.Scan(value); err != nil {
+			return time.Time{}, err
+		}
+		return nullable.Time, nil
+	}
+
+	if monotonic := strings.Index(text, " m="); monotonic >= 0 {
+		text = text[:monotonic]
+	}
+	for _, layout := range []string{
+		time.RFC3339Nano,
+		"2006-01-02 15:04:05.999999999 -0700 MST",
+		"2006-01-02 15:04:05.999999999Z07:00",
+		"2006-01-02 15:04:05.999999999",
+		"2006-01-02",
+	} {
+		if timestamp, err := time.Parse(layout, text); err == nil {
+			return timestamp, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("unsupported database time %q", text)
+}
+
+func formatDatabaseTime(timestamp time.Time) string {
+	return timestamp.UTC().Format(time.RFC3339Nano)
+}
 
 // ParseTimeWindow parses CLI time arguments and returns start and end times.
 func ParseTimeWindow(maxAge, startStr, endStr string) (startTime, endTime time.Time, err error) {
@@ -32,6 +94,7 @@ func parseExplicitTimeRange(startStr, endStr string) (startTime, endTime time.Ti
 		if err != nil {
 			return time.Time{}, time.Time{}, fmt.Errorf("invalid start time format: %w", err)
 		}
+		startTime = startTime.UTC()
 	}
 
 	if endStr != "" {
@@ -39,6 +102,7 @@ func parseExplicitTimeRange(startStr, endStr string) (startTime, endTime time.Ti
 		if err != nil {
 			return time.Time{}, time.Time{}, fmt.Errorf("invalid end time format: %w", err)
 		}
+		endTime = endTime.UTC()
 	} else {
 		endTime = time.Now().UTC()
 	}

--- a/internal/feedlist/feedlist.go
+++ b/internal/feedlist/feedlist.go
@@ -18,19 +18,25 @@ type Format string
 const (
 	FormatOPML Format = "opml"
 	FormatText Format = "text"
+
+	FeedTypeRSS    = "rss"
+	FeedTypeScrape = "scrape"
 )
 
 // Feed describes a feed and the configuration carried by its list entry.
 type Feed struct {
-	URL       string
-	UserAgent string
+	URL            string
+	UserAgent      string
+	Type           string
+	ScrapeSelector string
 }
 
 // DeduplicateFeeds preserves first-seen order and rejects conflicting configuration.
 func DeduplicateFeeds(feeds []Feed) ([]Feed, error) {
 	seen := make(map[string]Feed, len(feeds))
 	unique := make([]Feed, 0, len(feeds))
-	for _, feed := range feeds {
+	for _, rawFeed := range feeds {
+		feed := normalizeFeed(rawFeed)
 		existing, found := seen[feed.URL]
 		if !found {
 			seen[feed.URL] = feed
@@ -39,6 +45,9 @@ func DeduplicateFeeds(feeds []Feed) ([]Feed, error) {
 		}
 		if existing.UserAgent != feed.UserAgent {
 			return nil, fmt.Errorf("conflicting User-Agent values for feed %s", feed.URL)
+		}
+		if existing.Type != feed.Type || existing.ScrapeSelector != feed.ScrapeSelector {
+			return nil, fmt.Errorf("conflicting parser configuration for feed %s", feed.URL)
 		}
 	}
 	return unique, nil
@@ -55,6 +64,7 @@ type FeedList interface {
 	GetURLs() []string
 	AddFeed(feed Feed) error
 	SetUserAgent(url, userAgent string) bool
+	SetFeedType(url, feedType, scrapeSelector string) bool
 	Title() string
 	AddURL(url string) error
 	RemoveURL(url string) error
@@ -183,6 +193,7 @@ func (ofl *OPMLFeedList) AddURL(url string) error {
 
 // AddFeed adds a configured feed to the OPML feed list.
 func (ofl *OPMLFeedList) AddFeed(feed Feed) error {
+	feed = normalizeFeed(feed)
 	// Check if URL already exists
 	for _, existingFeed := range ofl.GetFeeds() {
 		if existingFeed.URL == feed.URL {
@@ -194,9 +205,10 @@ func (ofl *OPMLFeedList) AddFeed(feed Feed) error {
 	outline := opml.Outline{
 		Text:      feed.URL,
 		Title:     feed.URL,
-		Type:      "rss",
+		Type:      feed.Type,
 		XMLURL:    feed.URL,
 		UserAgent: feed.UserAgent,
+		Selector:  feed.ScrapeSelector,
 	}
 	ofl.opml.Body.Outlines = append(ofl.opml.Body.Outlines, outline)
 
@@ -206,6 +218,12 @@ func (ofl *OPMLFeedList) AddFeed(feed Feed) error {
 // SetUserAgent updates the User-Agent for an existing OPML feed entry.
 func (ofl *OPMLFeedList) SetUserAgent(url, userAgent string) bool {
 	return setOPMLUserAgent(ofl.opml.Body.Outlines, url, userAgent)
+}
+
+// SetFeedType updates parser configuration for an existing OPML feed entry.
+func (ofl *OPMLFeedList) SetFeedType(url, feedType, scrapeSelector string) bool {
+	feed := normalizeFeed(Feed{Type: feedType, ScrapeSelector: scrapeSelector})
+	return setOPMLFeedType(ofl.opml.Body.Outlines, url, feed.Type, feed.ScrapeSelector)
 }
 
 // RemoveURL removes a URL from the OPML feed list.
@@ -246,7 +264,7 @@ func (ofl *OPMLFeedList) Save(filename string) error {
 func (tfl *TextFeedList) GetFeeds() []Feed {
 	feeds := make([]Feed, 0, len(tfl.urls))
 	for _, url := range tfl.urls {
-		feeds = append(feeds, Feed{URL: url})
+		feeds = append(feeds, Feed{URL: url, Type: FeedTypeRSS})
 	}
 	return feeds
 }
@@ -284,14 +302,50 @@ func (tfl *TextFeedList) SetUserAgent(_, _ string) bool {
 	return false
 }
 
+// SetFeedType reports false because text feed lists carry URLs only.
+func (tfl *TextFeedList) SetFeedType(_, _, _ string) bool {
+	return false
+}
+
 func extractOPMLFeeds(outlines []opml.Outline, feeds *[]Feed) {
 	for i := range outlines {
 		outline := &outlines[i]
 		if outline.XMLURL != "" {
-			*feeds = append(*feeds, Feed{URL: outline.XMLURL, UserAgent: outline.UserAgent})
+			*feeds = append(*feeds, normalizeFeed(Feed{
+				URL:            outline.XMLURL,
+				UserAgent:      outline.UserAgent,
+				Type:           outline.Type,
+				ScrapeSelector: outline.Selector,
+			}))
 		}
 		extractOPMLFeeds(outline.Outlines, feeds)
 	}
+}
+
+func setOPMLFeedType(outlines []opml.Outline, url, feedType, scrapeSelector string) bool {
+	found := false
+	for i := range outlines {
+		if outlines[i].XMLURL == url {
+			outlines[i].Type = feedType
+			outlines[i].Selector = scrapeSelector
+			found = true
+		}
+		if setOPMLFeedType(outlines[i].Outlines, url, feedType, scrapeSelector) {
+			found = true
+		}
+	}
+	return found
+}
+
+func normalizeFeed(feed Feed) Feed {
+	if strings.EqualFold(strings.TrimSpace(feed.Type), FeedTypeScrape) {
+		feed.Type = FeedTypeScrape
+		feed.ScrapeSelector = strings.TrimSpace(feed.ScrapeSelector)
+		return feed
+	}
+	feed.Type = FeedTypeRSS
+	feed.ScrapeSelector = ""
+	return feed
 }
 
 func setOPMLUserAgent(outlines []opml.Outline, url, userAgent string) bool {

--- a/internal/feedlist/feedlist_test.go
+++ b/internal/feedlist/feedlist_test.go
@@ -16,6 +16,8 @@ const (
 	testURL1              = "https://example.com/feed.xml"
 	testURL2              = "https://another.com/rss"
 	testURL3              = "https://third.com/atom.xml"
+	testScrapeSelector    = ".post"
+	testNestedSelector    = ".entry > h2"
 )
 
 func TestDetectFormat(t *testing.T) {
@@ -304,8 +306,8 @@ func TestOPMLFeedUserAgentRoundTrip(t *testing.T) {
 		t.Fatalf("LoadFeedList() error = %v", err)
 	}
 	want := []Feed{
-		{URL: testURL1, UserAgent: testExistingUserAgent},
-		{URL: testURL2, UserAgent: testNewUserAgent},
+		{URL: testURL1, UserAgent: testExistingUserAgent, Type: FeedTypeRSS},
+		{URL: testURL2, UserAgent: testNewUserAgent, Type: FeedTypeRSS},
 	}
 	got := reloaded.GetFeeds()
 	if len(got) != len(want) {
@@ -315,6 +317,103 @@ func TestOPMLFeedUserAgentRoundTrip(t *testing.T) {
 		if got[i] != want[i] {
 			t.Errorf("GetFeeds()[%d] = %#v, want %#v", i, got[i], want[i])
 		}
+	}
+}
+
+func TestOPMLScrapeFeedRoundTrip(t *testing.T) {
+	const source = `<opml version="2.0"><body><outline text="Articles" type="scrape" xmlUrl="https://example.com/archive" selector="article.card" /></body></opml>`
+
+	list, err := loadOPMLFeedList(strings.NewReader(source))
+	if err != nil {
+		t.Fatalf("loadOPMLFeedList() error = %v", err)
+	}
+	feeds := list.GetFeeds()
+	if len(feeds) != 1 {
+		t.Fatalf("len(GetFeeds()) = %d, want 1", len(feeds))
+	}
+	want := Feed{URL: "https://example.com/archive", Type: FeedTypeScrape, ScrapeSelector: "article.card"}
+	if feeds[0] != want {
+		t.Errorf("GetFeeds()[0] = %#v, want %#v", feeds[0], want)
+	}
+
+	if err := list.AddFeed(Feed{
+		URL:            "https://another.example/archive",
+		Type:           FeedTypeScrape,
+		ScrapeSelector: testNestedSelector,
+	}); err != nil {
+		t.Fatalf("AddFeed() error = %v", err)
+	}
+
+	filename := filepath.Join(t.TempDir(), "feeds.opml")
+	if err := list.Save(filename); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	reloaded, err := LoadFeedList(FormatOPML, filename)
+	if err != nil {
+		t.Fatalf("LoadFeedList() error = %v", err)
+	}
+	got := reloaded.GetFeeds()
+	if len(got) != 2 {
+		t.Fatalf("len(GetFeeds()) after round trip = %d, want 2", len(got))
+	}
+	if got[1].Type != FeedTypeScrape || got[1].ScrapeSelector != testNestedSelector {
+		t.Errorf("round-tripped scrape config = %#v", got[1])
+	}
+}
+
+func TestOPMLFeedListSetFeedTypeUpdatesNestedDuplicates(t *testing.T) {
+	const source = `<opml version="2.0"><body><outline xmlUrl="https://example.com/feed.xml" /><outline text="Category"><outline xmlUrl="https://example.com/feed.xml" type="rss" /></outline></body></opml>`
+
+	list, err := loadOPMLFeedList(strings.NewReader(source))
+	if err != nil {
+		t.Fatalf("loadOPMLFeedList() error = %v", err)
+	}
+	if found := list.SetFeedType(testURL1, FeedTypeScrape, testScrapeSelector); !found {
+		t.Fatal("SetFeedType() = false, want true")
+	}
+	for i, feed := range list.GetFeeds() {
+		if feed.Type != FeedTypeScrape || feed.ScrapeSelector != testScrapeSelector {
+			t.Errorf("GetFeeds()[%d] = %#v, want scrape config", i, feed)
+		}
+	}
+
+	if found := list.SetFeedType(testURL1, FeedTypeRSS, ""); !found {
+		t.Fatal("SetFeedType() RSS = false, want true")
+	}
+	for i, feed := range list.GetFeeds() {
+		if feed.Type != FeedTypeRSS || feed.ScrapeSelector != "" {
+			t.Errorf("GetFeeds()[%d] = %#v, want RSS config", i, feed)
+		}
+	}
+}
+
+func TestDeduplicateFeedsRejectsConflictingParserConfiguration(t *testing.T) {
+	tests := []struct {
+		name  string
+		feeds []Feed
+	}{
+		{
+			name: "type",
+			feeds: []Feed{
+				{URL: testURL1, Type: FeedTypeRSS},
+				{URL: testURL1, Type: FeedTypeScrape, ScrapeSelector: testScrapeSelector},
+			},
+		},
+		{
+			name: "selector",
+			feeds: []Feed{
+				{URL: testURL1, Type: FeedTypeScrape, ScrapeSelector: testScrapeSelector},
+				{URL: testURL1, Type: FeedTypeScrape, ScrapeSelector: ".entry"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := DeduplicateFeeds(test.feeds); err == nil {
+				t.Fatal("DeduplicateFeeds() error = nil, want conflict")
+			}
+		})
 	}
 }
 
@@ -593,7 +692,10 @@ func TestDeduplicateFeedsPreservesFirstSeenOrder(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DeduplicateFeeds() error = %v", err)
 	}
-	want := []Feed{{URL: testURL1, UserAgent: testNewUserAgent}, {URL: testURL2}}
+	want := []Feed{
+		{URL: testURL1, UserAgent: testNewUserAgent, Type: FeedTypeRSS},
+		{URL: testURL2, Type: FeedTypeRSS},
+	}
 	if len(got) != len(want) {
 		t.Fatalf("DeduplicateFeeds() = %#v, want %#v", got, want)
 	}

--- a/internal/fetcher/fetcher.go
+++ b/internal/fetcher/fetcher.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/lmorchard/feedspool-go/internal/database"
 	"github.com/lmorchard/feedspool-go/internal/httpclient"
+	"github.com/lmorchard/feedspool-go/internal/scraper"
 	"github.com/lmorchard/feedspool-go/internal/unfurl"
 	"github.com/mmcdole/gofeed"
 	"github.com/sirupsen/logrus"
@@ -64,6 +65,15 @@ func (f *Fetcher) FetchFeed(feedURL string) *FetchResult {
 		result.Error = fmt.Errorf("failed to check existing feed: %w", err)
 		return result
 	}
+	feedType := database.FeedTypeRSS
+	if existingFeed != nil && existingFeed.Type == database.FeedTypeScrape {
+		feedType = database.FeedTypeScrape
+		if existingFeed.ScrapeSelector == "" {
+			result.Error = fmt.Errorf("scrape feed %s requires a selector", feedURL)
+			f.updateFeedError(existingFeed, result.Error.Error())
+			return result
+		}
+	}
 
 	headers := make(map[string]string)
 
@@ -106,25 +116,50 @@ func (f *Fetcher) FetchFeed(feedURL string) *FetchResult {
 		f.updateFeedError(existingFeed, result.Error.Error())
 		return result
 	}
+	return f.parseResponse(result, existingFeed, feedType, resp)
+}
+
+func (f *Fetcher) parseResponse(
+	result *FetchResult, existingFeed *database.Feed,
+	feedType string, resp *httpclient.Response,
+) *FetchResult {
+	if feedType == database.FeedTypeScrape {
+		baseURL := result.URL
+		if resp.Request != nil && resp.Request.URL != nil {
+			baseURL = resp.Request.URL.String()
+		}
+		scrapedItems, scrapeErr := scraper.Parse(resp.BodyReader, baseURL, existingFeed.ScrapeSelector)
+		if scrapeErr != nil {
+			result.Error = fmt.Errorf("failed to parse scrape feed: %w", scrapeErr)
+			f.updateFeedError(existingFeed, result.Error.Error())
+			return result
+		}
+		return f.processScrapedFeed(result, scrapedItems, existingFeed, resp)
+	}
 
 	parser := gofeed.NewParser()
-	gofeedData, err := parser.Parse(resp.BodyReader)
-	if err != nil {
-		result.Error = fmt.Errorf("failed to parse: %w", err)
+	gofeedData, parseErr := parser.Parse(resp.BodyReader)
+	if parseErr != nil {
+		result.Error = fmt.Errorf("failed to parse: %w", parseErr)
 		f.updateFeedError(existingFeed, result.Error.Error())
 		return result
 	}
 
-	return f.processParsedFeed(result, gofeedData, feedURL, resp)
+	return f.processParsedFeed(result, gofeedData, result.URL, existingFeed, resp)
 }
 
 func (f *Fetcher) processParsedFeed(
-	result *FetchResult, gofeedData *gofeed.Feed, feedURL string, resp *httpclient.Response,
+	result *FetchResult, gofeedData *gofeed.Feed, feedURL string,
+	existingFeed *database.Feed, resp *httpclient.Response,
 ) *FetchResult {
 	feed, err := database.FeedFromGofeed(gofeedData, feedURL)
 	if err != nil {
 		result.Error = fmt.Errorf("failed to convert: %w", err)
 		return result
+	}
+	feed.Type = database.FeedTypeRSS
+	if existingFeed != nil {
+		feed.UserAgent = existingFeed.UserAgent
 	}
 
 	feed.ETag = resp.Header.Get("ETag")
@@ -152,6 +187,56 @@ func (f *Fetcher) processParsedFeed(
 	}
 	// Note: If no items with valid dates, we preserve the existing latest_item_date in the database
 
+	result.ItemCount = itemCount
+	result.Feed = feed
+	return result
+}
+
+func (f *Fetcher) processScrapedFeed(
+	result *FetchResult, scrapedItems []scraper.ScrapedItem,
+	existingFeed *database.Feed, resp *httpclient.Response,
+) *FetchResult {
+	feed := existingFeed
+	if feed == nil {
+		feed = &database.Feed{URL: result.URL}
+	}
+	if feed.Title == "" {
+		feed.Title = result.URL
+	}
+	feed.Type = database.FeedTypeScrape
+	feed.ETag = resp.Header.Get("ETag")
+	feed.LastModified = resp.Header.Get("Last-Modified")
+	feed.LastFetchTime = time.Now()
+	feed.LastSuccessfulFetch = time.Now()
+	feed.ErrorCount = 0
+	feed.LastError = ""
+
+	if err := f.db.UpsertFeed(feed); err != nil {
+		result.Error = fmt.Errorf("failed to save feed: %w", err)
+		return result
+	}
+
+	items := make([]*database.Item, 0, len(scrapedItems))
+	maxItems := f.maxItems
+	if maxItems <= 0 || maxItems > len(scrapedItems) {
+		maxItems = len(scrapedItems)
+	}
+	for _, scrapedItem := range scrapedItems[:maxItems] {
+		item, err := database.ItemFromScrape(scrapedItem.Title, scrapedItem.Link, result.URL)
+		if err != nil {
+			logrus.Warnf("Failed to convert scraped item: %v", err)
+			continue
+		}
+		items = append(items, item)
+	}
+
+	itemCount, latestItemDate := f.processItems(items, result.URL)
+	if !latestItemDate.IsZero() {
+		feed.LatestItemDate = sql.NullTime{Time: latestItemDate, Valid: true}
+		if err := f.db.UpsertFeed(feed); err != nil {
+			logrus.Warnf("Failed to update feed with latest item date: %v", err)
+		}
+	}
 	result.ItemCount = itemCount
 	result.Feed = feed
 	return result
@@ -192,29 +277,31 @@ func clampItemDate(itemDate time.Time, firstSeen sql.NullTime) time.Time {
 	return itemDate
 }
 
-//nolint:cyclop // Complex feed processing logic requires multiple conditions
 func (f *Fetcher) processFeedItems(gofeedData *gofeed.Feed, feedURL string) (int, time.Time) {
-	activeGUIDs := []string{}
-	itemCount := 0
-	var latestItemDate time.Time
-	var newItemURLs []string
-
+	items := make([]*database.Item, 0, len(gofeedData.Items))
 	maxItems := f.maxItems
-	if maxItems <= 0 {
+	if maxItems <= 0 || maxItems > len(gofeedData.Items) {
 		maxItems = len(gofeedData.Items)
 	}
-
-	for i, gofeedItem := range gofeedData.Items {
-		if i >= maxItems {
-			break
-		}
-
+	for _, gofeedItem := range gofeedData.Items[:maxItems] {
 		item, err := database.ItemFromGofeed(gofeedItem, feedURL)
 		if err != nil {
 			logrus.Warnf("Failed to convert item: %v", err)
 			continue
 		}
+		items = append(items, item)
+	}
+	return f.processItems(items, feedURL)
+}
 
+//nolint:cyclop // Item lifecycle handling has independent date, archive, and unfurl paths.
+func (f *Fetcher) processItems(items []*database.Item, feedURL string) (int, time.Time) {
+	activeGUIDs := []string{}
+	itemCount := 0
+	var latestItemDate time.Time
+	var newItemURLs []string
+
+	for _, item := range items {
 		// Check if this is a new item (before upserting)
 		isNewItem := f.isNewItem(feedURL, item.GUID)
 

--- a/internal/fetcher/fetcher_test.go
+++ b/internal/fetcher/fetcher_test.go
@@ -35,6 +35,13 @@ const testFeedXML = `<?xml version="1.0" encoding="UTF-8"?>
     </channel>
 </rss>`
 
+const testScrapeHTML = `<html><body>
+<article class="post"><a href="/one">First scraped item</a></article>
+<article class="post"><a href="/two">Second scraped item</a></article>
+</body></html>`
+
+const testScrapeSelector = ".post"
+
 func setupTestDatabase(t *testing.T) *database.DB {
 	t.Helper()
 
@@ -130,6 +137,150 @@ func TestFetchFeedSuccess(t *testing.T) {
 
 	if result.Feed.ETag != testETag {
 		t.Errorf("FetchFeed() Feed.ETag = %v, want %q", result.Feed.ETag, testETag)
+	}
+}
+
+func TestFetchFeedScrape(t *testing.T) {
+	db := setupTestDatabase(t)
+	const userAgent = "Scrape Reader/1.0"
+
+	requests := make(chan *http.Request, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- r.Clone(r.Context())
+		w.Header().Set("ETag", "scrape-etag")
+		_, _ = w.Write([]byte(testScrapeHTML))
+	}))
+	defer server.Close()
+
+	if err := db.SetFeedConfig(server.URL, database.FeedTypeScrape, testScrapeSelector, userAgent); err != nil {
+		t.Fatal(err)
+	}
+	fetcher := NewFetcher(db, 30*time.Second, 1, false)
+	result := fetcher.FetchFeed(server.URL)
+	if result.Error != nil {
+		t.Fatalf("FetchFeed() error = %v", result.Error)
+	}
+	if result.ItemCount != 1 {
+		t.Errorf("ItemCount = %d, want max-items-limited count 1", result.ItemCount)
+	}
+	if got := (<-requests).Header.Get("User-Agent"); got != userAgent {
+		t.Errorf("User-Agent = %q, want %q", got, userAgent)
+	}
+	if result.Feed == nil || result.Feed.Type != database.FeedTypeScrape ||
+		result.Feed.ScrapeSelector != testScrapeSelector {
+		t.Fatalf("result.Feed = %#v, want preserved scrape config", result.Feed)
+	}
+	if result.Feed.ETag != "scrape-etag" {
+		t.Errorf("ETag = %q, want scrape-etag", result.Feed.ETag)
+	}
+
+	items, err := db.GetItemsForFeed(server.URL, 0, time.Time{}, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("len(GetItemsForFeed()) = %d, want 1", len(items))
+	}
+	if items[0].Link != server.URL+"/one" || items[0].Title != "First scraped item" {
+		t.Errorf("scraped item = %#v", items[0])
+	}
+	if !items[0].PublishedDate.IsZero() {
+		t.Errorf("PublishedDate = %v, want zero", items[0].PublishedDate)
+	}
+	var publishedDateIsNull bool
+	if err := db.GetConnection().QueryRow(
+		"SELECT published_date IS NULL FROM items WHERE feed_url = ?", server.URL,
+	).Scan(&publishedDateIsNull); err != nil {
+		t.Fatal(err)
+	}
+	if !publishedDateIsNull {
+		t.Error("published_date is not SQL NULL")
+	}
+	if !items[0].FirstSeen.Valid {
+		t.Error("FirstSeen is unset")
+	}
+	filteredItems, err := db.GetItemsForFeed(
+		server.URL, 0, items[0].FirstSeen.Time.Add(-time.Minute), items[0].FirstSeen.Time.Add(time.Minute),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(filteredItems) != 1 {
+		t.Errorf("time-filtered scraped items = %d, want 1 using first_seen fallback", len(filteredItems))
+	}
+}
+
+func TestFetchFeedScrapeRequiresSelector(t *testing.T) {
+	db := setupTestDatabase(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(testScrapeHTML))
+	}))
+	defer server.Close()
+
+	if err := db.SetFeedConfig(server.URL, database.FeedTypeScrape, "", ""); err != nil {
+		t.Fatal(err)
+	}
+	result := NewFetcher(db, 30*time.Second, 10, false).FetchFeed(server.URL)
+	if result.Error == nil || !strings.Contains(result.Error.Error(), "selector") {
+		t.Fatalf("FetchFeed() error = %v, want missing-selector error", result.Error)
+	}
+}
+
+func TestFetchFeedScrapeUsesFinalRedirectURLAsBase(t *testing.T) {
+	db := setupTestDatabase(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/archive" {
+			http.Redirect(w, r, "/archive/", http.StatusMovedPermanently)
+			return
+		}
+		_, _ = w.Write([]byte(`<article class="post"><a href="entry">Entry</a></article>`))
+	}))
+	defer server.Close()
+
+	feedURL := server.URL + "/archive"
+	if err := db.SetFeedConfig(feedURL, database.FeedTypeScrape, testScrapeSelector, ""); err != nil {
+		t.Fatal(err)
+	}
+	result := NewFetcher(db, 30*time.Second, 10, false).FetchFeed(feedURL)
+	if result.Error != nil {
+		t.Fatalf("FetchFeed() error = %v", result.Error)
+	}
+	items, err := db.GetItemsForFeed(feedURL, 0, time.Time{}, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 1 || items[0].Link != server.URL+"/archive/entry" {
+		t.Errorf("items = %#v, want redirect-relative link", items)
+	}
+}
+
+func TestFetchFeedParserChangeDoesNotUseStaleValidator(t *testing.T) {
+	db := setupTestDatabase(t)
+	const staleETag = "stale-parser-etag"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("If-None-Match") == staleETag {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		_, _ = w.Write([]byte(testScrapeHTML))
+	}))
+	defer server.Close()
+
+	if err := db.UpsertFeed(&database.Feed{
+		URL:            server.URL,
+		Type:           database.FeedTypeScrape,
+		ScrapeSelector: ".old",
+		ETag:           staleETag,
+		LastFetchTime:  time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SetFeedConfig(server.URL, database.FeedTypeScrape, testScrapeSelector, ""); err != nil {
+		t.Fatal(err)
+	}
+	result := NewFetcher(db, 30*time.Second, 10, false).FetchFeed(server.URL)
+	if result.Error != nil || result.Cached || result.ItemCount != 2 {
+		t.Errorf("FetchFeed() = %#v, want fresh scrape after parser change", result)
 	}
 }
 

--- a/internal/fetcher/orchestrator.go
+++ b/internal/fetcher/orchestrator.go
@@ -94,6 +94,8 @@ func (o *Orchestrator) FetchFromFile(
 		if err := o.SynchronizeFeedConfigs(feeds); err != nil {
 			return nil, err
 		}
+	} else if err := o.SynchronizeFeedParserConfigs(feeds); err != nil {
+		return nil, err
 	}
 
 	feedURLs := make([]string, 0, len(feeds))
@@ -114,6 +116,20 @@ func (o *Orchestrator) FetchFromFile(
 	return o.FetchFromURLs(ctx, feedURLs, opts), nil
 }
 
+// SynchronizeFeedParserConfigs writes parser settings without changing User-Agent.
+func (o *Orchestrator) SynchronizeFeedParserConfigs(feeds []feedlist.Feed) error {
+	feeds, err := feedlist.DeduplicateFeeds(feeds)
+	if err != nil {
+		return fmt.Errorf("invalid feed parser configuration: %w", err)
+	}
+	for _, feed := range feeds {
+		if err := o.db.SetFeedParserConfig(feed.URL, feed.Type, feed.ScrapeSelector); err != nil {
+			return fmt.Errorf("failed to synchronize feed parser configuration for %s: %w", feed.URL, err)
+		}
+	}
+	return nil
+}
+
 // SynchronizeFeedConfigs writes authoritative OPML configuration to the database.
 func (o *Orchestrator) SynchronizeFeedConfigs(feeds []feedlist.Feed) error {
 	feeds, err := feedlist.DeduplicateFeeds(feeds)
@@ -121,7 +137,7 @@ func (o *Orchestrator) SynchronizeFeedConfigs(feeds []feedlist.Feed) error {
 		return fmt.Errorf("invalid feed configuration: %w", err)
 	}
 	for _, feed := range feeds {
-		if err := o.db.SetFeedUserAgent(feed.URL, feed.UserAgent); err != nil {
+		if err := o.db.SetFeedConfig(feed.URL, feed.Type, feed.ScrapeSelector, feed.UserAgent); err != nil {
 			return fmt.Errorf("failed to synchronize feed configuration for %s: %w", feed.URL, err)
 		}
 	}

--- a/internal/fetcher/orchestrator_test.go
+++ b/internal/fetcher/orchestrator_test.go
@@ -151,6 +151,115 @@ func TestFetchFromFileSynchronizesUserAgent(t *testing.T) {
 	}
 }
 
+func TestFetchFromFileSynchronizesScrapeConfiguration(t *testing.T) {
+	db := setupTestDatabase(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(testScrapeHTML))
+	}))
+	defer server.Close()
+
+	filename := filepath.Join(t.TempDir(), "feeds.opml")
+	content := `<opml version="2.0"><body><outline type="scrape" selector="` + testScrapeSelector + `" xmlUrl="` +
+		server.URL + `" /></body></opml>`
+	if err := os.WriteFile(filename, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	o := NewOrchestrator(db, config.GetDefault())
+	results, err := o.FetchFromFile(context.Background(), feedlist.FormatOPML, filename, FetchOptions{
+		Timeout:     config.DefaultTimeout,
+		MaxItems:    config.DefaultMaxItems,
+		Concurrency: 1,
+	})
+	if err != nil {
+		t.Fatalf("FetchFromFile() error = %v", err)
+	}
+	if len(results) != 1 || results[0].Error != nil || results[0].ItemCount != 2 {
+		t.Fatalf("FetchFromFile() results = %#v, want one successful two-item scrape", results)
+	}
+	feed, err := db.GetFeed(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if feed.Type != database.FeedTypeScrape || feed.ScrapeSelector != testScrapeSelector {
+		t.Errorf("database feed config = %#v, want scrape selector", feed)
+	}
+}
+
+func TestFetchFromFileParserChangeBypassesMaxAge(t *testing.T) {
+	db := setupTestDatabase(t)
+	var hits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte(testScrapeHTML))
+	}))
+	defer server.Close()
+
+	if err := db.UpsertFeed(&database.Feed{
+		URL:           server.URL,
+		Type:          database.FeedTypeRSS,
+		LastFetchTime: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	filename := filepath.Join(t.TempDir(), "feeds.opml")
+	content := `<opml version="2.0"><body><outline type="scrape" selector="` + testScrapeSelector +
+		`" xmlUrl="` + server.URL + `" /></body></opml>`
+	if err := os.WriteFile(filename, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	o := NewOrchestrator(db, config.GetDefault())
+	results, err := o.FetchFromFile(context.Background(), feedlist.FormatOPML, filename, FetchOptions{
+		Timeout:     config.DefaultTimeout,
+		MaxItems:    config.DefaultMaxItems,
+		MaxAge:      time.Hour,
+		Concurrency: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hits.Load() != 1 || len(results) != 1 || results[0].ItemCount != 2 {
+		t.Errorf("hits = %d, results = %#v; want fresh scrape despite max-age", hits.Load(), results)
+	}
+}
+
+func TestFetchFromTextListRestoresRSSParserWithoutClearingUserAgent(t *testing.T) {
+	db := setupTestDatabase(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(testFeedXML))
+	}))
+	defer server.Close()
+	const userAgent = "Preserved Reader/1.0"
+	if err := db.SetFeedConfig(server.URL, database.FeedTypeScrape, testScrapeSelector, userAgent); err != nil {
+		t.Fatal(err)
+	}
+
+	filename := filepath.Join(t.TempDir(), "feeds.txt")
+	if err := os.WriteFile(filename, []byte(server.URL+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	o := NewOrchestrator(db, config.GetDefault())
+	results, err := o.FetchFromFile(context.Background(), feedlist.FormatText, filename, FetchOptions{
+		Timeout:     config.DefaultTimeout,
+		MaxItems:    config.DefaultMaxItems,
+		Concurrency: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0].Error != nil || results[0].ItemCount != 2 {
+		t.Fatalf("FetchFromFile() results = %#v, want RSS parse", results)
+	}
+	feed, err := db.GetFeed(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if feed.Type != database.FeedTypeRSS || feed.UserAgent != userAgent {
+		t.Errorf("feed config = %#v, want RSS with preserved User-Agent", feed)
+	}
+}
+
 func TestFetchFromFileRejectsConflictingUserAgents(t *testing.T) {
 	db := setupTestDatabase(t)
 	var hits atomic.Int32

--- a/internal/opml/parser.go
+++ b/internal/opml/parser.go
@@ -34,6 +34,7 @@ type Outline struct {
 	XMLURL        string       `xml:"xmlUrl,attr,omitempty"`
 	HTMLURL       string       `xml:"htmlUrl,attr,omitempty"`
 	UserAgent     string       `xml:"userAgent,attr,omitempty"`
+	Selector      string       `xml:"selector,attr,omitempty"`
 	OtherAttrs    []xml.Attr   `xml:",any,attr"`
 	Outlines      []Outline    `xml:"outline"`
 	OtherElements []RawElement `xml:",any"`

--- a/internal/renderer/templates/feed.html
+++ b/internal/renderer/templates/feed.html
@@ -82,7 +82,7 @@
                                 {{end}}
                             </div>
                         </div>
-                        <time class="item-date" datetime="{{.PublishedDate.Format "2006-01-02T15:04:05Z07:00"}}">{{.PublishedDate.Format "Jan 2, 2006 15:04 UTC"}}</time>
+                        <time class="item-date" datetime="{{.EffectiveDate.Format "2006-01-02T15:04:05Z07:00"}}">{{.EffectiveDate.Format "Jan 2, 2006 15:04 UTC"}}</time>
                     </summary>
                     <div class="item-content">
                         {{if .Content}}

--- a/internal/renderer/workflow.go
+++ b/internal/renderer/workflow.go
@@ -46,7 +46,7 @@ type WorkflowConfig struct {
 type Result struct {
 	FeedCount  int       // Feeds matching the time window and feed-list filter.
 	ItemCount  int       // Items rendered, after min/max per-feed limits.
-	NewestItem time.Time // Newest PublishedDate rendered; zero if no items.
+	NewestItem time.Time // Newest effective item date rendered; zero if no items.
 }
 
 // summarize computes a Result from the data about to be rendered.
@@ -56,8 +56,9 @@ func summarize(feeds []database.Feed, items map[string][]database.Item) *Result 
 		feedItems := items[feeds[i].URL]
 		result.ItemCount += len(feedItems)
 		for j := range feedItems {
-			if feedItems[j].PublishedDate.After(result.NewestItem) {
-				result.NewestItem = feedItems[j].PublishedDate
+			itemDate := feedItems[j].EffectiveDate()
+			if itemDate.After(result.NewestItem) {
+				result.NewestItem = itemDate
 			}
 		}
 	}

--- a/internal/renderer/workflow_test.go
+++ b/internal/renderer/workflow_test.go
@@ -109,6 +109,62 @@ func TestExecuteWorkflowResult(t *testing.T) {
 	}
 }
 
+func TestExecuteWorkflowUsesFirstSeenForScrapedItemDates(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "scrape.db")
+	db, err := database.New(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.InitSchema(); err != nil {
+		t.Fatal(err)
+	}
+	firstSeen := time.Date(2026, time.August, 25, 20, 30, 0, 0, time.UTC)
+	const scrapedItemURL = "https://example.com/scraped"
+	if err := db.UpsertFeed(&database.Feed{
+		URL:            testFeedURL,
+		Title:          "Scraped Feed",
+		Type:           database.FeedTypeScrape,
+		ScrapeSelector: ".post",
+		LatestItemDate: sql.NullTime{Time: firstSeen, Valid: true},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.UpsertItem(&database.Item{
+		FeedURL:   testFeedURL,
+		GUID:      scrapedItemURL,
+		Title:     "Scraped item",
+		Link:      scrapedItemURL,
+		FirstSeen: sql.NullTime{Time: firstSeen, Valid: true},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &WorkflowConfig{
+		Start:     firstSeen.Add(-time.Minute).Format(time.RFC3339),
+		End:       firstSeen.Add(time.Minute).Format(time.RFC3339),
+		OutputDir: filepath.Join(tmpDir, "build"),
+		Database:  dbPath,
+	}
+	result, err := ExecuteWorkflow(cfg)
+	if err != nil {
+		t.Fatalf("ExecuteWorkflow() error = %v", err)
+	}
+	if !result.NewestItem.Equal(firstSeen) {
+		t.Errorf("NewestItem = %v, want first_seen %v", result.NewestItem, firstSeen)
+	}
+	page, err := os.ReadFile(filepath.Join(cfg.OutputDir, "index.html"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(page), firstSeen.Format("Jan 2, 2006 15:04 UTC")) {
+		t.Errorf("rendered page does not contain first_seen date: %s", page)
+	}
+}
+
 func TestExecuteWorkflowWritesIndexWhenEmpty(t *testing.T) {
 	cfg, _ := newTestWorkflow(t, false)
 

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -1,0 +1,101 @@
+// Package scraper extracts feed-shaped entries from HTML pages.
+//
+// Portions adapted from github.com/Hyaxia/blogwatcher (MIT).
+package scraper
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/andybalholm/cascadia"
+)
+
+// ScrapedItem is the link metadata synthesized from one HTML match.
+type ScrapedItem struct {
+	Title string
+	Link  string
+}
+
+// Parse applies selector to body and returns deduplicated, resolved links.
+func Parse(body io.Reader, baseURL, selector string) ([]ScrapedItem, error) {
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid base URL %q: %w", baseURL, err)
+	}
+	if !base.IsAbs() {
+		return nil, fmt.Errorf("invalid base URL %q: URL must be absolute", baseURL)
+	}
+
+	selector = strings.TrimSpace(selector)
+	if selector == "" {
+		return nil, fmt.Errorf("scrape selector cannot be empty")
+	}
+	matcher, err := cascadia.Compile(selector)
+	if err != nil {
+		return nil, fmt.Errorf("invalid scrape selector %q: %w", selector, err)
+	}
+
+	document, err := goquery.NewDocumentFromReader(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse HTML: %w", err)
+	}
+
+	items := make([]ScrapedItem, 0)
+	seen := make(map[string]struct{})
+	document.FindMatcher(matcher).Each(func(_ int, match *goquery.Selection) {
+		link := nearestLink(match)
+		if link.Length() == 0 {
+			return
+		}
+
+		href, found := link.Attr("href")
+		if !found || strings.TrimSpace(href) == "" {
+			return
+		}
+		reference, parseErr := url.Parse(strings.TrimSpace(href))
+		if parseErr != nil {
+			return
+		}
+		resolved := base.ResolveReference(reference).String()
+		if _, duplicate := seen[resolved]; duplicate {
+			return
+		}
+		seen[resolved] = struct{}{}
+
+		items = append(items, ScrapedItem{
+			Title: extractTitle(link, match),
+			Link:  resolved,
+		})
+	})
+
+	return items, nil
+}
+
+func nearestLink(match *goquery.Selection) *goquery.Selection {
+	if goquery.NodeName(match) == "a" {
+		return match.First()
+	}
+	if descendant := match.Find("a").First(); descendant.Length() > 0 {
+		return descendant
+	}
+	return match.ParentsFiltered("a").First()
+}
+
+func extractTitle(link, match *goquery.Selection) string {
+	if title := normalizedText(link.Text()); title != "" {
+		return title
+	}
+	if title, found := link.Attr("title"); found {
+		if title = normalizedText(title); title != "" {
+			return title
+		}
+	}
+	return normalizedText(match.Text())
+}
+
+func normalizedText(value string) string {
+	return strings.Join(strings.Fields(value), " ")
+}

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -1,0 +1,95 @@
+package scraper
+
+import (
+	"strings"
+	"testing"
+)
+
+const (
+	testBaseURL      = "https://example.com"
+	testBaseURLError = "base URL"
+	testSelectorText = "selector"
+)
+
+func TestParseExtractsResolvesAndDeduplicatesLinks(t *testing.T) {
+	const document = `
+		<html><body>
+			<article class="post"><a href="/posts/one"><span> First post </span></a></article>
+			<article class="post"><a href="posts/two" title="Second post"></a></article>
+			<article class="post"><a href="/posts/one">Duplicate title</a></article>
+			<a href="/posts/three"><span class="post">Third post</span></a>
+			<div class="post">No link here</div>
+		</body></html>`
+
+	items, err := Parse(strings.NewReader(document), "https://example.com/archive/", ".post")
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	want := []ScrapedItem{
+		{Title: "First post", Link: "https://example.com/posts/one"},
+		{Title: "Second post", Link: "https://example.com/archive/posts/two"},
+		{Title: "Third post", Link: "https://example.com/posts/three"},
+	}
+	if len(items) != len(want) {
+		t.Fatalf("len(Parse()) = %d, want %d: %#v", len(items), len(want), items)
+	}
+	for i := range want {
+		if items[i] != want[i] {
+			t.Errorf("items[%d] = %#v, want %#v", i, items[i], want[i])
+		}
+	}
+}
+
+func TestParseUsesMatchedElementTextAsTitleFallback(t *testing.T) {
+	const document = `<div class="post">Fallback heading <a href="/post"></a></div>`
+
+	items, err := Parse(strings.NewReader(document), "https://example.com/", ".post")
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("len(Parse()) = %d, want 1", len(items))
+	}
+	if items[0].Title != "Fallback heading" {
+		t.Errorf("Title = %q, want %q", items[0].Title, "Fallback heading")
+	}
+}
+
+func TestParseRejectsInvalidInputs(t *testing.T) {
+	tests := []struct {
+		name     string
+		baseURL  string
+		selector string
+		wantText string
+	}{
+		{name: testBaseURLError, baseURL: "://bad", selector: "a", wantText: testBaseURLError},
+		{name: "relative base URL", baseURL: "/archive", selector: "a", wantText: "absolute"},
+		{name: "empty selector", baseURL: testBaseURL, selector: "", wantText: testSelectorText},
+		{name: "invalid selector", baseURL: testBaseURL, selector: "[", wantText: testSelectorText},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := Parse(strings.NewReader(`<a href="/post">Post</a>`), test.baseURL, test.selector)
+			if err == nil {
+				t.Fatal("Parse() error = nil, want error")
+			}
+			if !strings.Contains(err.Error(), test.wantText) {
+				t.Errorf("Parse() error = %q, want it to contain %q", err, test.wantText)
+			}
+		})
+	}
+}
+
+func TestParseReturnsEmptySliceWhenNothingMatches(t *testing.T) {
+	items, err := Parse(strings.NewReader(`<a href="/post">Post</a>`), "https://example.com", ".missing")
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if items == nil {
+		t.Fatal("Parse() = nil, want empty non-nil slice")
+	}
+	if len(items) != 0 {
+		t.Errorf("len(Parse()) = %d, want 0", len(items))
+	}
+}

--- a/internal/sitegroup/render.go
+++ b/internal/sitegroup/render.go
@@ -26,7 +26,10 @@ type FetchPlan struct {
 	Skipped     []Skipped
 	URLs        []string        // Deduped union across every site.
 	FeedConfigs []feedlist.Feed // Deduped configuration from OPML lists.
-	References  int             // Total URL references before dedup.
+	// ParserConfigs covers every URL. OPML configuration wins when the same
+	// URL also appears in a URL-only text list.
+	ParserConfigs []feedlist.Feed
+	References    int // Total URL references before dedup.
 }
 
 // PlanFetch discovers the feed lists in dir and unions their URLs so a feed
@@ -49,13 +52,33 @@ func PlanFetch(dir string) (*FetchPlan, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid directory feed configuration: %w", err)
 	}
+	parserConfigs := append([]feedlist.Feed(nil), feedConfigs...)
+	opmlURLs := make(map[string]struct{}, len(feedConfigs))
+	for _, feed := range feedConfigs {
+		opmlURLs[feed.URL] = struct{}{}
+	}
+	for i := range sites {
+		if sites[i].Format != feedlist.FormatText {
+			continue
+		}
+		for _, feed := range sites[i].Feeds {
+			if _, configuredByOPML := opmlURLs[feed.URL]; !configuredByOPML {
+				parserConfigs = append(parserConfigs, feed)
+			}
+		}
+	}
+	parserConfigs, err = feedlist.DeduplicateFeeds(parserConfigs)
+	if err != nil {
+		return nil, fmt.Errorf("invalid directory feed parser configuration: %w", err)
+	}
 
 	return &FetchPlan{
-		Sites:       sites,
-		Skipped:     skipped,
-		URLs:        UnionURLs(sites),
-		FeedConfigs: feedConfigs,
-		References:  references,
+		Sites:         sites,
+		Skipped:       skipped,
+		URLs:          UnionURLs(sites),
+		FeedConfigs:   feedConfigs,
+		ParserConfigs: parserConfigs,
+		References:    references,
 	}, nil
 }
 

--- a/internal/sitegroup/render_test.go
+++ b/internal/sitegroup/render_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/lmorchard/feedspool-go/internal/database"
+	"github.com/lmorchard/feedspool-go/internal/feedlist"
 	"github.com/lmorchard/feedspool-go/internal/renderer"
 )
 
@@ -87,7 +88,8 @@ func TestPlanFetchDedupes(t *testing.T) {
 
 func TestPlanFetchCarriesOPMLUserAgents(t *testing.T) {
 	dir := writeDir(t, map[string]string{
-		oneOPML:   `<opml version="2.0"><body><outline xmlUrl="` + feedA + `" userAgent="` + directoryCustomUserAgent + `" /></body></opml>`,
+		oneOPML: `<opml version="2.0"><body><outline xmlUrl="` + feedA + `" userAgent="` +
+			directoryCustomUserAgent + `" type="scrape" selector=".post" /></body></opml>`,
 		"two.txt": feedA + "\n" + feedB + "\n",
 	})
 
@@ -100,6 +102,16 @@ func TestPlanFetchCarriesOPMLUserAgents(t *testing.T) {
 	}
 	if got := plan.FeedConfigs[0]; got.URL != feedA || got.UserAgent != directoryCustomUserAgent {
 		t.Errorf("FeedConfigs[0] = %#v, want configured %s", got, feedA)
+	}
+	if len(plan.ParserConfigs) != 2 {
+		t.Fatalf("len(ParserConfigs) = %d, want two unique URLs", len(plan.ParserConfigs))
+	}
+	if got := plan.ParserConfigs[0]; got.URL != feedA || got.Type != feedlist.FeedTypeScrape ||
+		got.ScrapeSelector != ".post" {
+		t.Errorf("ParserConfigs[0] = %#v, want OPML scrape config", got)
+	}
+	if got := plan.ParserConfigs[1]; got.URL != feedB || got.Type != feedlist.FeedTypeRSS {
+		t.Errorf("ParserConfigs[1] = %#v, want text-list RSS config", got)
 	}
 }
 

--- a/internal/subscription/subscription.go
+++ b/internal/subscription/subscription.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/lmorchard/feedspool-go/internal/config"
@@ -88,6 +89,10 @@ type SubscribeOptions struct {
 	// UserAgent is nil when the option was not supplied. A non-nil empty
 	// string explicitly clears an existing override.
 	UserAgent *string
+	// FeedType is nil when parser configuration was not supplied.
+	FeedType *string
+	// ScrapeSelector accompanies a scrape FeedType.
+	ScrapeSelector *string
 }
 
 // Subscribe adds one or more URLs to a feed list.
@@ -105,6 +110,10 @@ func (m *Manager) SubscribeWithOptions(
 	}
 	if options.UserAgent != nil && feedFormat != feedlist.FormatOPML {
 		return nil, fmt.Errorf("per-feed User-Agent is supported only for OPML feed lists")
+	}
+	options, err = normalizeParserOptions(feedFormat, options)
+	if err != nil {
+		return nil, err
 	}
 
 	list, createdNew, err := m.LoadOrCreateFeedList(feedFormat, filename)
@@ -243,24 +252,28 @@ func (m *Manager) addFeedsToList(
 
 	for _, feedURL := range urlsToAdd {
 		matches, exists := existingFeeds[feedURL]
-		if exists && (options.UserAgent == nil || allFeedsUseUserAgent(matches, *options.UserAgent)) {
-			warnings = append(warnings, fmt.Sprintf("Feed URL already exists in list: %s", feedURL))
-			continue
-		}
 		if exists {
-			if list.SetUserAgent(feedURL, *options.UserAgent) {
+			if allFeedsMatchOptions(matches, options) {
+				warnings = append(warnings, fmt.Sprintf("Feed URL already exists in list: %s", feedURL))
+				continue
+			}
+			matches, updated := updateExistingFeed(list, feedURL, matches, options)
+			if updated {
 				updatedCount++
-				for i := range matches {
-					matches[i].UserAgent = *options.UserAgent
-				}
 				existingFeeds[feedURL] = matches
 			}
 			continue
 		}
 
-		feed := feedlist.Feed{URL: feedURL}
+		feed := feedlist.Feed{URL: feedURL, Type: feedlist.FeedTypeRSS}
 		if options.UserAgent != nil {
 			feed.UserAgent = *options.UserAgent
+		}
+		if options.FeedType != nil {
+			feed.Type = *options.FeedType
+		}
+		if options.ScrapeSelector != nil {
+			feed.ScrapeSelector = *options.ScrapeSelector
 		}
 		if err := list.AddFeed(feed); err != nil {
 			warnings = append(warnings, fmt.Sprintf("Failed to add URL %s: %v", feedURL, err))
@@ -273,10 +286,94 @@ func (m *Manager) addFeedsToList(
 	return addedCount, updatedCount, warnings
 }
 
-func allFeedsUseUserAgent(feeds []feedlist.Feed, userAgent string) bool {
+func updateExistingFeed(
+	list feedlist.FeedList, feedURL string, matches []feedlist.Feed, options SubscribeOptions,
+) ([]feedlist.Feed, bool) {
+	userAgentUpdated := updateExistingUserAgent(list, feedURL, matches, options.UserAgent)
+	parserUpdated := updateExistingParser(list, feedURL, matches, options)
+	return matches, userAgentUpdated || parserUpdated
+}
+
+func updateExistingUserAgent(
+	list feedlist.FeedList, feedURL string, matches []feedlist.Feed, userAgent *string,
+) bool {
+	if userAgent == nil || !list.SetUserAgent(feedURL, *userAgent) {
+		return false
+	}
+	for i := range matches {
+		matches[i].UserAgent = *userAgent
+	}
+	return true
+}
+
+func updateExistingParser(
+	list feedlist.FeedList, feedURL string, matches []feedlist.Feed, options SubscribeOptions,
+) bool {
+	if options.FeedType == nil {
+		return false
+	}
+	selector := ""
+	if options.ScrapeSelector != nil {
+		selector = *options.ScrapeSelector
+	}
+	if !list.SetFeedType(feedURL, *options.FeedType, selector) {
+		return false
+	}
+	for i := range matches {
+		matches[i].Type = *options.FeedType
+		matches[i].ScrapeSelector = selector
+	}
+	return true
+}
+
+func normalizeParserOptions(format feedlist.Format, options SubscribeOptions) (SubscribeOptions, error) {
+	if options.FeedType == nil && options.ScrapeSelector == nil {
+		return options, nil
+	}
+	if format != feedlist.FormatOPML {
+		return options, fmt.Errorf("per-feed parser configuration is supported only for OPML feed lists")
+	}
+	if options.FeedType == nil {
+		return options, fmt.Errorf("--selector requires --type scrape")
+	}
+
+	feedType := strings.ToLower(strings.TrimSpace(*options.FeedType))
+	switch feedType {
+	case feedlist.FeedTypeRSS:
+		if options.ScrapeSelector != nil && strings.TrimSpace(*options.ScrapeSelector) != "" {
+			return options, fmt.Errorf("--selector can be used only with --type scrape")
+		}
+	case feedlist.FeedTypeScrape:
+		if options.ScrapeSelector == nil || strings.TrimSpace(*options.ScrapeSelector) == "" {
+			return options, fmt.Errorf("--type scrape requires a non-empty --selector")
+		}
+	default:
+		return options, fmt.Errorf("unsupported feed type %q (must be 'rss' or 'scrape')", *options.FeedType)
+	}
+	options.FeedType = &feedType
+	if options.ScrapeSelector != nil {
+		selector := strings.TrimSpace(*options.ScrapeSelector)
+		options.ScrapeSelector = &selector
+	}
+	return options, nil
+}
+
+func allFeedsMatchOptions(feeds []feedlist.Feed, options SubscribeOptions) bool {
 	for _, feed := range feeds {
-		if feed.UserAgent != userAgent {
+		if options.UserAgent != nil && feed.UserAgent != *options.UserAgent {
 			return false
+		}
+		if options.FeedType != nil {
+			if feed.Type != *options.FeedType {
+				return false
+			}
+			selector := ""
+			if options.ScrapeSelector != nil {
+				selector = *options.ScrapeSelector
+			}
+			if feed.ScrapeSelector != selector {
+				return false
+			}
 		}
 	}
 	return true

--- a/internal/subscription/subscription_test.go
+++ b/internal/subscription/subscription_test.go
@@ -395,6 +395,99 @@ func TestSubscribeWithUserAgentRejectsTextList(t *testing.T) {
 	}
 }
 
+func TestSubscribeWithScrapeConfiguration(t *testing.T) {
+	manager := New(&config.Config{})
+	filename := filepath.Join(t.TempDir(), "feeds.opml")
+	feedType := feedlist.FeedTypeScrape
+	selector := "article.card"
+
+	result, err := manager.SubscribeWithOptions(testFormatOPML, filename, []string{testURL1}, SubscribeOptions{
+		FeedType:       &feedType,
+		ScrapeSelector: &selector,
+	})
+	if err != nil {
+		t.Fatalf("SubscribeWithOptions() error = %v", err)
+	}
+	if result.AddedCount != 1 || result.UpdatedCount != 0 {
+		t.Fatalf("result = %#v, want one added feed", result)
+	}
+
+	list, err := feedlist.LoadFeedList(feedlist.FormatOPML, filename)
+	if err != nil {
+		t.Fatalf("LoadFeedList() error = %v", err)
+	}
+	feed := list.GetFeeds()[0]
+	if feed.Type != feedlist.FeedTypeScrape || feed.ScrapeSelector != selector {
+		t.Errorf("saved feed = %#v, want scrape selector %q", feed, selector)
+	}
+
+	updatedSelector := ".entry > a"
+	result, err = manager.SubscribeWithOptions(testFormatOPML, filename, []string{testURL1}, SubscribeOptions{
+		FeedType:       &feedType,
+		ScrapeSelector: &updatedSelector,
+	})
+	if err != nil {
+		t.Fatalf("SubscribeWithOptions() update error = %v", err)
+	}
+	if result.UpdatedCount != 1 {
+		t.Fatalf("UpdatedCount = %d, want 1", result.UpdatedCount)
+	}
+
+	rssType := feedlist.FeedTypeRSS
+	result, err = manager.SubscribeWithOptions(testFormatOPML, filename, []string{testURL1}, SubscribeOptions{
+		FeedType: &rssType,
+	})
+	if err != nil {
+		t.Fatalf("SubscribeWithOptions() RSS update error = %v", err)
+	}
+	if result.UpdatedCount != 1 {
+		t.Fatalf("RSS UpdatedCount = %d, want 1", result.UpdatedCount)
+	}
+	list, err = feedlist.LoadFeedList(feedlist.FormatOPML, filename)
+	if err != nil {
+		t.Fatalf("LoadFeedList() after RSS update error = %v", err)
+	}
+	feed = list.GetFeeds()[0]
+	if feed.Type != feedlist.FeedTypeRSS || feed.ScrapeSelector != "" {
+		t.Errorf("feed after RSS update = %#v, want RSS with empty selector", feed)
+	}
+}
+
+func TestSubscribeRejectsInvalidScrapeConfiguration(t *testing.T) {
+	manager := New(&config.Config{})
+	scrapeType := feedlist.FeedTypeScrape
+	rssType := feedlist.FeedTypeRSS
+	selector := ".post"
+	emptySelector := ""
+	badType := "html"
+
+	tests := []struct {
+		name    string
+		format  string
+		options SubscribeOptions
+	}{
+		{name: "text list", format: testFormatText, options: SubscribeOptions{FeedType: &scrapeType, ScrapeSelector: &selector}},
+		{name: "missing selector", format: testFormatOPML, options: SubscribeOptions{FeedType: &scrapeType}},
+		{name: "empty selector", format: testFormatOPML, options: SubscribeOptions{FeedType: &scrapeType, ScrapeSelector: &emptySelector}},
+		{name: "selector with RSS", format: testFormatOPML, options: SubscribeOptions{FeedType: &rssType, ScrapeSelector: &selector}},
+		{name: "selector without type", format: testFormatOPML, options: SubscribeOptions{ScrapeSelector: &selector}},
+		{name: "unknown type", format: testFormatOPML, options: SubscribeOptions{FeedType: &badType}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			filename := filepath.Join(t.TempDir(), "feeds.opml")
+			_, err := manager.SubscribeWithOptions(test.format, filename, []string{testURL1}, test.options)
+			if err == nil {
+				t.Fatal("SubscribeWithOptions() error = nil, want validation error")
+			}
+			if _, statErr := os.Stat(filename); !os.IsNotExist(statErr) {
+				t.Errorf("feed list created despite invalid options: stat error = %v", statErr)
+			}
+		})
+	}
+}
+
 func TestSubscribeDoesNotOverwriteMalformedFeedList(t *testing.T) {
 	manager := New(&config.Config{})
 	filename := filepath.Join(t.TempDir(), "feeds.opml")


### PR DESCRIPTION
## Summary

- add explicit OPML scrape parser configuration and subscription flags
- parse and deduplicate HTML links through the shared HTTP, cache, item, archive, and unfurl lifecycle
- persist and export parser configuration while using `first_seen` as the effective date for undated scraped items

## Test plan

- [x] `make format`
- [x] `make lint`
- [x] `make test`
- [x] `make build BINARY=/tmp/feedspool-issue-38`
- [x] `git diff --check`

## Notes

- PR #53 supplied the shared authoritative per-feed OPML configuration plumbing. After #53 merged, this branch was rebased directly onto `main`.
- Text feed lists remain RSS-only. In directory mode, OPML parser metadata wins when the same URL also appears in a text list.
- Scraped items intentionally leave `PublishedDate` unset and use the UTC-normalized `first_seen` fallback for filtering and presentation.

Closes #38
