### PR TITLE
Fix concurrent SQLite connection setup

### DIFF
--- a/docs/dev-sessions/2026-08-25-1741-database-lock/notes.md
+++ b/docs/dev-sessions/2026-08-25-1741-database-lock/notes.md
@@ -1,0 +1,45 @@
+# Session notes
+
+## Context
+
+- Branch: `fix/57-database-lock`
+- Worktree: `.claude/worktrees/issue-57-database-lock`
+- Base: `origin/main` at `1e389a4` after PR #55 merged.
+- Issue: https://github.com/lmorchard/feedspool-go/issues/57
+
+## Current state
+
+Implementation, project verification, and independent review are complete. The branch is ready to commit and open as a PR.
+
+## Decisions
+
+- Use SQLite's busy timeout to tolerate ordinary transient contention.
+- Avoid requesting WAL when the database already reports WAL mode.
+- Treat a failed pending migration as an initialization error rather than silently continuing.
+- Retry only typed SQLite busy errors while converting a non-WAL database, with a context-enforced five-second hard deadline.
+
+## Implemented
+
+- Configure the SQLite busy timeout before foreign-key, journal, or synchronous pragmas.
+- Limit the connection pool before setup so every pragma applies to the sole physical connection.
+- Read journal mode first and skip the write-like WAL pragma for initialized WAL databases.
+- Retry first-time WAL conversion after transient `SQLITE_BUSY` errors for at most five seconds.
+- Return migration failures from `IsInitialized` with context.
+- Added deterministic writer-lock tests, a 24-reader concurrent stress test, and migration failure coverage.
+
+## Verification
+
+- Focused issue tests — passed.
+- All focused issue tests with `-count=20` — passed.
+- `make format` — passed.
+- `make lint` — passed with 0 issues.
+- `make test` — passed for all packages.
+- `make build BINARY=/tmp/feedspool-issue-57` — passed.
+- `git diff --check` — passed.
+
+## Review
+
+- The initial independent review found no Important issues and two Minors: the busy handler could extend the retry beyond five seconds, and the WAL retry test lacked a deterministic first-attempt barrier.
+- The retry now uses `QueryRowContext` under a five-second context deadline.
+- The tests now signal the first locked conversion attempt, assert at least one typed busy retry, and separately verify deadline enforcement.
+- The narrow re-review confirmed both Minors are resolved and reported no remaining Important or Minor findings.

--- a/docs/dev-sessions/2026-08-25-1741-database-lock/plan.md
+++ b/docs/dev-sessions/2026-08-25-1741-database-lock/plan.md
@@ -1,0 +1,6 @@
+# Plan
+
+1. Add focused tests for concurrent opens, WAL preservation, and migration failure propagation.
+2. Configure connection setup in lock-safe order and avoid redundant WAL assignments.
+3. Run focused stress coverage and the complete project verification gates.
+4. Request an independent review, then commit, push, and open a PR closing issue #57.

--- a/docs/dev-sessions/2026-08-25-1741-database-lock/spec.md
+++ b/docs/dev-sessions/2026-08-25-1741-database-lock/spec.md
@@ -1,0 +1,22 @@
+# Concurrent database opens
+
+Issue: https://github.com/lmorchard/feedspool-go/issues/57
+
+## Goal
+
+Allow independent CLI processes to open and read the same initialized WAL database without sporadic `database is locked` failures during connection setup.
+
+## Design
+
+- Configure a five-second SQLite busy timeout before other connection setup.
+- Read the current journal mode and request WAL only when the database is not already using it.
+- Preserve per-connection foreign-key enforcement, synchronous mode, and the single-connection pool.
+- Return pending migration failures from `IsInitialized` instead of warning and continuing with a potentially incompatible schema.
+
+## Acceptance criteria
+
+- Concurrent opens and reads of an initialized WAL database succeed reliably.
+- Opening an existing WAL database does not execute a journal-mode change.
+- A new or non-WAL database is still converted to WAL.
+- Pending migration failures are explicit to callers.
+- Existing single-process behavior remains covered and passing.

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -1,19 +1,30 @@
 package database
 
 import (
+	"context"
 	"database/sql"
 	_ "embed"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/lmorchard/feedspool-go/internal/config"
 	"github.com/sirupsen/logrus"
-	_ "modernc.org/sqlite" // pure-Go sqlite driver, no CGO
+	modernsqlite "modernc.org/sqlite" // pure-Go sqlite driver, no CGO
+	sqlite3 "modernc.org/sqlite/lib"
 )
 
 //go:embed schema.sql
 var schemaSQL string
+
+const (
+	sqliteBusyTimeout       = 5 * time.Second
+	sqliteBusyTimeoutPragma = "PRAGMA busy_timeout = 5000"
+	sqliteRetryInterval     = 25 * time.Millisecond
+)
 
 // DB wraps a database connection with methods for feed operations.
 type DB struct {
@@ -33,15 +44,29 @@ func New(dbPath string) (*DB, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
+	conn.SetMaxOpenConns(1)
+	conn.SetMaxIdleConns(1)
+
+	if _, err := conn.Exec(sqliteBusyTimeoutPragma); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("failed to set busy timeout: %w", err)
+	}
 
 	if _, err := conn.Exec("PRAGMA foreign_keys = ON"); err != nil {
 		conn.Close()
 		return nil, fmt.Errorf("failed to enable foreign keys: %w", err)
 	}
 
-	if _, err := conn.Exec("PRAGMA journal_mode = WAL"); err != nil {
+	var journalMode string
+	if err := conn.QueryRow("PRAGMA journal_mode").Scan(&journalMode); err != nil {
 		conn.Close()
-		return nil, fmt.Errorf("failed to set journal mode: %w", err)
+		return nil, fmt.Errorf("failed to read journal mode: %w", err)
+	}
+	if !strings.EqualFold(journalMode, "wal") {
+		if err := enableWAL(conn, &journalMode); err != nil {
+			conn.Close()
+			return nil, fmt.Errorf("failed to set journal mode: %w", err)
+		}
 	}
 
 	if _, err := conn.Exec("PRAGMA synchronous = NORMAL"); err != nil {
@@ -49,11 +74,40 @@ func New(dbPath string) (*DB, error) {
 		return nil, fmt.Errorf("failed to set synchronous mode: %w", err)
 	}
 
-	conn.SetMaxOpenConns(1)
-	conn.SetMaxIdleConns(1)
-
 	logrus.Debug("Database connection established")
 	return &DB{conn: conn}, nil
+}
+
+func enableWAL(conn *sql.DB, journalMode *string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), sqliteBusyTimeout)
+	defer cancel()
+	return retrySQLiteBusy(ctx, func() error {
+		return conn.QueryRowContext(ctx, "PRAGMA journal_mode = WAL").Scan(journalMode)
+	})
+}
+
+func retrySQLiteBusy(ctx context.Context, operation func() error) error {
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		err := operation()
+		if err == nil || !isSQLiteBusy(err) {
+			return err
+		}
+		timer := time.NewTimer(sqliteRetryInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func isSQLiteBusy(err error) bool {
+	var sqliteErr *modernsqlite.Error
+	return errors.As(err, &sqliteErr) && sqliteErr.Code()&0xff == sqlite3.SQLITE_BUSY
 }
 
 // InitSchema initializes the database schema.
@@ -91,8 +145,7 @@ func (db *DB) IsInitialized() error {
 
 	// Run any pending migrations for existing databases
 	if err := db.RunMigrations(); err != nil {
-		logrus.Warnf("Failed to run migrations: %v", err)
-		// Don't fail here - the database is still usable even if migrations fail
+		return fmt.Errorf("failed to run migrations: %w", err)
 	}
 
 	return nil

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -1,0 +1,229 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestNewOpensExistingWALDatabaseDuringWrite(t *testing.T) {
+	dbPath := initializedDatabasePath(t)
+	writer := beginImmediate(t, dbPath)
+	defer rollback(t, writer)
+
+	db, err := New(dbPath)
+	if err != nil {
+		t.Fatalf("New() during WAL write = %v", err)
+	}
+	defer db.Close()
+
+	var count int
+	if err := db.conn.QueryRow("SELECT COUNT(*) FROM feeds").Scan(&count); err != nil {
+		t.Fatalf("concurrent read = %v", err)
+	}
+}
+
+func TestWALRetryWaitsForLockRelease(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "delete-mode.db")
+	seed, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := seed.Exec("CREATE TABLE seed (id INTEGER PRIMARY KEY)"); err != nil {
+		seed.Close()
+		t.Fatal(err)
+	}
+	if err := seed.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	writer := beginImmediate(t, dbPath)
+	candidate, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer candidate.Close()
+	if _, err := candidate.Exec("PRAGMA busy_timeout = 0"); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	attempted := make(chan struct{})
+	result := make(chan error, 1)
+	attempts := 0
+	var mode string
+	go func() {
+		result <- retrySQLiteBusy(ctx, func() error {
+			attempts++
+			if attempts == 1 {
+				close(attempted)
+			}
+			return candidate.QueryRowContext(ctx, "PRAGMA journal_mode = WAL").Scan(&mode)
+		})
+	}()
+	<-attempted
+
+	select {
+	case err := <-result:
+		rollback(t, writer)
+		t.Fatalf("WAL retry returned before lock release: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	rollback(t, writer)
+
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("WAL retry after lock release = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("WAL retry did not finish after lock release")
+	}
+	if attempts < 2 {
+		t.Fatalf("WAL attempts = %d, want a typed busy retry", attempts)
+	}
+	if !strings.EqualFold(mode, "wal") {
+		t.Fatalf("journal_mode = %q, want WAL", mode)
+	}
+}
+
+func TestWALRetryHonorsDeadline(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "locked.db")
+	seed, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := seed.Exec("CREATE TABLE seed (id INTEGER PRIMARY KEY)"); err != nil {
+		seed.Close()
+		t.Fatal(err)
+	}
+	if err := seed.Close(); err != nil {
+		t.Fatal(err)
+	}
+	writer := beginImmediate(t, dbPath)
+	defer rollback(t, writer)
+
+	candidate, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer candidate.Close()
+	if _, err := candidate.Exec("PRAGMA busy_timeout = 0"); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	var mode string
+	started := time.Now()
+	err = retrySQLiteBusy(ctx, func() error {
+		return candidate.QueryRowContext(ctx, "PRAGMA journal_mode = WAL").Scan(&mode)
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("WAL retry error = %v, want context deadline", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("WAL retry exceeded hard deadline by too much: %v", elapsed)
+	}
+}
+
+func TestConcurrentOpenAndRead(t *testing.T) {
+	dbPath := initializedDatabasePath(t)
+	const workers = 24
+	start := make(chan struct{})
+	errs := make(chan error, workers)
+	var group sync.WaitGroup
+	for range workers {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			<-start
+			db, err := New(dbPath)
+			if err != nil {
+				errs <- err
+				return
+			}
+			defer db.Close()
+			var count int
+			if err := db.conn.QueryRow("SELECT COUNT(*) FROM feeds").Scan(&count); err != nil {
+				errs <- err
+			}
+		}()
+	}
+	close(start)
+	group.Wait()
+	close(errs)
+	for err := range errs {
+		t.Errorf("concurrent open/read: %v", err)
+	}
+}
+
+func TestIsInitializedReturnsMigrationFailure(t *testing.T) {
+	db := setupTestDB(t)
+	if _, err := db.conn.Exec("DROP TABLE items"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.conn.Exec("DELETE FROM schema_migrations WHERE version = ?", migrationVersion9); err != nil {
+		t.Fatal(err)
+	}
+
+	err := db.IsInitialized()
+	if err == nil {
+		t.Fatal("IsInitialized() succeeded after a pending migration failed")
+	}
+	if !strings.Contains(err.Error(), "failed to run migrations") {
+		t.Fatalf("IsInitialized() error = %q, want migration context", err)
+	}
+}
+
+func initializedDatabasePath(t *testing.T) string {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "feeds.db")
+	db, err := New(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.InitSchema(); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return dbPath
+}
+
+func beginImmediate(t *testing.T, dbPath string) *sql.Conn {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	conn, err := db.Conn(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := conn.ExecContext(context.Background(), "BEGIN IMMEDIATE"); err != nil {
+		conn.Close()
+		t.Fatal(err)
+	}
+	return conn
+}
+
+func rollback(t *testing.T, conn *sql.Conn) {
+	t.Helper()
+	if conn == nil {
+		return
+	}
+	if _, err := conn.ExecContext(context.Background(), "ROLLBACK"); err != nil {
+		t.Errorf("rollback writer: %v", err)
+	}
+	if err := conn.Close(); err != nil {
+		t.Errorf("close writer: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- configure SQLite busy handling before connection setup
- avoid reapplying WAL mode to databases already using it
- retry first-time WAL conversion only for typed SQLite busy errors under a hard five-second deadline
- surface pending migration failures instead of continuing with an incompatible schema
- add deterministic lock, deadline, concurrent-reader, and migration regression tests

## Verification

- make format
- make lint
- make test
- focused issue tests repeated 20 times
- make build BINARY=/tmp/feedspool-issue-57
- independent review: no remaining Important or Minor findings

Closes #57