### PR TITLE
Full-text search over feed items with FTS5

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -145,7 +145,7 @@ linters:
         path: cmd/
       - linters:
           - forbidigo
-        path: cmd/(fetch|show|purge|export|render|serve|subscribe|unsubscribe|version)\.go
+        path: cmd/(fetch|show|purge|export|reindex|render|serve|subscribe|unsubscribe|version)\.go
       - linters:
           - nestif
         path: cmd/(fetch|purge|render|root)\.go

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -674,11 +674,27 @@ before the index existed.
 |---|---|---|
 | `--force` | false | Discard every derived row and rebuild from scratch |
 
-Use `--force` after changing how text is derived or tokenized — for example,
-if a future release changes the `porter` stemmer setting — since the stale
-rows otherwise look up to date and nothing else will invalidate them. Budget
-on the order of 30 seconds for a full rebuild on a 20,000-item spool (measured
-at 34.4s). A no-op run — nothing to do — is still slower than it looks: about
+Use `--force` for either of two reasons:
+
+- **After changing how text is derived or tokenized** — for example, if a
+  future release changes the `porter` stemmer setting — since the stale rows
+  otherwise look up to date and nothing else will invalidate them.
+- **After running an older `feedspool` against the database.** A release
+  rollback breaks the assumption the staleness check rests on: an older
+  binary's item writes update `items.title` and `items.content` without
+  touching `item_text`, and because the check ignores the source hash, the
+  derived row goes on looking current forever. Items the old binary *inserted*
+  are picked up by a plain `reindex` — they have no derived row at all — but
+  items it *updated* are only repaired by `--force`.
+
+Note that `--force` clears the derived text before the rebuild begins, and the
+rebuild commits in batches, so an interrupted `--force` leaves search returning
+nothing at all until it is run again. A plain `reindex` has no such window: it
+only fills in what is missing, so an interruption leaves the index partially
+built rather than empty.
+
+Budget on the order of 30 seconds for a full rebuild on a 20,000-item spool
+(measured at 34.4s). A no-op run — nothing to do — is still slower than it looks: about
 5 seconds wall time on the same spool, nearly all of it spent scanning for
 stale rows rather than doing any work.
 
@@ -797,7 +813,7 @@ curl -s 'localhost:8889/api/v1/items?limit=20&seen=false' | jq '.data[].title'
 | `feed_url` | exact feed URL | — |
 | `feed_query` | feed URL substring, case-insensitive | — |
 | `link` | exact item link | — |
-| `q` | full-text search over title, summary, and body | — |
+| `q` | full-text search over title, summary, and body; at most 2048 characters | — |
 | `since` / `until` | RFC3339, on discovery time | — |
 | `seen` | `true` \| `false` | both |
 | `archived` | `true` \| `false` \| `any` | `false` |
@@ -844,7 +860,10 @@ Three of these have sharp edges worth knowing:
   `NEAR` are searched for rather than treated as operators. A query of nothing
   but exclusions (`q=-draft` on its own) is a `400 invalid_parameter` — FTS5
   cannot answer "everything except X", and an empty result set would read as a
-  bug rather than a rejected query. `sort=relevance` ranks by `bm25()` (title
+  bug rather than a rejected query. **`q` is limited to 2048 characters**, also
+  a `400 invalid_parameter` past that: no search box comes near the cap, but
+  without one a single request can carry a chain of hundreds of thousands of
+  terms and hold the one database connection for as long as it takes to run. `sort=relevance` ranks by `bm25()` (title
   weighted above summary above body) and requires `q`; **`newest` stays the
   default sort even when `q` is given.** Remember that `archived` defaults to
   `false` here — a search against this endpoint sees fewer hits than the same
@@ -1271,7 +1290,7 @@ problem. Run with `-v` to see progress.
 
 ### `schema_migrations`
 
-Internal version tracking. Current version: 4.
+Internal version tracking. Current version: 11.
 
 ## SQL Recipes
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -365,11 +365,11 @@ shortcut; `--feed` instead performs a case-insensitive URL substring match.
 | Flag | Default | Description |
 |---|---|---|
 | `--feed` | (none) | Filter by feed URL substring |
-| `--search` | (none) | Filter by item title substring |
+| `--search` | (none) | Full-text search over title, summary, and body |
 | `--since` | (none) | Items first discovered after this RFC3339 timestamp |
 | `--until` | (none) | Items first discovered at or before this RFC3339 timestamp |
 | `--limit` | `0` | Maximum results (0 = all) |
-| `--sort` | `newest` | `newest` or `oldest` |
+| `--sort` | `newest` | `newest`, `oldest`, or `relevance` (requires `--search`) |
 | `--seen` | false | Only items carrying a `seen` annotation |
 | `--unseen` | false | Only items without a `seen` annotation |
 | `--mark-seen` | false | Add a `seen` annotation to returned items |
@@ -387,10 +387,37 @@ newly discovered post has an older publication date. Combined filters form the
 half-open cursor window `(since, until]`, so a saved `until` value can become
 the next run's `since` without repeating boundary items.
 
+**`--search` is a full-text search over an item's title, summary, and body,**
+indexed and ranked with SQLite's FTS5 rather than scanned as a substring. It
+was a title-only substring match early in this tool's life, but that never
+shipped in a tagged release — the `items` command itself postdates `v1.0.2` —
+so there is no released contract to preserve. It takes a small query language,
+spelled identically here and for the API's `?q=` below so the two surfaces
+never disagree about what a search matches:
+
+| Input | Meaning |
+| --- | --- |
+| `rust release` | both terms (implicit AND) |
+| `"release notes"` | phrase |
+| `-draft` | exclude |
+| `secur*` | prefix |
+
+Everything else is matched as literal text, so `C++`, `title:foo`, and `NEAR`
+are searched for rather than treated as operators. A query of nothing but
+exclusions (`-draft` on its own) exits nonzero — FTS5 cannot answer "everything
+except X", and returning zero rows would read as a bug rather than a rejected
+query.
+
+`--sort relevance` ranks results by `bm25()` — title weighted above summary
+above body — instead of discovery order, and requires `--search`. **`newest`
+stays the default sort even when `--search` is given**; a search does not by
+itself imply you want relevance order over the usual newest-first feed.
+
 ```bash
 feedspool --json items --since 2026-08-25T12:00:00Z
 feedspool --json items --compact --since 2026-08-25T12:00:00Z
 feedspool items --feed example.com --search "release notes" --limit 20
+feedspool items --search "container networking" --sort relevance --limit 20
 ```
 
 **Side effects:** Read-only unless `--mark-seen` is set.
@@ -633,6 +660,34 @@ subscription list are deleted. ON DELETE CASCADE removes their items.
 }
 ```
 
+### reindex
+
+Bring the full-text search index (`item_text` and `items_fts`, see
+[Data Model](#data-model)) up to date. Ordinary use needs no flags: fetching
+already derives and indexes text for every item it writes, so this command
+only fills in whatever is missing — freshly migrated rows, or items written
+before the index existed.
+
+**Usage:** `feedspool reindex [flags]`
+
+| Flag | Default | Description |
+|---|---|---|
+| `--force` | false | Discard every derived row and rebuild from scratch |
+
+Use `--force` after changing how text is derived or tokenized — for example,
+if a future release changes the `porter` stemmer setting — since the stale
+rows otherwise look up to date and nothing else will invalidate them. Budget
+on the order of 30 seconds for a full rebuild on a 20,000-item spool (measured
+at 34.4s). A no-op run — nothing to do — is still slower than it looks: about
+5 seconds wall time on the same spool, nearly all of it spent scanning for
+stale rows rather than doing any work.
+
+Progress prints to stdout rather than the log, because a rebuild of a large
+spool can run for tens of seconds and the default log level would otherwise
+make it indistinguishable from a hang.
+
+**Side effects:** Writes `item_text`; `--force` also truncates it first.
+
 ### export
 
 Write all feeds currently in the database to a subscription file.
@@ -742,11 +797,11 @@ curl -s 'localhost:8889/api/v1/items?limit=20&seen=false' | jq '.data[].title'
 | `feed_url` | exact feed URL | — |
 | `feed_query` | feed URL substring, case-insensitive | — |
 | `link` | exact item link | — |
-| `q` | item **title** substring, case-insensitive | — |
+| `q` | full-text search over title, summary, and body | — |
 | `since` / `until` | RFC3339, on discovery time | — |
 | `seen` | `true` \| `false` | both |
 | `archived` | `true` \| `false` \| `any` | `false` |
-| `sort` | `newest` \| `oldest` | `newest` |
+| `sort` | `newest` \| `oldest` \| `relevance` (requires `q`) | `newest` |
 | `limit` | 1–200 | 50 |
 | `cursor` | opaque continuation token | — |
 | `include` | `content`, `raw`, `metadata`, `annotations` | none |
@@ -770,10 +825,30 @@ Three of these have sharp edges worth knowing:
   every time. Note that items are *ordered* by the opposite precedence
   (`published_date` falling back to `first_seen`), so `discovered_at` is a
   polling key, not a sort key.
-- **`q` matches titles only**, not body or summary — the same limitation as
-  `feedspool items --search`. Deliberately identical rather than a second,
-  subtly different search. Tracked in
-  [#58](https://github.com/lmorchard/feedspool-go/issues/58).
+- **`q` is a full-text search over an item's title, summary, and body,**
+  indexed and ranked with SQLite's FTS5, spelled identically to
+  `feedspool items --search` so the two surfaces never disagree about what a
+  search matches. This endpoint has never shipped in a tagged release — it
+  merged after `v1.0.2` and exists only in the `latest` dev prerelease — so
+  there was never a released substring contract to preserve; what you see here
+  is what `q` has always meant. It accepts a small query language:
+
+  | Input | Meaning |
+  | --- | --- |
+  | `rust release` | both terms (implicit AND) |
+  | `"release notes"` | phrase |
+  | `-draft` | exclude |
+  | `secur*` | prefix |
+
+  Everything else is matched as literal text, so `C++`, `title:foo`, and
+  `NEAR` are searched for rather than treated as operators. A query of nothing
+  but exclusions (`q=-draft` on its own) is a `400 invalid_parameter` — FTS5
+  cannot answer "everything except X", and an empty result set would read as a
+  bug rather than a rejected query. `sort=relevance` ranks by `bm25()` (title
+  weighted above summary above body) and requires `q`; **`newest` stays the
+  default sort even when `q` is given.** Remember that `archived` defaults to
+  `false` here — a search against this endpoint sees fewer hits than the same
+  search on `feedspool items` unless you also pass `archived=any`.
 
 **Unknown parameters are rejected with a 400** rather than ignored, so
 `?limitt=10` tells you about the typo instead of quietly returning the default
@@ -1140,6 +1215,60 @@ Unfurl results, keyed by item link URL.
 A row with `fetch_status_code` in 2xx is considered final; failures may be
 retried per `--retry-after`.
 
+### `item_text`
+
+HTML-stripped derived text for full-text search, one row per item. This is
+the canonical text both search and (per #30) any future embedding work index
+against, kept separate from `items` so the raw markup never leaks into search
+results.
+
+| Column | Type | Notes |
+|---|---|---|
+| `item_id` | INTEGER PK | FK → `items.id`, ON DELETE CASCADE |
+| `title` | TEXT | Stripped title |
+| `summary` | TEXT | Stripped summary |
+| `body` | TEXT | Stripped content, truncated at 256 KiB as a bloat guard |
+| `source_hash` | TEXT | Hash of the source columns this row was derived from |
+| `generator` | TEXT | Name of the derivation logic that produced this row |
+| `generator_version` | INTEGER | Bumped when derivation logic changes; drives staleness checks |
+| `computed_at` | DATETIME | |
+
+`feedspool fetch` keeps this table current as items are written.
+`feedspool reindex` fills in anything missing (a fresh migration, or items
+written before the index existed); `reindex --force` discards and rebuilds
+every row, which is what a change to `generator_version` calls for.
+
+### `items_fts`
+
+An external-content FTS5 virtual table indexing `item_text`, maintained by
+triggers on `item_text` rather than by application code — the triggers are
+what make deletes through `ON DELETE CASCADE` (dropping a feed, purging items)
+keep the index consistent without a code path that has to remember to update
+it.
+
+```sql
+CREATE VIRTUAL TABLE items_fts USING fts5(
+    title, summary, body,
+    content='item_text', content_rowid='item_id',
+    tokenize="porter unicode61 remove_diacritics 2"
+);
+```
+
+`porter` stemming means a search for `network` also matches `networking` and
+`networked`, and `secur*` and `security` both match `secure`. It costs a
+little precision on an exact known-item lookup, in exchange for recall on
+everything else — kept as the default. Search ranks matches with
+`bm25(items_fts, 10.0, 4.0, 1.0)`, weighting a title hit above a summary hit
+above a body hit.
+
+Upgrading an existing database runs a one-time backfill (migration 11) that
+derives text for every item already in the spool, alongside whatever earlier
+migrations also need to run. On a 19,750-item production spool, migrating from
+schema v4 to v11 took 23.5 seconds wall time end to end and grew the database
+file by about 24%; it is quiet at the default log level, so an upgrade that
+appears to hang for a few dozen seconds is this backfill running, not a
+problem. Run with `-v` to see progress.
+
 ### `schema_migrations`
 
 Internal version tracking. Current version: 4.
@@ -1158,15 +1287,25 @@ ORDER BY i.published_date DESC
 LIMIT 50;
 ```
 
-**Items mentioning a topic:**
+**Items mentioning a topic, best matches first:**
+
+The same index `feedspool items --search` and `?q=` use, queried directly.
+Note the table is joined unaliased — `MATCH` and `bm25()` need the FTS table's
+own name, not an alias:
 
 ```sql
 SELECT i.published_date, i.title, i.link
 FROM items i
-WHERE i.archived = 0
-  AND (i.title LIKE '%foo%' OR i.content LIKE '%foo%' OR i.summary LIKE '%foo%')
-ORDER BY i.published_date DESC;
+JOIN items_fts ON items_fts.rowid = i.id
+WHERE items_fts MATCH '"container networking"'
+  AND i.archived = 0
+ORDER BY bm25(items_fts, 10.0, 4.0, 1.0) ASC
+LIMIT 20;
 ```
+
+`MATCH` takes raw FTS5 syntax here, not the small query language the CLI and
+API accept — quote a phrase yourself, and `AND`/`OR`/`NOT`/`NEAR`/`col:` are
+live operators rather than literal text.
 
 **Feeds that have not produced anything recently:**
 

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -1,5 +1,7 @@
 package cmd
 
+import "github.com/lmorchard/feedspool-go/internal/database"
+
 const (
 	// Common defaults.
 	defaultOutputDir = "./build"
@@ -13,8 +15,12 @@ const (
 	formatJSON  = "json"
 	formatTable = "table"
 	formatCSV   = "csv"
-	sortOldest  = "oldest"
-	sortNewest  = "newest"
+
+	// The sort names are the database package's, not the CLI's own: the same
+	// spellings reach the query builder, so a copy here could drift from it.
+	sortOldest    = database.SortOldest
+	sortNewest    = database.SortNewest
+	sortRelevance = database.SortRelevance
 
 	// Queries.
 	queryFindItemByLink = `SELECT feed_url, guid FROM items WHERE link = ? LIMIT 1`

--- a/cmd/items.go
+++ b/cmd/items.go
@@ -36,6 +36,7 @@ timestamps. Invalid flags and conflicting filters exit non-zero.`,
   feedspool --json items --feed example.com
   feedspool --json items --compact --since 2026-08-25T12:00:00Z
   feedspool items --search "release notes" --limit 20
+  feedspool items --search "container networking" --sort relevance
   feedspool items https://example.com/feed.xml`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runItems,
@@ -43,7 +44,7 @@ timestamps. Invalid flags and conflicting filters exit non-zero.`,
 
 func init() {
 	itemsCmd.Flags().StringVar(&itemsFormat, "format", formatTable, "Output format (table|json|csv)")
-	itemsCmd.Flags().StringVar(&itemsSort, "sort", "newest", "Sort order (newest|oldest)")
+	itemsCmd.Flags().StringVar(&itemsSort, "sort", sortNewest, "Sort order (newest|oldest|relevance)")
 	itemsCmd.Flags().IntVar(&itemsLimit, "limit", 0, "Maximum items to return (0 for all)")
 	itemsCmd.Flags().StringVar(&itemsSince, "since", "", "Filter items discovered after time (RFC3339)")
 	itemsCmd.Flags().StringVar(&itemsUntil, "until", "", "Filter items discovered until time (RFC3339)")
@@ -51,7 +52,7 @@ func init() {
 	itemsCmd.Flags().BoolVar(&itemsSeen, "seen", false, "Filter to items with a seen annotation")
 	itemsCmd.Flags().BoolVar(&itemsMarkSeen, "mark-seen", false, "Mark all returned items as seen")
 	itemsCmd.Flags().StringVar(&itemsFeed, "feed", "", "Filter by feed URL substring")
-	itemsCmd.Flags().StringVar(&itemsSearch, "search", "", "Filter by item title substring")
+	itemsCmd.Flags().StringVar(&itemsSearch, "search", "", "Full-text search over title, summary and body")
 	itemsCmd.Flags().BoolVar(&itemsCompact, "compact", false, "Emit a compact JSON manifest")
 	rootCmd.AddCommand(itemsCmd)
 }
@@ -86,6 +87,7 @@ func runItems(_ *cobra.Command, args []string) error {
 		FeedURL:   feedURL,
 		FeedQuery: itemsFeed,
 		Search:    itemsSearch,
+		Sort:      itemsSort,
 		Limit:     itemsLimit,
 		Since:     since,
 		Until:     until,
@@ -98,6 +100,8 @@ func runItems(_ *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Only the oldest-first ordering is produced by reversing; relevance arrives
+	// already ranked best-first, and reversing it would surface the worst match.
 	if itemsSort == sortOldest {
 		reverseItemsList(items)
 	}
@@ -126,8 +130,11 @@ func validateItemsOptions(args []string) error {
 	if itemsSeen && itemsUnseen {
 		return fmt.Errorf("--seen cannot be combined with --unseen")
 	}
-	if itemsSort != sortNewest && itemsSort != sortOldest {
+	if itemsSort != sortNewest && itemsSort != sortOldest && itemsSort != sortRelevance {
 		return fmt.Errorf("unknown sort order: %s", itemsSort)
+	}
+	if itemsSort == sortRelevance && itemsSearch == "" {
+		return fmt.Errorf("--sort relevance requires --search")
 	}
 	return nil
 }

--- a/cmd/reindex.go
+++ b/cmd/reindex.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/lmorchard/feedspool-go/internal/database"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -44,12 +43,21 @@ func runReindex(_ *cobra.Command, _ []string) error {
 	}
 
 	if reindexForce {
-		logrus.Info("Discarding every derived row before rebuilding")
+		fmt.Println("Discarding all derived text before rebuilding...")
 	}
-	if err := db.ReindexItemText(reindexForce, database.ItemTextProgressLogger()); err != nil {
+	fmt.Println("Updating full-text search index...")
+
+	// Progress goes to stdout rather than logrus: a rebuild of a large spool
+	// runs for tens of seconds, and the default log level is Warn, so a command
+	// reporting at info level would be indistinguishable from one doing nothing.
+	var indexed int64
+	if err := db.ReindexItemText(reindexForce, func(done, total int64) {
+		indexed = done
+		fmt.Printf("Indexed %d of %d items\n", done, total)
+	}); err != nil {
 		return err
 	}
 
-	logrus.Info("Search index is up to date")
+	fmt.Printf("Search index is up to date (%d items indexed)\n", indexed)
 	return nil
 }

--- a/cmd/reindex.go
+++ b/cmd/reindex.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/lmorchard/feedspool-go/internal/database"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var reindexForce bool
+
+var reindexCmd = &cobra.Command{
+	Use:   "reindex",
+	Short: "Rebuild the full-text search index",
+	Long: `Derive search text for any items that lack it and bring the full-text
+search index up to date. Ordinary use needs no flags: fetching maintains the
+index, and this command only fills in what is missing.
+
+Use --force after changing how text is derived or tokenized. It discards every
+derived row and rebuilds from the items themselves, which takes as long as the
+original migration did.`,
+	Example: `  feedspool reindex
+  feedspool reindex --force`,
+	Args: cobra.NoArgs,
+	RunE: runReindex,
+}
+
+func init() {
+	reindexCmd.Flags().BoolVar(&reindexForce, "force", false,
+		"Discard and rebuild every derived row, e.g. after a tokenizer change")
+	rootCmd.AddCommand(reindexCmd)
+}
+
+func runReindex(_ *cobra.Command, _ []string) error {
+	cfg := GetConfig()
+	db, err := database.New(cfg.Database)
+	if err != nil {
+		return fmt.Errorf("failed to connect to database: %w", err)
+	}
+	defer db.Close()
+	if err := db.IsInitialized(); err != nil {
+		return err
+	}
+
+	if reindexForce {
+		logrus.Info("Discarding every derived row before rebuilding")
+	}
+	if err := db.ReindexItemText(reindexForce, database.ItemTextProgressLogger()); err != nil {
+		return err
+	}
+
+	logrus.Info("Search index is up to date")
+	return nil
+}

--- a/cmd/reindex.go
+++ b/cmd/reindex.go
@@ -16,9 +16,15 @@ var reindexCmd = &cobra.Command{
 search index up to date. Ordinary use needs no flags: fetching maintains the
 index, and this command only fills in what is missing.
 
-Use --force after changing how text is derived or tokenized. It discards every
-derived row and rebuilds from the items themselves, which takes as long as the
-original migration did.`,
+Use --force after changing how text is derived or tokenized, or after running
+an older feedspool against this database. It discards every derived row and
+rebuilds from the items themselves, which takes as long as the original
+migration did.
+
+--force clears the index before the rebuild starts, and the rebuild commits in
+batches, so an interrupted --force leaves search returning nothing until it is
+run again. A plain reindex has no such window: it only fills in what is
+missing.`,
 	Example: `  feedspool reindex
   feedspool reindex --force`,
 	Args: cobra.NoArgs,
@@ -27,7 +33,7 @@ original migration did.`,
 
 func init() {
 	reindexCmd.Flags().BoolVar(&reindexForce, "force", false,
-		"Discard and rebuild every derived row, e.g. after a tokenizer change")
+		"Discard and rebuild every derived row; search returns nothing if interrupted")
 	rootCmd.AddCommand(reindexCmd)
 }
 

--- a/cmd/reindex.go
+++ b/cmd/reindex.go
@@ -53,7 +53,7 @@ func runReindex(_ *cobra.Command, _ []string) error {
 	var indexed int64
 	if err := db.ReindexItemText(reindexForce, func(done, total int64) {
 		indexed = done
-		fmt.Printf("Indexed %d of %d items\n", done, total)
+		fmt.Printf("Indexed %d of %d outstanding items\n", done, total)
 	}); err != nil {
 		return err
 	}

--- a/docs/dev-sessions/2026-08-26-1247-fts5-search/notes.md
+++ b/docs/dev-sessions/2026-08-26-1247-fts5-search/notes.md
@@ -154,6 +154,48 @@ above says "migrating from schema v4 to v11," which made the stale line read
 as a contradiction rather than as staleness. The final review pass corrected
 it to 11.
 
+## Two follow-up candidates, with the reasoning that produced them
+
+Recorded here because the working notes that held them do not survive the
+session.
+
+**`reindex --force` empties the index before refilling it.** The `DELETE FROM
+item_text` commits on its own, then the backfill runs in batches, so an
+interruption in between leaves search returning nothing until someone re-runs
+the command. That window is documented in `MANUAL.md`, in `reindex --help`, and
+in the `--force` flag description rather than closed, and the reasoning is worth
+keeping: folding the delete into the first batch would need a new pre-batch hook
+on the shared `RunBackfill` path that #30 is expected to implement against, and
+it would still put a full-table delete plus every triggered FTS delete into one
+transaction — which is the exact thing the batching exists to avoid.
+
+The better fix, deferred rather than rejected: mark the rows stale
+(`UPDATE item_text SET generator_version = -1`) instead of deleting them. The
+backfill's staleness predicate already treats a version mismatch as work to do,
+so every row gets re-derived, and the index is never empty at any point. It
+needs a think about what a `-1` sentinel means to a second generator before
+being worth doing.
+
+**Migration 11 is quiet at the default log level.** It is on logrus like the
+other ten migrations, so a first run after upgrading prints nothing for ~24s on
+a 20k-item spool — and because `IsInitialized` runs migrations, the command that
+pays that cost is usually an incidental `feedspool status` or a cron
+`feedspool fetch`, not something the user chose to run. The other migrations are
+fast enough that their silence is invisible; this is the first one where it is
+not. `MANUAL.md` documents the one-time cost as a stopgap. The real fix is to
+thread a progress callback through `RunMigrations`, which is a change to shared
+migration machinery and deserves its own issue rather than being smuggled in
+here.
+
+## A grammar edge worth knowing
+
+Control characters in a search query fold to whitespace, which is what stops a
+NUL byte from becoming an FTS5 syntax error and a 500. One consequence: in
+adversarial input like `-<NUL>draft`, the fold separates the `-` from the term,
+so the exclusion marker is dropped and `draft` becomes a positive term instead.
+No error, no crash, and no realistic query looks like that — but it is the one
+place folding changes meaning rather than just spelling.
+
 ## For whoever picks this up next
 
 - The feature is done and reviewed through phase 6; this phase is

--- a/docs/dev-sessions/2026-08-26-1247-fts5-search/notes.md
+++ b/docs/dev-sessions/2026-08-26-1247-fts5-search/notes.md
@@ -44,8 +44,12 @@ old database that had never seen migrations 5–11).
 
 **Migration.** 23.5 seconds wall time for migrations 5 through 11 together
 (not migration 11 alone — this database needed all of them). All 19,750 items
-ended up indexed; SQLite's FTS5 integrity check (`INSERT INTO items_fts(items_fts)
-VALUES('integrity-check')`) came back clean afterward.
+ended up indexed; SQLite's FTS5 integrity check came back clean afterward —
+the strong form, `INSERT INTO items_fts(items_fts, rank)
+VALUES('integrity-check', 1)`, which is what actually ran. The `rank`
+argument is the whole point: the bare `('integrity-check')` only checks the
+index's internal consistency and passes happily on an index that has drifted
+from its content table. See the correction in `research.md`.
 
 **Disk.** 478,056,448 → 593,018,880 bytes, +24%. That's the cost of a second
 copy of every item's stripped text plus the inverted index over it.
@@ -141,13 +145,14 @@ spool that's ~24 seconds of apparent hang during an otherwise-instant
 `items_fts` in the Data Model section so a future upgrade isn't mistaken for
 a stuck migration.
 
-## Loose end noticed, not fixed
+## Loose end noticed, then fixed
 
-`MANUAL.md`'s `schema_migrations` entry says "Current version: 4," which
-predates this work by a long way — the schema is now at version 11. Out of
-scope for this phase (nothing here asked for it, and it's not related to
-FTS5), but worth a follow-up pass since it's directly under the tables this
-phase just documented.
+`MANUAL.md`'s `schema_migrations` entry said "Current version: 4," which
+predated this work by a long way — the schema is now at version 11. It was
+first left alone as out of scope, but this phase's own text a few paragraphs
+above says "migrating from schema v4 to v11," which made the stale line read
+as a contradiction rather than as staleness. The final review pass corrected
+it to 11.
 
 ## For whoever picks this up next
 

--- a/docs/dev-sessions/2026-08-26-1247-fts5-search/notes.md
+++ b/docs/dev-sessions/2026-08-26-1247-fts5-search/notes.md
@@ -1,0 +1,163 @@
+# Session Notes: FTS5 Full-Text Search
+
+**Issue:** [#58](https://github.com/lmorchard/feedspool-go/issues/58)
+**Branch:** `feat/58-fts5-search` (worktree at `.claude/worktrees/issue-58-fts5-search`)
+**Status:** Complete. All seven phases committed; documentation is the last
+phase and this note closes it out.
+
+## What shipped
+
+`feedspool items --search` and `GET /api/v1/items?q=` both do real full-text
+search now — title, summary, and body, ranked by `bm25()` — replacing the old
+case-insensitive title-substring match. Both surfaces accept the same small
+query language (implicit AND, `"phrase"`, `-exclude`, `prefix*`); everything
+else is literal text, so `C++`, `title:foo`, and `NEAR` are searched for
+rather than parsed as syntax. A query of nothing but exclusions is rejected
+(exit 1 / `400 invalid_parameter`) rather than silently returning nothing.
+
+`--sort relevance` / `sort=relevance` join `newest`/`oldest` and require a
+search; `newest` stays the default even with a search present. A new
+`feedspool reindex [--force]` command fills in missing derived text or forces
+a full rebuild.
+
+Underneath: migration 11 adds `item_text` (HTML-stripped title/summary/body
+plus `source_hash`/`generator`/`generator_version`/`computed_at` bookkeeping)
+and an external-content FTS5 virtual table `items_fts`, kept in sync by
+triggers on `item_text`. Go derives and writes `item_text` on every item
+write; triggers handle deletes, which is what reaches the `ON DELETE CASCADE`
+path `DeleteFeed` and purge use without any FTS-aware code there.
+
+See `MANUAL.md` for the user-facing contract (the `items` and `reindex`
+subcommand sections, the API's "Reading items" section, the `item_text` /
+`items_fts` entries under Data Model, and a worked `bm25()` query under SQL
+Recipes) and `spec.md` / `research.md` / `plan.md` in this directory for the
+design rationale and phase-by-phase implementation record.
+
+## Smoke test against a real database
+
+Phase 7 called for running the full smoke test against a copy of a real
+production spool rather than synthetic fixtures — the kind of test that
+catches problems synthetic data can't: is the migration actually fast enough,
+does ranking actually look better, are the size assumptions in the spec
+right. This ran against a pristine copy of a 19,750-item spool, schema v4 (an
+old database that had never seen migrations 5–11).
+
+**Migration.** 23.5 seconds wall time for migrations 5 through 11 together
+(not migration 11 alone — this database needed all of them). All 19,750 items
+ended up indexed; SQLite's FTS5 integrity check (`INSERT INTO items_fts(items_fts)
+VALUES('integrity-check')`) came back clean afterward.
+
+**Disk.** 478,056,448 → 593,018,880 bytes, +24%. That's the cost of a second
+copy of every item's stripped text plus the inverted index over it.
+
+**`reindex` with nothing to do.** 5.07 seconds wall time but only 0.6 seconds
+of CPU — it's I/O bound scanning for staleness, not doing any real work. Slow
+for a no-op; worth knowing if something ever calls `reindex` on a schedule
+expecting it to be instant when idle.
+
+**`reindex --force`.** 34.4 seconds — a full rebuild from scratch, somewhat
+slower than the original combined migration despite doing less schema work,
+which tracks: it's pure backfill with no DDL to amortize the cost against.
+Integrity check clean afterward.
+
+**Ranking quality — the judgment that actually matters.** This is the part a
+timing number can't tell you: relevance ordering is *visibly* better than date
+order on this corpus, not just technically correct.
+- `kubernetes` by date surfaces AI-digest aggregator posts that mention the
+  word in passing, buried among unrelated content. By relevance, the top four
+  results are all genuinely about Kubernetes, with the term in the title.
+- `privacy` by date returns a measles outbreak story and an unrelated job
+  posting (probably a body-text coincidence). By relevance: a TikTok privacy
+  settlement, a privacy compliance role, and a privacy lawsuit — all on
+  point.
+
+**Body reach is real, not just theoretical.** Date-ordered results for these
+same queries include body-only matches — items where the search term never
+appears in the title — that a title-only search could never have surfaced.
+This is the actual point of #58, and it's confirmed on real data rather than
+just in a unit test with a hand-built fixture.
+
+**Grammar on real data.**
+- Phrase narrows: a bare-terms query at 730 hits dropped to 164 once quoted
+  as a phrase.
+- Exclusion narrows: 449 hits dropped to 228 once a `-term` exclusion was
+  added.
+- Prefix widens only slightly: `secur` alone was 1327 hits, `secur*` only
+  1332. See stemming, below — this is why.
+
+**Truncation cap: fine as-is.** The largest derived body on this corpus is
+258,150 bytes against the 262,144-byte (256 KiB) cap — nothing is actually
+truncated, but the largest real item sits at 98.5% of the limit. 76 items
+(out of 19,750) exceed 64 KiB; the mean is roughly 2.6 KiB. **Answered open
+question: leave the cap where it is.** It's comfortably ahead of the largest
+real item today, and 98.5% is close enough that raising it "for headroom"
+would be premature — revisit only if a future corpus actually hits it.
+
+**Porter stemming: doing real work, kept as-is.** Prefix search (`secur*`
+vs `secur`) adds almost nothing on this corpus, and the reason is that porter
+stemming already conflates `secure`/`security`/`securing` into the same stem
+— so a search for `security` already recall-matches nearly everything a
+prefix search would have added by hand. **Answered open question:** this
+isn't a wash, it's stemming visibly pulling its weight. Recorded as answered
+and kept, not left open.
+
+**CLI and API agree on real data.** With `archived=any`, the API returns
+exactly the same 57 items for `kubernetes` as the CLI does, in identical rank
+order — the shared query-building code (`search_sql.go`) is doing its job.
+Without `archived=any`, the API's `archived=false` default cuts that to 34 —
+see below.
+
+**Relevance pagination holds together.** Paging through `kubernetes` results
+in pages of 7 (9 pages) collected all 57 ids, all distinct, in the same order
+as a single page with `limit=200`. The offset-in-cursor design for
+`sort=relevance` (as opposed to the keyset cursor date sorts use) isn't
+losing or duplicating rows under real pagination.
+
+**Pre-existing log noise, not introduced here.** Migrating this database
+printed four `Failed to rollback transaction` warnings at the default log
+level, and nothing else. This is an existing codebase idiom — a transaction
+that already committed still runs its deferred rollback, which errors
+harmlessly and gets logged as a warning (see `internal/database/db.go:184`
+and `internal/database/migrations.go:308`) — not something phase 7's smoke
+test introduced. It is, however, what a real upgrade actually looks like on
+the console, so it's worth knowing before you go looking for a bug that isn't
+there.
+
+## Two things worth knowing that weren't in the original spec
+
+**The API's `archived=false` default bites harder in a search context than a
+browse context.** It's already documented as a general divergence between the
+CLI (which includes archived items by default) and the API (which doesn't),
+but a user typing a search into the API and getting 34 results instead of the
+57 the CLI would give them for the same query is a much easier default to
+trip over than "my item list is 40% smaller than I expected." `MANUAL.md`'s
+search sections now point at `archived=any` explicitly rather than relying on
+the reader to have already read the general pagination caveat.
+
+**Upgrading is quiet, not broken.** Migration 11's backfill has no progress
+output at the default log level (Warn) — only at `-v` (Info). On a 20k-item
+spool that's ~24 seconds of apparent hang during an otherwise-instant
+`fetch` or `status` invocation. `MANUAL.md` now says this plainly under
+`items_fts` in the Data Model section so a future upgrade isn't mistaken for
+a stuck migration.
+
+## Loose end noticed, not fixed
+
+`MANUAL.md`'s `schema_migrations` entry says "Current version: 4," which
+predates this work by a long way — the schema is now at version 11. Out of
+scope for this phase (nothing here asked for it, and it's not related to
+FTS5), but worth a follow-up pass since it's directly under the tables this
+phase just documented.
+
+## For whoever picks this up next
+
+- The feature is done and reviewed through phase 6; this phase is
+  documentation only, no code changed.
+- If `porter` or the 256 KiB cap ever need reconsidering, this note has the
+  measurements that justified leaving them alone — don't just eyeball the
+  spec's original guesses.
+- The smoke test was against one real spool. If a much larger or very
+  differently-shaped corpus (e.g., mostly very long body text, or many more
+  feeds) becomes available, it would be worth re-running the same checks —
+  particularly the truncation-cap headroom and the no-op `reindex` I/O cost,
+  since both are workload-shape-dependent.

--- a/docs/dev-sessions/2026-08-26-1247-fts5-search/plan.md
+++ b/docs/dev-sessions/2026-08-26-1247-fts5-search/plan.md
@@ -1,0 +1,1161 @@
+# Full-Text Search Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: use `superpowers:subagent-driven-development`
+> (recommended) or `superpowers:executing-plans` to implement this plan phase by
+> phase. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace title-substring search with FTS5 over title + summary + body,
+ranked by `bm25()`, on both `feedspool items --search` and
+`GET /api/v1/items?q=`, leaving behind a canonical item-text substrate for #30.
+
+**Approach:** A Go function derives HTML-stripped text into an `item_text`
+table; an external-content `items_fts` virtual table indexes it, maintained by
+triggers on `item_text`. Go owns inserts and updates (stripping is Go code);
+triggers own deletes, which is what reaches the `ON DELETE CASCADE` path that
+`DeleteFeed` uses. Search becomes one more `WHERE` condition in both query
+builders.
+
+**Tech stack:** Go 1.25, `modernc.org/sqlite` (FTS5, `CGO_ENABLED=0`),
+`golang.org/x/net/html`, Cobra.
+
+**Spec:** `docs/dev-sessions/2026-08-26-1247-fts5-search/spec.md`
+**Research:** `docs/dev-sessions/2026-08-26-1247-fts5-search/research.md`
+
+## Global constraints
+
+- `make build`, never `go build`. `CGO_ENABLED=0` is load-bearing — no cgo, no
+  C extensions, no new SQLite driver.
+- `make format && make lint && make test` after every phase. `make lint` uses
+  the golangci-lint version pinned in the Makefile; do not install another.
+- Lint is strict about `goconst` (hoist repeated string literals, including in
+  tests) and `gochecknoglobals` (package-level `var` slices/maps become
+  functions). Budget a cleanup pass in each phase that adds a package.
+- `internal/` gets tests; `cmd/` does not need them.
+- One commit per phase, message `Phase N: <name>`.
+- The CLI and the API must never disagree about what a query matches. Every
+  phase that touches matching touches both, or explains why not.
+
+---
+
+## Phase 1: `internal/itemtext` — canonical text derivation
+
+The one function that answers "what text represents this item?". Pure, no
+database. #30's embedder is intended to call the same function with a smaller
+truncation cap.
+
+**Files:**
+- Create: `internal/itemtext/itemtext.go`
+- Test: `internal/itemtext/itemtext_test.go`
+
+**Key changes:**
+
+```go
+package itemtext
+
+// Generator and Version identify this derivation in item_text bookkeeping.
+// Bump Version whenever the output of Derive changes for the same input --
+// that is what forces a reindex.
+const (
+	Generator = "itemtext"
+	Version   = 1
+)
+
+// DefaultMaxBodyBytes is a bloat guard, not a recall limit: long-form articles
+// run well under it. #30 will pass a far smaller cap for embedding token
+// limits, which is why this is an option rather than a constant in Derive.
+const (
+	DefaultMaxTitleBytes   = 4 * 1024
+	DefaultMaxSummaryBytes = 32 * 1024
+	DefaultMaxBodyBytes    = 256 * 1024
+)
+
+type Options struct {
+	MaxTitleBytes   int
+	MaxSummaryBytes int
+	MaxBodyBytes    int
+}
+
+func DefaultOptions() Options
+
+type Text struct {
+	Title   string
+	Summary string
+	Body    string
+}
+
+// Derive strips HTML, decodes entities, collapses whitespace and truncates.
+func Derive(title, summary, content string, opts Options) Text
+
+// SourceHash fingerprints the raw inputs so an unchanged item on re-fetch is a
+// string comparison rather than an HTML parse.
+func SourceHash(title, summary, content string) string
+```
+
+Stripping uses `html.NewTokenizer` streaming, not goquery: this runs over the
+whole corpus inside a migration, and goquery builds a document tree per item.
+
+```go
+func stripHTML(raw string) string {
+	tokenizer := html.NewTokenizer(strings.NewReader(raw))
+	var out strings.Builder
+	skipDepth := 0
+	for {
+		switch tokenizer.Next() {
+		case html.ErrorToken: // includes io.EOF
+			return strings.Join(strings.Fields(out.String()), " ")
+		case html.StartTagToken:
+			if name, _ := tokenizer.TagName(); isSkippedElement(name) {
+				skipDepth++
+			}
+		case html.EndTagToken:
+			if name, _ := tokenizer.TagName(); isSkippedElement(name) && skipDepth > 0 {
+				skipDepth--
+			}
+		case html.TextToken:
+			if skipDepth == 0 {
+				out.Write(tokenizer.Text()) // already entity-decoded
+				out.WriteByte(' ')
+			}
+		}
+	}
+}
+
+// isSkippedElement drops elements whose text content is markup, not prose.
+func isSkippedElement(name []byte) bool {
+	switch string(name) {
+	case "script", "style", "noscript", "template":
+		return true
+	}
+	return false
+}
+```
+
+`SourceHash` is `sha256` over `title + "\x00" + summary + "\x00" + content`,
+hex-encoded and truncated to 32 characters — the same truncated-hash idiom as
+`ItemHashID` in `internal/database/pagination.go:29`.
+
+Truncation cuts at the byte cap then backs off to a UTF-8 rune boundary with
+`utf8.DecodeLastRuneInString`, so a multi-byte character is never split.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+func TestDeriveStripsMarkup(t *testing.T) {
+	got := Derive(
+		"Rust 1.87 &amp; friends",
+		"<p>A <b>short</b> summary</p>",
+		`<div>Hello <script>var x = "networking";</script> world</div>`,
+		DefaultOptions(),
+	)
+	if got.Title != "Rust 1.87 & friends" {
+		t.Errorf("title = %q", got.Title)
+	}
+	if got.Summary != "A short summary" {
+		t.Errorf("summary = %q", got.Summary)
+	}
+	if got.Body != "Hello world" {
+		t.Errorf("body = %q, script contents must not be indexed", got.Body)
+	}
+}
+
+func TestDeriveTruncatesOnRuneBoundary(t *testing.T) {
+	opts := DefaultOptions()
+	opts.MaxBodyBytes = 5
+	got := Derive("", "", "aé😀bcdef", opts)
+	if !utf8.ValidString(got.Body) {
+		t.Fatalf("body %q is not valid UTF-8", got.Body)
+	}
+	if len(got.Body) > opts.MaxBodyBytes {
+		t.Fatalf("body is %d bytes, cap is %d", len(got.Body), opts.MaxBodyBytes)
+	}
+}
+
+func TestSourceHashDistinguishesFieldBoundaries(t *testing.T) {
+	// Without a separator these two would hash identically.
+	if SourceHash("ab", "c", "") == SourceHash("a", "bc", "") {
+		t.Fatal("hash ignores the boundary between title and summary")
+	}
+	if SourceHash("a", "b", "c") != SourceHash("a", "b", "c") {
+		t.Fatal("hash is not stable")
+	}
+}
+```
+
+Plus table-driven cases for: plain text with no markup passes through; `a < b`
+survives as text; entity-only input; empty input yields empty fields;
+whitespace and newlines collapse to single spaces; unclosed tags do not consume
+the rest of the document.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./internal/itemtext/ -v`
+Expected: build failure — package does not exist.
+
+- [ ] **Step 3: Implement `internal/itemtext/itemtext.go`**
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./internal/itemtext/ -v`
+
+**Verification — automated:**
+- [ ] `go test ./internal/itemtext/ -v` passes
+- [ ] `make format` clean
+- [ ] `make lint` passes
+- [ ] `make test` passes
+
+**Verification — manual:**
+- [ ] Read the derived output for one real article body (paste one into a
+      scratch test and `t.Log` it). Confirm it reads as prose, with no leftover
+      tag names, attribute values, or URL fragments.
+
+---
+
+## Phase 2: Migration 11 — schema, triggers, backfill runner, `feedspool reindex`
+
+Delivers a database whose index exists and is correct: existing corpora get
+backfilled, and every delete path is covered by triggers. Nothing searches it
+yet.
+
+**Files:**
+- Create: `internal/database/item_text.go`
+- Create: `internal/database/backfill.go`
+- Create: `internal/database/item_text_test.go`
+- Create: `internal/database/backfill_test.go`
+- Create: `cmd/reindex.go`
+- Modify: `internal/database/migrations.go` — add `migrationVersion11`, bump
+  `maxMigrationVersion` to it, add DDL to `getMigrations()`, add
+  `applyMigration11` and its `applySpecificMigration` case
+- Modify: `internal/database/schema.sql` — same DDL, `IF NOT EXISTS`, matching
+  the `item_annotations` precedent where schema.sql and migration 6 both
+  declare the table
+- Modify: `internal/database/migrations_test.go` — the three
+  `maxMigrationVersion` assertions at lines 228, 297, 367 follow the constant,
+  so they need no edit; confirm they still pass
+
+**Key changes — DDL** (identical text in `getMigrations()` and `schema.sql`):
+
+```sql
+CREATE TABLE IF NOT EXISTS item_text (
+    item_id           INTEGER PRIMARY KEY REFERENCES items(id) ON DELETE CASCADE,
+    title             TEXT NOT NULL DEFAULT '',
+    summary           TEXT NOT NULL DEFAULT '',
+    body              TEXT NOT NULL DEFAULT '',
+    source_hash       TEXT NOT NULL,
+    generator         TEXT NOT NULL,
+    generator_version INTEGER NOT NULL,
+    computed_at       DATETIME NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_item_text_generator
+    ON item_text(generator, generator_version);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS items_fts USING fts5(
+    title, summary, body,
+    content='item_text', content_rowid='item_id',
+    tokenize="porter unicode61 remove_diacritics 2"
+);
+
+CREATE TRIGGER IF NOT EXISTS item_text_ai AFTER INSERT ON item_text BEGIN
+    INSERT INTO items_fts(rowid, title, summary, body)
+    VALUES (new.item_id, new.title, new.summary, new.body);
+END;
+CREATE TRIGGER IF NOT EXISTS item_text_ad AFTER DELETE ON item_text BEGIN
+    INSERT INTO items_fts(items_fts, rowid, title, summary, body)
+    VALUES ('delete', old.item_id, old.title, old.summary, old.body);
+END;
+CREATE TRIGGER IF NOT EXISTS item_text_au AFTER UPDATE ON item_text BEGIN
+    INSERT INTO items_fts(items_fts, rowid, title, summary, body)
+    VALUES ('delete', old.item_id, old.title, old.summary, old.body);
+    INSERT INTO items_fts(rowid, title, summary, body)
+    VALUES (new.item_id, new.title, new.summary, new.body);
+END;
+```
+
+The `'delete'` command must carry the **old** column values: an
+external-content table cannot recover them from `item_text`, which by then
+holds the new ones.
+
+**Key changes — the reusable runner** (`internal/database/backfill.go`):
+
+```go
+// DerivedBackfill describes an artifact derived from items that must be
+// recomputed when the item changes or the generator's version moves. #58
+// implements it for FTS text; #30 implements it for embeddings.
+type DerivedBackfill interface {
+	Name() string
+	Version() int
+	// NextBatch returns up to limit item IDs still needing work, all with
+	// id > afterID, in ascending id order.
+	NextBatch(tx *sql.Tx, afterID int64, limit int) ([]int64, error)
+	// Recompute derives and stores the artifact for those item IDs.
+	Recompute(tx *sql.Tx, ids []int64) error
+	// Remaining reports how many items still need work, for progress output.
+	Remaining(tx *sql.Tx) (int64, error)
+}
+
+const defaultBackfillBatchSize = 500
+
+// RunBackfill processes the generator in committed batches, so an interrupted
+// run resumes where it stopped instead of restarting, and a large database is
+// never held in one transaction.
+func (db *DB) RunBackfill(gen DerivedBackfill, batchSize int, progress func(done, total int64)) error
+```
+
+`RunBackfill` walks by ascending item ID: begin tx, `NextBatch(tx, afterID,
+batchSize)`, return if empty, `Recompute`, commit, set `afterID` to the largest
+ID in the batch. The ID cursor is what makes the loop terminate even if a row
+somehow stays stale — without it, a row the generator cannot fix would be
+re-selected forever.
+
+**Key changes — the FTS text generator** (`internal/database/item_text.go`):
+
+```go
+type itemTextBackfill struct{ opts itemtext.Options }
+
+func (g *itemTextBackfill) Name() string { return itemtext.Generator }
+func (g *itemTextBackfill) Version() int { return itemtext.Version }
+```
+
+Its `NextBatch` query — staleness is "no row, or a row from an older
+generator version". A changed item is handled on the live write path in phase
+3, which is the only thing that changes item text, so the backfill does not
+need to re-hash every row on every run:
+
+```sql
+SELECT i.id
+FROM items i LEFT JOIN item_text t ON t.item_id = i.id
+WHERE i.id > ? AND (t.item_id IS NULL OR t.generator <> ? OR t.generator_version <> ?)
+ORDER BY i.id
+LIMIT ?
+```
+
+`Recompute` reads `title, summary, content` for those IDs, calls
+`itemtext.Derive` and `itemtext.SourceHash`, and writes each through the one
+shared helper. Phase 3's live write path calls the same helper — two spellings
+of this statement is exactly the drift the spec exists to prevent:
+
+```go
+// upsertItemTextTx is the only place item_text rows are written. The backfill
+// runner and UpsertItem both go through it.
+func upsertItemTextTx(tx *sql.Tx, itemID int64, text itemtext.Text, sourceHash string) error {
+	_, err := tx.Exec(`
+		INSERT INTO item_text
+			(item_id, title, summary, body, source_hash, generator, generator_version, computed_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(item_id) DO UPDATE SET
+			title = excluded.title, summary = excluded.summary, body = excluded.body,
+			source_hash = excluded.source_hash, generator = excluded.generator,
+			generator_version = excluded.generator_version, computed_at = excluded.computed_at`,
+		itemID, text.Title, text.Summary, text.Body, sourceHash,
+		itemtext.Generator, itemtext.Version, formatDatabaseTime(time.Now().UTC()),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to upsert item text for item %d: %w", itemID, err)
+	}
+	return nil
+}
+```
+
+Exported entry point, shared by the migration and the command:
+
+```go
+// ReindexItemText brings the derived text and search index up to date. force
+// discards every derived row first, which the triggers turn into a full index
+// clear, so a tokenizer change can be applied without a schema migration.
+func (db *DB) ReindexItemText(force bool, progress func(done, total int64)) error
+```
+
+**Key changes — `applyMigration11`:**
+
+Three stages, deliberately not one transaction:
+
+1. DDL in its own transaction. Idempotent (`IF NOT EXISTS` throughout).
+2. `ReindexItemText(false, progressLogger)` — batched, committed per batch.
+3. `INSERT INTO schema_migrations (version) VALUES (11)` in a final small
+   transaction.
+
+The version is recorded **last** on purpose: it then means "fully indexed". An
+interrupted migration leaves the version unbumped, so the next run re-applies
+the idempotent DDL and the backfill resumes from where it stopped. Bumping the
+version first would mark a partially indexed database as done, and search would
+silently miss items forever.
+
+Follow the transaction shape of `applyMigration9` at
+`internal/database/migrations.go:402` (`committed` flag plus deferred rollback).
+
+**Key changes — `cmd/reindex.go`:**
+
+Follow the structure of `cmd/status.go`: `database.New`, `IsInitialized`,
+`defer db.Close()`. Flag `--force` (bool, "Discard and rebuild every derived
+row, e.g. after a tokenizer change"). Progress to logrus at info level.
+
+- [ ] **Step 1: Write the failing tests**
+
+The maintenance matrix is the important one — an external-content index fails
+*silently*, so every case asserts `('integrity-check')` afterward.
+
+```go
+// integrityCheck fails the test if the FTS index disagrees with item_text.
+// External-content tables do not self-maintain, so this is the only assertion
+// that catches a missing trigger.
+func integrityCheck(t *testing.T, db *DB) {
+	t.Helper()
+	if _, err := db.conn.Exec(`INSERT INTO items_fts(items_fts) VALUES('integrity-check')`); err != nil {
+		t.Fatalf("fts integrity-check failed: %v", err)
+	}
+}
+
+func TestItemTextTriggersCoverEveryDeletePath(t *testing.T) {
+	cases := []struct {
+		name     string
+		act      func(t *testing.T, db *DB)
+		wantRows int // expected rows left in items_fts, from a seed of 2
+	}{
+		{"direct delete", func(t *testing.T, db *DB) {
+			mustExec(t, db, `DELETE FROM item_text WHERE item_id = ?`, firstItemID(t, db))
+		}, 1},
+		{"one-level cascade from items", func(t *testing.T, db *DB) {
+			mustExec(t, db, `DELETE FROM items WHERE id = ?`, firstItemID(t, db))
+		}, 1},
+		{"two-level cascade from feeds", func(t *testing.T, db *DB) {
+			// feeds -> items -> item_text -> trigger. Verified to fire at this
+			// depth; DeleteFeed reaches the index no other way.
+			if err := db.DeleteFeed(testFeedURL); err != nil {
+				t.Fatal(err)
+			}
+		}, 0},
+		{"archived purge", func(t *testing.T, db *DB) {
+			mustExec(t, db, `UPDATE items SET archived = 1`)
+			if _, err := db.DeleteArchivedItems(time.Now().Add(time.Hour)); err != nil {
+				t.Fatal(err)
+			}
+		}, 0},
+		{"marking archived indexes nothing away", func(t *testing.T, db *DB) {
+			// archived is a filter on items, not a text change, so the index
+			// must be untouched.
+			if err := db.MarkItemsArchived(testFeedURL, nil); err != nil {
+				t.Fatal(err)
+			}
+		}, 2},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := seedTwoIndexedItems(t)
+			tc.act(t, db)
+			if got := countFTSRows(t, db); got != tc.wantRows {
+				t.Errorf("items_fts has %d rows, want %d", got, tc.wantRows)
+			}
+			integrityCheck(t, db)
+		})
+	}
+}
+
+func TestItemTextUpdateRetiresStaleTerms(t *testing.T) {
+	// Update a body; the old body term must stop matching, the untouched title
+	// term must keep matching, and the new body term must match.
+	// Regression guard: an update trigger that inserts without deleting leaves
+	// both the old and new terms searchable, and integrity-check still passes.
+}
+
+func TestRunBackfillIsResumable(t *testing.T) {
+	// Seed 25 items, run with batchSize 10 and a progress hook that returns
+	// after the first batch; assert 10 indexed. Re-run to completion; assert
+	// 25 indexed, no duplicates, integrityCheck.
+}
+
+func TestReindexItemTextRecomputesOnVersionBump(t *testing.T) {
+	// Backfill, then rewrite every generator_version to itemtext.Version - 1,
+	// then re-run: every row is recomputed and computed_at moves.
+}
+
+func TestReindexItemTextForceRebuilds(t *testing.T) {
+	// Corrupt item_text by hand (UPDATE body to junk), run with force=true,
+	// assert the derived text matches itemtext.Derive output again.
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./internal/database/ -run 'ItemText|Backfill|Reindex' -v`
+Expected: FAIL — `item_text` does not exist.
+
+- [ ] **Step 3: Implement the DDL, `backfill.go`, `item_text.go`, migration 11, `cmd/reindex.go`**
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./internal/database/ -run 'ItemText|Backfill|Reindex|Migration' -v`
+
+- [ ] **Step 5: Commit** — `Phase 2: FTS5 schema, triggers, and backfill`
+
+**Verification — automated:**
+- [ ] `go test ./internal/database/ -v` passes
+- [ ] `make format` clean
+- [ ] `make lint` passes
+- [ ] `make test` passes
+- [ ] `make build` succeeds
+
+**Verification — manual:**
+- [ ] Copy a real feed database, run the built binary against it, and watch
+      migration 11 apply. Note the wall-clock time and the item count.
+- [ ] `sqlite3 <copy> "INSERT INTO items_fts(items_fts) VALUES('integrity-check');"`
+      returns without error.
+- [ ] Compare `SELECT count(*) FROM items` and `SELECT count(*) FROM item_text`
+      — they must be equal.
+- [ ] Check the on-disk size delta against the pre-migration copy, and record
+      it in `notes.md` alongside the 81%-of-source figure from `research.md`.
+
+---
+
+## Phase 3: `UpsertItem` keeps the index current
+
+Delivers end-to-end freshness for new data: a fetched item is searchable
+immediately, and an unchanged item on re-fetch costs a hash comparison rather
+than an HTML parse.
+
+**Files:**
+- Modify: `internal/database/item_repository.go:29-59` — `UpsertItem`
+- Modify: `internal/database/item_repository_test.go`
+
+**Key changes:**
+
+`UpsertItem` becomes transactional and returns the item ID from the write so
+the derived row can be attached to it:
+
+```go
+// RETURNING is required here: LastInsertId is not meaningful for the
+// ON CONFLICT DO UPDATE branch, which is the common case on re-fetch.
+query := `
+	INSERT INTO items (feed_url, guid, title, link, published_date, first_seen,
+		content, summary, archived, item_json)
+	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	ON CONFLICT(feed_url, guid) DO UPDATE SET
+		title = excluded.title,
+		link = excluded.link,
+		content = excluded.content,
+		summary = excluded.summary,
+		archived = excluded.archived,
+		item_json = excluded.item_json
+	RETURNING id
+`
+```
+
+Then, in the same transaction:
+
+```go
+// Skip the derivation entirely when nothing that feeds the index changed.
+// Re-fetching an unchanged feed is the common case, and this keeps it to one
+// indexed lookup instead of an HTML parse per item. It also avoids firing the
+// update trigger, which would delete and reinsert identical index rows.
+hash := itemtext.SourceHash(item.Title, item.Summary, item.Content)
+var storedHash string
+var storedVersion int
+err := tx.QueryRow(
+	`SELECT source_hash, generator_version FROM item_text WHERE item_id = ?`, id,
+).Scan(&storedHash, &storedVersion)
+switch {
+case errors.Is(err, sql.ErrNoRows): // fall through to derive
+case err != nil:
+	return err
+case storedHash == hash && storedVersion == itemtext.Version:
+	return tx.Commit() // nothing to do
+}
+```
+
+Reuse the same upsert statement as `Recompute` in phase 2 — extract it to a
+shared helper `upsertItemTextTx(tx *sql.Tx, id int64, text itemtext.Text, hash string) error`
+in `internal/database/item_text.go` and call it from both. Two spellings of
+this statement is exactly the drift the spec is trying to prevent.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+func TestUpsertItemIndexesNewItem(t *testing.T) {
+	// Upsert an item with markup in its content; assert a matching item_text
+	// row exists with stripped text, and that an FTS MATCH on a body-only term
+	// finds it. integrityCheck.
+}
+
+func TestUpsertItemSkipsDerivationWhenUnchanged(t *testing.T) {
+	// Upsert twice with identical content; assert computed_at is unchanged
+	// after the second call -- proving the short-circuit fired rather than
+	// silently re-deriving.
+}
+
+func TestUpsertItemReindexesChangedContent(t *testing.T) {
+	// Upsert, then upsert the same feed_url/guid with different content.
+	// Assert the old body term no longer matches and the new one does.
+	// integrityCheck.
+}
+
+func TestUpsertItemReindexesOnVersionBump(t *testing.T) {
+	// Upsert, hand-set generator_version to itemtext.Version - 1, upsert the
+	// same unchanged item; assert it was recomputed despite the hash matching.
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./internal/database/ -run TestUpsertItem -v`
+
+- [ ] **Step 3: Implement the `UpsertItem` change**
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./internal/database/ ./internal/fetcher/ -v`
+
+- [ ] **Step 5: Commit** — `Phase 3: Maintain the search index on item writes`
+
+**Verification — automated:**
+- [ ] `go test ./internal/database/ ./internal/fetcher/ -v` passes
+- [ ] `make format` clean
+- [ ] `make lint` passes
+- [ ] `make test` passes
+
+**Verification — manual:**
+- [ ] Against the real-database copy: `feedspool fetch` one feed, then confirm
+      `SELECT count(*) FROM items` still equals `SELECT count(*) FROM item_text`
+      and integrity-check passes.
+- [ ] Run the same fetch twice and confirm the second is not noticeably slower
+      than it was before this phase.
+
+---
+
+## Phase 4: `internal/search` — the query parser
+
+Delivers a safe translation from a user's search box to an FTS5 `MATCH`
+expression. Standalone and pure; nothing calls it yet.
+
+**Files:**
+- Create: `internal/search/search.go`
+- Test: `internal/search/search_test.go`
+
+**Key changes:**
+
+```go
+package search
+
+// ErrOnlyExclusions is returned for a query with nothing to match, such as
+// "-draft". FTS5 cannot answer "everything except X", and returning zero rows
+// would read as a bug rather than as a rejected query.
+var ErrOnlyExclusions = errors.New("search query needs at least one term to match")
+
+// Parse translates user input into an FTS5 MATCH expression. An empty result
+// with a nil error means "no search filter", matching today's behavior for an
+// empty q or --search.
+//
+// Every term is emitted double-quoted, so FTS5 operators a user did not intend
+// -- NEAR, AND, column filters like title:foo, bare punctuation such as C++ --
+// are matched as literal text instead of being parsed as syntax or raising a
+// syntax error the caller would have to surface as a 500.
+func Parse(raw string) (expression string, err error)
+```
+
+Grammar, in the order the tokenizer applies it:
+
+| Input | Emitted |
+| --- | --- |
+| `rust release` | `("rust" AND "release")` |
+| `"release notes"` | `("release notes")` |
+| `-draft` | `NOT ("draft")` |
+| `secur*` | `("secur"*)` |
+| `C++` | `("C++")` |
+
+Positives and negatives combine as `(pos1 AND pos2) NOT (neg1 OR neg2)`. The
+parentheses are load-bearing: FTS5 binds `NOT` tighter than `AND`, so the
+unparenthesized `a AND b NOT c` would mean `a AND (b NOT c)`.
+
+Quoting doubles any embedded `"`. An unterminated quote closes implicitly at
+end of input rather than erroring — forgiving is right for a search box, and
+the result is still a well-formed expression.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+func TestParse(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{"empty", "", ""},
+		{"whitespace only", "   ", ""},
+		{"single term", "rust", `("rust")`},
+		{"implicit and", "rust release", `("rust" AND "release")`},
+		{"phrase", `"release notes"`, `("release notes")`},
+		{"exclusion", "rust -draft", `("rust") NOT ("draft")`},
+		{"prefix", "secur*", `("secur"*)`},
+		{"operator as literal", "foo NEAR bar", `("foo" AND "NEAR" AND "bar")`},
+		{"column filter as literal", "title:foo", `("title:foo")`},
+		{"punctuation", "C++", `("C++")`},
+		{"embedded quote", `say "hi" there`, `("say" AND "hi" AND "there")`},
+		{"unterminated quote", `"release notes`, `("release notes")`},
+		{"bare star", "*", ""},
+	}
+	// ... assert Parse(in) == want, err == nil
+}
+
+func TestParseRejectsOnlyExclusions(t *testing.T) {
+	if _, err := Parse("-draft -wip"); !errors.Is(err, ErrOnlyExclusions) {
+		t.Fatalf("err = %v, want ErrOnlyExclusions", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./internal/search/ -v`
+Expected: build failure — package does not exist.
+
+- [ ] **Step 3: Implement `internal/search/search.go`**
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./internal/search/ -v`
+
+- [ ] **Step 5: Commit** — `Phase 4: Add the FTS5 query parser`
+
+**Verification — automated:**
+- [ ] `go test ./internal/search/ -v` passes
+- [ ] `make format` clean
+- [ ] `make lint` passes
+- [ ] `make test` passes
+
+**Verification — manual:**
+- [ ] None. Pure function, fully covered by the table above.
+
+---
+
+## Phase 5: CLI search end-to-end
+
+Delivers a working feature: `feedspool items --search "container networking"
+--sort relevance` searches bodies and ranks results. If phase 6 never lands,
+this still ships.
+
+**Files:**
+- Create: `internal/database/search_sql.go` — the SQL fragments both query
+  builders share
+- Modify: `internal/database/item_repository.go` — `ItemFilter` gains `Sort`;
+  `buildItemsQuery` (line 411) gains an error return and the FTS join; the
+  `instr(lower(i.title), ...)` condition at line 442 goes away
+- Modify: `internal/database/item_repository_test.go`
+- Modify: `cmd/items.go` — `--sort relevance`, `--search` help text,
+  `validateItemsOptions`, skip `reverseItemsList` for relevance
+
+**Key changes — the shared fragments** (`internal/database/search_sql.go`):
+
+```go
+// These three constants are the single source of truth for what a search
+// matches and how it ranks. buildItemsQuery (CLI) and itemPageConditions (API)
+// both build from them; TestSearchSurfacesAgree asserts they cannot drift.
+// The predecessor to this file was a duplicated instr() expression in two
+// places held in step only by a comment.
+const (
+	itemsFTSJoin  = " JOIN items_fts f ON f.rowid = i.id"
+	itemsFTSMatch = "f MATCH ?"
+	// Title outranks summary outranks body. Without column weights, a body
+	// mention buries an exact title match.
+	itemsFTSRank = "bm25(f, 10.0, 4.0, 1.0)"
+)
+
+// SortRelevance and friends name the orderings both surfaces accept.
+const (
+	SortNewest    = "newest"
+	SortOldest    = "oldest"
+	SortRelevance = "relevance"
+)
+```
+
+**Key changes — `buildItemsQuery`:**
+
+```go
+func buildItemsQuery(filter *ItemFilter) (query string, args []interface{}, err error)
+```
+
+When `filter.Search != ""`, call `search.Parse`; an empty expression means no
+filter, and an error propagates out of `GetItems` (so `-search "-draft"` exits
+non-zero with the parser's message rather than returning everything). When the
+expression is non-empty, append `itemsFTSJoin` to the FROM clause and
+`itemsFTSMatch` to the conditions.
+
+Ordering: `SortRelevance` emits
+`ORDER BY ` + itemsFTSRank + ` ASC, ` + aliasedEffectiveDateExpression + ` DESC, i.id DESC`.
+bm25 is negative-better, so the sort ascends; the date and ID tiebreaks make
+the ordering total for equally-scored rows. Anything else keeps the existing
+`ORDER BY aliasedEffectiveDateExpression DESC`.
+
+The structural test that both surfaces agree lands in **phase 6**, once
+`ListItems` also searches — there is nothing to compare against until then.
+
+**Key changes — `cmd/items.go`:**
+
+- `--search` help becomes `"Full-text search over title, summary and body"`.
+- `--sort` help becomes `"Sort order (newest|oldest|relevance)"`.
+- `validateItemsOptions` (line 129) accepts `relevance` and rejects it without
+  `--search`: `"--sort relevance requires --search"`.
+- `runItems` (line 101) must not call `reverseItemsList` when the sort is
+  relevance — the ranking is already in the right order and reversing it would
+  put the worst match first.
+- `--sort relevance` with `--limit 0` is allowed; ranking without a limit is
+  slow but not wrong, and the CLI has no pagination.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+func TestGetItemsSearchMatchesBodyAndSummary(t *testing.T) {
+	// A term present only in content, and one only in summary, both match --
+	// the behavior change from title-only substring search.
+}
+
+func TestGetItemsSearchComposesWithFilters(t *testing.T) {
+	// search + FeedURL, search + Since/Until, search + Seen/Unseen.
+	// Each must intersect, not replace.
+}
+
+func TestGetItemsRelevanceRanksTitleAboveBody(t *testing.T) {
+	// Two items: one with the term in the title, one with it repeated in the
+	// body. With Sort=relevance the title match comes first -- this is what
+	// the bm25 column weights buy.
+}
+
+func TestGetItemsSearchRejectsOnlyExclusions(t *testing.T) {
+	// GetItems returns the parser error rather than every row.
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./internal/database/ -run 'GetItemsSearch|Relevance' -v`
+
+- [ ] **Step 3: Implement `search_sql.go`, the `buildItemsQuery` change, and the `cmd/items.go` change**
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./internal/database/ -v`
+
+- [ ] **Step 5: Commit** — `Phase 5: Full-text search and relevance on the CLI`
+
+**Verification — automated:**
+- [ ] `go test ./internal/database/ -v` passes
+- [ ] `make format` clean
+- [ ] `make lint` passes
+- [ ] `make test` passes
+- [ ] `make build` succeeds
+
+**Verification — manual:**
+- [ ] Against the real-database copy: `feedspool items --search "<a topic you
+      know is in there>" --limit 20` returns items whose *bodies* are about
+      that topic, not only ones with it in the title.
+- [ ] The same query with `--sort relevance` puts visibly better matches first.
+      This is a judgement call and the point of the phase — a correct search
+      that ranks badly is still a bad search.
+- [ ] `feedspool items --search "-draft"` exits non-zero with a readable
+      message rather than dumping the whole database.
+- [ ] `feedspool items --sort relevance` without `--search` exits non-zero.
+
+---
+
+## Phase 6: API search end-to-end
+
+Delivers the HTTP surface: `?q=` matches bodies, `sort=relevance` ranks, and
+relevance paginates by an offset hidden inside the opaque cursor.
+
+**Files:**
+- Modify: `internal/database/pagination.go` — `ItemPage` gains `Sort`;
+  `ItemCursor` gains `Relevance` and `Offset`; `itemPageConditions` (line 155)
+  swaps the `instr()` condition at line 175 for the FTS join; `ListItems`
+  gains the relevance ordering and offset path
+- Modify: `internal/database/pagination_test.go`
+- Modify: `internal/api/cursor.go` — payload gains the two fields
+- Modify: `internal/api/items.go` — `sortRelevance`, validation, `Sort` wiring;
+  `itemFilters` (line ~136) gains a `sort string` field alongside `ascending`,
+  because two later checks need to know which ordering was requested, not just
+  its direction
+- Modify: `internal/api/openapi.yaml` — `q` description, `sort` enum
+- Modify: `internal/api/handlers_test.go` — including
+  `TestListItemsSearchMatchesTitleOnly` at line 314, which asserts the old
+  behavior and must be rewritten rather than deleted
+- Create: `internal/database/search_agreement_test.go`
+
+**Key changes — the cursor:**
+
+```go
+type ItemCursor struct {
+	DateRank      int
+	EffectiveDate float64
+	ID            int64
+
+	// Relevance and Offset are used only by Sort == SortRelevance. A bm25
+	// ordering has no stable natural key -- the score depends on corpus
+	// statistics, so any write shifts every score -- and a keyset built on it
+	// would silently skip rows. Offset can only repeat or drop a row, which is
+	// the ordinary offset caveat and a strictly better failure.
+	Relevance bool
+	Offset    int
+}
+```
+
+`itemCursorPayload` gains `Relevance bool \`json:"m,omitempty"\`` and
+`Offset int \`json:"o,omitempty"\``. `cursorVersion` stays 1: the decoder uses
+`DisallowUnknownFields`, and older cursors simply decode with both fields
+zero, which is exactly the date-mode cursor they were.
+
+`decodeItemCursor` gains no new validation; the *handler* rejects the mismatch,
+because that is where the requested sort is known.
+
+**Key changes — `ListItems`:**
+
+When `page.Sort == SortRelevance`, the query orders by `itemsFTSRank ASC,
+effective_date DESC, i.id DESC` and paginates with `LIMIT ? OFFSET ?` from
+`page.After.Offset`, ignoring the keyset predicate entirely. The next cursor is
+`&ItemCursor{Relevance: true, Offset: previousOffset + limit}`. Everything else
+keeps the existing keyset path unchanged.
+
+Relevance requires a search expression; `ListItems` returns an error if
+`Sort == SortRelevance` with an empty parsed expression, mirroring the CLI.
+
+**Key changes — `internal/api/items.go`:**
+
+The sort names must exist once, not twice. `internal/api` already declares
+`sortNewest` and `sortOldest` at `internal/api/items.go:14-15`; rebind all three
+to the `internal/database` constants added in phase 5 so the two packages cannot
+drift on a spelling:
+
+```go
+// Bound to the database constants rather than re-spelled, so a rename cannot
+// leave the two packages disagreeing about what "relevance" is called.
+const (
+	sortNewest    = database.SortNewest
+	sortOldest    = database.SortOldest
+	sortRelevance = database.SortRelevance
+)
+```
+
+In `parseItemFilters` (line 142), extend the validation at lines 167-174 and
+record the chosen sort:
+
+```go
+if sort != sortNewest && sort != sortOldest && sort != sortRelevance {
+	return filters, fmt.Errorf("%s must be %s, %s or %s",
+		paramSort, sortNewest, sortOldest, sortRelevance)
+}
+if sort == sortRelevance && strings.TrimSpace(query.Get(paramQuery)) == "" {
+	return filters, fmt.Errorf("%s=%s requires %s", paramSort, sortRelevance, paramQuery)
+}
+filters.sort = sort
+filters.ascending = sort == sortOldest
+```
+
+`strings` is not currently imported in `internal/api/items.go`; add it.
+
+In `buildItemPage`, after decoding the cursor, reject a mode mismatch as a
+cursor error so the handler reports `invalid_cursor`:
+
+```go
+// A cursor from one ordering means nothing in another: a relevance cursor
+// carries an offset, a date cursor carries a keyset position. Replaying the
+// wrong one would silently return a wrong page rather than an error.
+if after != nil && after.Relevance != (filters.sort == sortRelevance) {
+	return nil, nil, cursorError{fmt.Errorf("cursor does not match sort=%s", filters.sort)}
+}
+```
+
+A `search.Parse` failure must surface as `400 invalid_parameter`, not a 500.
+`ListItems` returns the parser's error; `handleListItems` needs to distinguish
+it from a database failure — check `errors.Is(err, search.ErrOnlyExclusions)`
+before falling through to `writeInternalError`.
+
+**Key changes — `openapi.yaml`:**
+
+Replace the `q` description at lines 174-178:
+
+```yaml
+        - name: q
+          in: query
+          description: |
+            Full-text search over the item title, summary and body. Terms are
+            ANDed; `"quoted phrases"`, `-exclusions` and `prefix*` are
+            supported; everything else is matched literally. Identical to
+            `feedspool items --search`.
+          schema: { type: string }
+```
+
+and the `sort` enum at line 200-202:
+
+```yaml
+        - name: sort
+          in: query
+          description: |
+            `relevance` requires `q` and is the only ordering that does not use
+            a keyset cursor; its cursors are not interchangeable with the
+            others.
+          schema: { type: string, enum: [newest, oldest, relevance], default: newest }
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+func TestListItemsSearchMatchesBodyAndSummary(t *testing.T) {
+	// Replaces TestListItemsSearchMatchesTitleOnly at handlers_test.go:314.
+	// Rewrite rather than delete: the old test pins the old contract, and the
+	// new one is the record that the contract changed deliberately.
+}
+
+func TestListItemsRelevancePaginatesWithoutGapsOrRepeats(t *testing.T) {
+	// Seed 25 matching items, page through with limit 10, collect IDs.
+	// Assert 25 distinct IDs and that the relevance order is preserved across
+	// page boundaries. This is the totality property the offset cursor has to
+	// keep in the absence of writes.
+}
+
+func TestListItemsRejectsCursorFromAnotherSort(t *testing.T) {
+	// A relevance cursor replayed with sort=newest is 400 invalid_cursor,
+	// and vice versa.
+}
+
+func TestListItemsRelevanceRequiresQuery(t *testing.T) {
+	// sort=relevance with no q is 400 invalid_parameter.
+}
+
+func TestListItemsOnlyExclusionsIsBadRequest(t *testing.T) {
+	// q=-draft is 400 invalid_parameter, not 500.
+}
+
+func TestListItemsDefaultsToNewestWithAQuery(t *testing.T) {
+	// The spec's explicit call: a query does NOT imply relevance. ?q=<term>
+	// with no sort returns newest-first and a keyset cursor, not an offset
+	// cursor. Asserting it means a later "helpful" change to the default has
+	// to be deliberate.
+}
+
+// TestSearchSurfacesAgree is the guard against the CLI and the API drifting
+// apart on what a query matches -- the failure mode #62 hit with annotation
+// kinds. It is a structural invariant, not a regression test: any query, any
+// corpus, the two paths must return the same item IDs. Lives in
+// internal/database/search_agreement_test.go.
+func TestSearchSurfacesAgree(t *testing.T) {
+	// Seed a corpus with terms appearing in title only, summary only, body
+	// only, several at once, and none.
+	for _, query := range []string{
+		"networking", "release notes", `"release notes"`, "rust -draft",
+		"secur*", "C++", "absent",
+	} {
+		cliItems, cliErr := db.GetItems(&ItemFilter{Search: query})
+		apiItems, _, apiErr := db.ListItems(&ItemPage{Search: query, Limit: 1000})
+		// Errors must agree too: "-draft" has to fail on both surfaces or
+		// neither, otherwise one of them is silently returning everything.
+		if (cliErr == nil) != (apiErr == nil) {
+			t.Errorf("query %q: CLI err = %v, API err = %v", query, cliErr, apiErr)
+			continue
+		}
+		if cliErr != nil {
+			continue
+		}
+		if cli, api := sortedIDs(cliItems), sortedIDs(apiItems); !slices.Equal(cli, api) {
+			t.Errorf("query %q: CLI returned %v, API returned %v", query, cli, api)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./internal/api/ ./internal/database/ -run 'ListItems|Relevance|Cursor' -v`
+
+- [ ] **Step 3: Implement the pagination, cursor, handler and OpenAPI changes**
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./internal/api/ ./internal/database/ -v`
+
+- [ ] **Step 5: Confirm the two surfaces agree**
+
+Run: `go test ./internal/database/ -run TestSearchSurfacesAgree -v`
+
+- [ ] **Step 6: Commit** — `Phase 6: Full-text search and relevance on the API`
+
+**Verification — automated:**
+- [ ] `go test ./internal/api/ ./internal/database/ -v` passes
+- [ ] `TestOpenAPICoversEveryRoute` passes (it is what keeps the hand-written
+      spec from drifting — see `internal/api/openapi.go:14`)
+- [ ] `make format` clean
+- [ ] `make lint` passes
+- [ ] `make test` passes
+- [ ] `go test -race ./internal/api/ ./internal/database/` passes (needs cgo,
+      runs outside the Makefile, as CI does it)
+
+**Verification — manual:**
+- [ ] Against the real-database copy, with `feedspool serve` running:
+      `curl -s 'localhost:8889/api/v1/items?q=<topic>&sort=relevance&limit=5' | jq '.data[].title'`
+      returns sensibly ranked results.
+- [ ] Page through with the returned `next_cursor` and confirm no repeats.
+- [ ] `curl -s 'localhost:8889/api/v1/items?sort=relevance'` returns 400.
+- [ ] Compare the same query through the CLI and the API and confirm the same
+      items come back.
+
+---
+
+## Phase 7: Documentation and the real-database smoke test
+
+**Files:**
+- Modify: `MANUAL.md` — the `items` subcommand section (line ~357), the HTTP
+  API "Reading items" parameter table (line ~733) and its `q` bullet, the
+  Data Model section (line ~1076) for `item_text` and `items_fts`, a `reindex`
+  subcommand entry, and the SQL Recipes section (line ~1147) with one worked
+  FTS query
+- Modify: `docs/dev-sessions/2026-08-26-1247-fts5-search/notes.md`
+
+**Key changes:**
+
+MANUAL.md's `q` bullet currently reads "**`q` matches titles only**, not body or
+summary — the same limitation as `feedspool items --search` ... Tracked in
+#58." That text and the matching row in the parameter table are the two places
+the old contract is written down; both change, and the note should say plainly
+that the semantics changed before v1 shipped in a tagged release.
+
+Add the query-language table from the spec to both the CLI and API sections,
+spelled the same way in each.
+
+- [ ] **Step 1: Update MANUAL.md**
+
+- [ ] **Step 2: Run the full smoke test against a copy of a real feed database**
+
+```bash
+cp ~/path/to/real/feeds.db /tmp/fts-smoke.db
+make build
+./feedspool --database /tmp/fts-smoke.db status
+./feedspool --database /tmp/fts-smoke.db items --search "<known topic>" --limit 20
+./feedspool --database /tmp/fts-smoke.db items --search "<known topic>" --sort relevance --limit 20
+./feedspool --database /tmp/fts-smoke.db reindex --force
+sqlite3 /tmp/fts-smoke.db "INSERT INTO items_fts(items_fts) VALUES('integrity-check');"
+```
+
+- [ ] **Step 3: Record findings in `notes.md`** — migration wall-clock, index
+      size delta, query latency at the real corpus size, and a judgement on
+      result quality. If items are hitting the 256 KiB body cap, or `porter`
+      stemming is visibly hurting known-item lookup, this is where those two
+      open questions from the spec get closed.
+
+- [ ] **Step 4: Commit** — `Phase 7: Document full-text search`
+
+**Verification — automated:**
+- [ ] `make format` clean
+- [ ] `make lint` passes
+- [ ] `make test` passes
+- [ ] `make build` succeeds
+
+**Verification — manual:**
+- [ ] Read the MANUAL.md diff end to end. The CLI section and the API section
+      must describe the same query language in the same words.
+- [ ] No remaining claim anywhere in the repo that search matches titles only:
+      `grep -rn "title.*only\|titles only" MANUAL.md internal/ cmd/`
+- [ ] The smoke-test results are recorded in `notes.md`, including the quality
+      judgement rather than only the timings.
+
+---
+
+## Deferred, recorded so it is not silently dropped
+
+- `include=snippet` and a relevance score on the item DTO. Both work for free
+  with an external-content table; neither has a consumer yet, and both are
+  purely additive whenever one appears.
+- `OR`, `NEAR`, and column filters in the query language. Literal text today;
+  adding operators later is additive.
+- Re-deriving text when `items` is written by anything other than `UpsertItem`.
+  Nothing does today; `reindex --force` is the repair path if that changes.

--- a/docs/dev-sessions/2026-08-26-1247-fts5-search/plan.md
+++ b/docs/dev-sessions/2026-08-26-1247-fts5-search/plan.md
@@ -391,7 +391,7 @@ row, e.g. after a tokenizer change"). Progress to logrus at info level.
 - [ ] **Step 1: Write the failing tests**
 
 The maintenance matrix is the important one — an external-content index fails
-*silently*, so every case asserts `('integrity-check')` afterward.
+*silently*, so every case asserts `('integrity-check', 1)` afterward. **The argument is load-bearing:** the bare `('integrity-check')` only checks the index's internal consistency and passes happily on an index that has drifted from its content table. Only the `1` argument reads `item_text` back and reports `SQLITE_CORRUPT`. Verified against the `sqlite3` CLI during Phase 2.
 
 ```go
 // integrityCheck fails the test if the FTS index disagrees with item_text.
@@ -399,7 +399,7 @@ The maintenance matrix is the important one — an external-content index fails
 // that catches a missing trigger.
 func integrityCheck(t *testing.T, db *DB) {
 	t.Helper()
-	if _, err := db.conn.Exec(`INSERT INTO items_fts(items_fts) VALUES('integrity-check')`); err != nil {
+	if _, err := db.conn.Exec(`INSERT INTO items_fts(items_fts, rank) VALUES('integrity-check', 1)`); err != nil {
 		t.Fatalf("fts integrity-check failed: %v", err)
 	}
 }
@@ -496,7 +496,7 @@ Run: `go test ./internal/database/ -run 'ItemText|Backfill|Reindex|Migration' -v
 **Verification — manual:**
 - [ ] Copy a real feed database, run the built binary against it, and watch
       migration 11 apply. Note the wall-clock time and the item count.
-- [ ] `sqlite3 <copy> "INSERT INTO items_fts(items_fts) VALUES('integrity-check');"`
+- [ ] `sqlite3 <copy> "INSERT INTO items_fts(items_fts, rank) VALUES('integrity-check', 1);"`
       returns without error.
 - [ ] Compare `SELECT count(*) FROM items` and `SELECT count(*) FROM item_text`
       — they must be equal.
@@ -1123,7 +1123,7 @@ make build
 ./feedspool --database /tmp/fts-smoke.db items --search "<known topic>" --limit 20
 ./feedspool --database /tmp/fts-smoke.db items --search "<known topic>" --sort relevance --limit 20
 ./feedspool --database /tmp/fts-smoke.db reindex --force
-sqlite3 /tmp/fts-smoke.db "INSERT INTO items_fts(items_fts) VALUES('integrity-check');"
+sqlite3 /tmp/fts-smoke.db "INSERT INTO items_fts(items_fts, rank) VALUES('integrity-check', 1);"
 ```
 
 - [ ] **Step 3: Record findings in `notes.md`** — migration wall-clock, index

--- a/docs/dev-sessions/2026-08-26-1247-fts5-search/plan.md
+++ b/docs/dev-sessions/2026-08-26-1247-fts5-search/plan.md
@@ -747,11 +747,11 @@ this still ships.
 // The predecessor to this file was a duplicated instr() expression in two
 // places held in step only by a comment.
 const (
-	itemsFTSJoin  = " JOIN items_fts f ON f.rowid = i.id"
-	itemsFTSMatch = "f MATCH ?"
+	itemsFTSJoin  = " JOIN items_fts ON items_fts.rowid = i.id"
+	itemsFTSMatch = "items_fts MATCH ?"
 	// Title outranks summary outranks body. Without column weights, a body
 	// mention buries an exact title match.
-	itemsFTSRank = "bm25(f, 10.0, 4.0, 1.0)"
+	itemsFTSRank = "bm25(items_fts, 10.0, 4.0, 1.0)"
 )
 
 // SortRelevance and friends name the orderings both surfaces accept.

--- a/docs/dev-sessions/2026-08-26-1247-fts5-search/research.md
+++ b/docs/dev-sessions/2026-08-26-1247-fts5-search/research.md
@@ -1,0 +1,137 @@
+# Research: FTS5 search (#58)
+
+Facts gathered before designing. Everything here was read or measured, not
+assumed. Line references are against `d5968b4` (`origin/main` at session start).
+
+## Where search lives today
+
+Substring match over titles only, in two places that must stay consistent:
+
+| Location | Expression |
+| --- | --- |
+| `internal/database/item_repository.go:442` (in `buildItemsQuery`, line 411; backs the CLI) | `instr(lower(i.title), lower(?)) > 0` |
+| `internal/database/pagination.go:175` (in `itemPageConditions`, line 155; backs the API) | same |
+
+Surfaces:
+
+- CLI: `feedspool items --search` — flag at `cmd/items.go:54`, wired at
+  `cmd/items.go:88`.
+- API: `GET /api/v1/items?q=` — `paramQuery` at `internal/api/names.go:14`,
+  wired at `internal/api/items.go:95`.
+
+`--sort` on the CLI is Go-side only: `cmd/items.go:101-102` reverses the slice
+for `oldest`. `ItemFilter` has no sort field. The API validates `sort` at
+`internal/api/items.go:167-174` (inside `parseItemFilters`, line 142) and turns it into `ItemPage.Ascending`.
+
+## Item write paths
+
+Every path that can change or remove indexed text:
+
+| Path | Location |
+| --- | --- |
+| `UpsertItem` | `internal/database/item_repository.go:29-59` — `INSERT ... ON CONFLICT(feed_url, guid) DO UPDATE`; the only caller is `internal/fetcher/fetcher.go:337` |
+| `MarkItemsArchived` | `item_repository.go:170-206` — sets `archived = 1`; does not touch text |
+| `DeleteArchivedItems` | `item_repository.go:208-221` |
+| `deleteArchivedItemsForFeed` | `item_repository.go:252-310` |
+| `DeleteFeed` | `feed_repository.go:311` — `DELETE FROM feeds`, which reaches `items` only by cascade |
+
+`items` declares `FOREIGN KEY (feed_url) REFERENCES feeds(url) ON DELETE
+CASCADE` (`internal/database/schema.sql:32`), and `internal/database/db.go:55`
+sets `PRAGMA foreign_keys = ON`. So `DeleteFeed` removes items without passing
+through any item write path — the case that decides triggers vs. explicit
+maintenance.
+
+## Connection setup
+
+`internal/database/db.go`: `sql.Open("sqlite", ...)` (line 43),
+`SetMaxOpenConns(1)` (47), `foreign_keys = ON` (55), WAL (85),
+`synchronous = NORMAL` (72), `busy_timeout = 5000` (25). `recursive_triggers`
+is never set, so it is at its default (off).
+
+## Migrations
+
+`maxMigrationVersion` is `10` (`internal/database/migrations.go:21`). Simple
+migrations are SQL strings in `getMigrations()`; ones needing Go run through the
+`applySpecificMigration` switch (line 156). Migrations 4 and 9 already rewrite
+every row in `items`, so a full-corpus pass is an established cost here.
+
+Relevant existing indexes: `idx_items_effective_date` and
+`idx_items_feed_effective_date`, both over
+`julianday(COALESCE(published_date, first_seen))` (migration 9).
+
+## Dependencies
+
+`golang.org/x/net` and `github.com/PuerkitoBio/goquery` are already direct
+dependencies (`go.mod`). HTML handling precedent: `internal/scraper/scraper.go`,
+`internal/unfurl/unfurl.go`. No new dependency is needed.
+
+## FTS5 availability under `modernc.org/sqlite`
+
+Verified empirically on 2026-08-26 (recorded in
+`docs/dev-sessions/2026-08-25-1752-web-api/handoff-58-fts5-search.md`), through
+`database.New` rather than a bare `sql.Open`:
+
+- SQLite 3.53.3; `PRAGMA compile_options` reports `ENABLE_FTS5`.
+- Term, phrase, boolean and prefix queries work; `bm25()` and `snippet()` work;
+  `porter` and `unicode61` tokenizers work.
+- External-content tables work, including `('rebuild')`.
+
+Measured over 25k items with article-sized bodies (~82 MB of text):
+
+| Operation | Time |
+| --- | --- |
+| Full-corpus backfill | 3.6 s |
+| Single incremental insert | ~0.5 ms |
+| Ranked top-20 `bm25()` | 73 ms |
+| Count of a common term | 3.5 ms |
+| Prefix query (`secur*`) | 86 ms |
+
+Latencies are worst-case: the synthetic corpus is Zipfian, so the queried term
+appears in nearly every document.
+
+Index size over the same corpus (15k-item subset):
+
+| Layout | Size | vs. source text |
+| --- | --- | --- |
+| Plain `fts5` | 47.1 MB | 216% |
+| External-content `fts5` | 17.7 MB | 81% |
+
+## Probe: do triggers fire on cascade deletes?
+
+Two throwaway probes run this session through `database.New` with the project's
+real pragmas, then deleted.
+
+**Probe 1 — one level.** An `AFTER DELETE` trigger on `items` issuing the FTS5
+`'delete'` command **does** fire when the row is removed by `ON DELETE CASCADE`
+from `feeds`, with `recursive_triggers` at its default. `('integrity-check')`
+passes afterward. Confirmed identically under the `sqlite3` CLI.
+
+**Probe 2 — the actual design, at cascade depth 2.** The chosen layout puts the
+triggers on `item_text`, which `DeleteFeed` reaches through *two* cascades
+(`feeds` → `items` → `item_text`), so probe 1 did not actually cover it.
+Verified against the real proposed schema — `item_text` plus an
+external-content `items_fts` with insert/update/delete triggers:
+
+- One-level cascade (`DELETE FROM items`) clears `item_text` and the index.
+- **Two-level cascade (`DELETE FROM feeds`) clears both as well** — the trigger
+  fires at depth 2.
+- The update trigger correctly retires stale body terms while leaving untouched
+  title terms indexed.
+- `bm25(items_fts, 10.0, 4.0, 1.0)` with column weights works.
+- `('rebuild')` works against `content='item_text'`, and `('integrity-check')`
+  passes after every step.
+
+This is the load-bearing fact behind the trigger-based maintenance decision: it
+means the purge and feed-delete paths need no FTS code at all.
+
+## Release state of the v1 API
+
+`v1.0.2` was tagged 2026-08-25. The API landed on `main` in `406185c` on
+2026-08-26, after it. So `?q=` exists only in the `latest` dev prerelease and
+has never shipped in a stable release.
+
+## Coordination
+
+#60 (`buildItemsQuery` / `GetItems` rewrite) merged as `d5968b4` before this
+session started. The handoff's warning about editing that function in parallel
+no longer applies.

--- a/docs/dev-sessions/2026-08-26-1247-fts5-search/research.md
+++ b/docs/dev-sessions/2026-08-26-1247-fts5-search/research.md
@@ -124,6 +124,31 @@ external-content `items_fts` with insert/update/delete triggers:
 This is the load-bearing fact behind the trigger-based maintenance decision: it
 means the purge and feed-delete paths need no FTS code at all.
 
+### Correction, found during Phase 2
+
+Both probes above used the bare `('integrity-check')`, and **that form is much
+weaker than it looks.** On an external-content table it verifies only the
+index's own internal consistency; it passes happily on an index that has
+drifted from its content table. Only `INSERT INTO items_fts(items_fts, rank)
+VALUES('integrity-check', 1)` reads the content table back and reports
+`SQLITE_CORRUPT` on a mismatch. Demonstrated directly:
+
+```sql
+CREATE TABLE src(id INTEGER PRIMARY KEY, body TEXT);
+CREATE VIRTUAL TABLE ft USING fts5(body, content='src', content_rowid='id');
+INSERT INTO src VALUES (1,'hello world');
+INSERT INTO ft(rowid, body) VALUES (1,'hello world');
+UPDATE src SET body = 'totally different text' WHERE id = 1;  -- index now stale
+INSERT INTO ft(ft) VALUES('integrity-check');            -- passes (!)
+INSERT INTO ft(ft, rank) VALUES('integrity-check', 1);   -- database disk image is malformed
+```
+
+This does not overturn either probe's conclusion — those rested on row counts
+and `MATCH` results, which were real observations. But the "integrity-check
+passes" line carried less weight than it appeared to, and the argument is now
+mandatory everywhere in the test suite. It is exactly the silent-failure mode
+the external-content design was already flagged for.
+
 ## Release state of the v1 API
 
 `v1.0.2` was tagged 2026-08-25. The API landed on `main` in `406185c` on

--- a/docs/dev-sessions/2026-08-26-1247-fts5-search/spec.md
+++ b/docs/dev-sessions/2026-08-26-1247-fts5-search/spec.md
@@ -147,7 +147,7 @@ CREATE VIRTUAL TABLE items_fts USING fts5(
 Plus `AFTER INSERT` / `AFTER UPDATE` / `AFTER DELETE` triggers on `item_text`
 issuing the standard FTS5 external-content maintenance commands.
 
-Ranking is `bm25(f, 10.0, 4.0, 1.0)` over title, summary, body, ascending
+Ranking is `bm25(items_fts, 10.0, 4.0, 1.0)` over title, summary, body, ascending
 (bm25 is negative-better), tie-broken by `effective_date DESC, i.id DESC` so the
 ordering is total.
 

--- a/docs/dev-sessions/2026-08-26-1247-fts5-search/spec.md
+++ b/docs/dev-sessions/2026-08-26-1247-fts5-search/spec.md
@@ -1,0 +1,193 @@
+# Full-Text Search Spec
+
+**Goal:** Give `feedspool items --search` and `GET /api/v1/items?q=` real
+full-text search — matching bodies and summaries, ranked by relevance, over an
+index instead of a table scan — and leave behind the shared text substrate that
+#30 will build on.
+
+**Source:** https://github.com/lmorchard/feedspool-go/issues/58
+
+## Current state
+
+Search is a case-insensitive substring match over `items.title` only, spelled
+identically in two places (`item_repository.go:442`, `pagination.go:175`) so the
+CLI and API cannot drift. It matches no body text, cannot rank, and scans every
+row. See `research.md` for the full map of surfaces and write paths.
+
+Three facts from `research.md` shape everything below:
+
+1. FTS5 is compiled into `modernc.org/sqlite` under `CGO_ENABLED=0`, including
+   external-content tables and `bm25()`. Measured, not assumed.
+2. An FTS5 delete trigger on the indexed table **does** fire when rows go away
+   via `ON DELETE CASCADE`. This is what makes trigger-based maintenance safe
+   given that `DeleteFeed` removes items without touching any item write path.
+3. `?q=` has never shipped in a tagged release — the API merged after `v1.0.2`.
+
+## Desired end state
+
+`q` and `--search` both take a small query language and match title, summary,
+and body:
+
+| Input | Meaning |
+| --- | --- |
+| `rust release` | both terms (implicit AND) |
+| `"release notes"` | phrase |
+| `-draft` | exclude |
+| `secur*` | prefix |
+
+Everything else is a literal term, so `C++`, `foo:bar`, and `NEAR` are text
+rather than FTS5 syntax. A query of nothing but exclusions is a `400` /
+non-zero exit — FTS5 cannot answer "everything except X", and returning zero
+rows would read as a bug.
+
+`sort=relevance` (API) and `--sort relevance` (CLI) join `newest`/`oldest`, and
+are an error without a query. **`newest` stays the default even when a query is
+present.** Search composes with every existing filter — `feed_id`, `since`,
+`seen`, `archived` — as one more `WHERE` condition, not a separate query path.
+
+A new `feedspool reindex [--force]` rebuilds the derived text and index.
+
+## Design decisions
+
+- **Decision:** `q` and `--search` become FTS5 outright. No `match=fts` opt-in,
+  no second parameter.
+  - **Why:** the substring version exists only in an untagged dev build, so
+    this is finishing v1 before it ships rather than breaking it. The v1
+    additive-only rule is about released contracts.
+  - **Rejected:** an opt-in `match=fts` parameter, and a separate `fts=`
+    parameter. Both leave two search implementations to maintain forever, a bad
+    default nobody discovers, and a matching CLI flag needed to keep the
+    surfaces in step.
+
+- **Decision:** index a canonical HTML-stripped derivation, not the raw columns.
+  - **Why:** raw columns make markup and href fragments searchable tokens, so
+    `div` matches everything and `snippet()` would emit tag soup. The
+    derivation is also the one text both #58 and #30 must agree on; deriving it
+    twice is how they drift.
+  - **Rejected:** external content over `items` directly — simplest by far, but
+    `content='items'` means FTS5 reads column values back out of `items`, so
+    the indexed text has to *be* the stored text. A Go-side transform and an
+    external-content table over `items` are mutually exclusive.
+
+- **Decision:** one `item_text` table carrying both the derived text and the
+  `(generator, generator_version, source_hash, computed_at)` bookkeeping.
+  - **Why:** it is the tuple both issues asked for, and #30 adds
+    `item_embedding` with the same four columns. The reusable code is a Go
+    backfill runner over a small interface, which #30 implements for embeddings.
+  - **Rejected:** a generic `item_derived_state` table addressing arbitrary
+    generators. Machinery neither feature needs yet; a working pattern plus a
+    shared runner is the cheaper way to prevent drift.
+
+- **Decision:** `title`, `summary`, `body` stay separate columns.
+  - **Why:** `bm25()` column weights are most of the difference between useful
+    and useless ranking. Concatenating throws that away.
+
+- **Decision:** triggers on `item_text` maintain `items_fts`; Go maintains
+  `item_text`.
+  - **Why:** the split follows from what each side can do. Stripping HTML is Go
+    code, so inserts and updates must be Go. Deletes carry no transform, and
+    the probe shows triggers reach the cascade path that Go code cannot see —
+    so purge, archive-purge, and feed-delete need no FTS code at all.
+  - **Rejected:** all-explicit Go maintenance. `DeleteFeed` would silently
+    leave stale index rows, and an external-content table fails silently rather
+    than loudly.
+
+- **Decision:** truncation length is a parameter of the derive function, not a
+  constant. FTS passes a generous cap (a bloat guard only).
+  - **Why:** #30 needs a far smaller cap for embedding token limits. A baked-in
+    number is exactly how two features drift while appearing to share code.
+
+- **Decision:** `sort=relevance` paginates by offset carried inside the opaque
+  cursor; date sorts keep the existing keyset.
+  - **Why:** the cursor is already documented as opaque, so this is invisible
+    to clients. Worst case is the ordinary offset caveat — a repeated or skipped
+    row if the index changes mid-pagination.
+  - **Rejected:** a bm25 score in the cursor. bm25 depends on corpus statistics,
+    so any write shifts every score and the float-equality tiebreak then
+    *skips* rows rather than merely repeating one — a worse failure for a
+    keyset whose whole promise is totality.
+
+- **Decision:** `newest` stays the default sort even when a query is present.
+  - **Why:** a feed reader's search is usually "what's new about X", and it
+    keeps the default path on the keyset cursor rather than quietly moving every
+    search onto offset pagination.
+
+- **Decision:** migration 11 creates the schema and runs the backfill in
+  committed batches with progress logging.
+  - **Why:** resumable by construction, since "stale" is a query against
+    `item_text`. Migrations 4 and 9 already rewrite every item row, so a
+    one-time full pass is an established cost. Deferring the backfill to
+    `reindex` would mean search silently returns nothing until someone runs it.
+
+- **Decision:** strip HTML with `x/net/html`'s streaming tokenizer, not goquery.
+  - **Why:** goquery builds a full document tree per item; this runs over the
+    whole corpus inside a migration.
+
+## Schema
+
+```sql
+CREATE TABLE item_text (
+    item_id           INTEGER PRIMARY KEY REFERENCES items(id) ON DELETE CASCADE,
+    title             TEXT NOT NULL DEFAULT '',
+    summary           TEXT NOT NULL DEFAULT '',
+    body              TEXT NOT NULL DEFAULT '',
+    source_hash       TEXT NOT NULL,
+    generator         TEXT NOT NULL,
+    generator_version INTEGER NOT NULL,
+    computed_at       DATETIME NOT NULL
+);
+
+CREATE VIRTUAL TABLE items_fts USING fts5(
+    title, summary, body,
+    content='item_text', content_rowid='item_id',
+    tokenize="porter unicode61 remove_diacritics 2"
+);
+```
+
+Plus `AFTER INSERT` / `AFTER UPDATE` / `AFTER DELETE` triggers on `item_text`
+issuing the standard FTS5 external-content maintenance commands.
+
+Ranking is `bm25(f, 10.0, 4.0, 1.0)` over title, summary, body, ascending
+(bm25 is negative-better), tie-broken by `effective_date DESC, i.id DESC` so the
+ordering is total.
+
+## Patterns to follow
+
+- Migration with Go logic: the `applySpecificMigration` switch in
+  `internal/database/migrations.go` (see `applyMigration4WithBackfill` at `migrations.go:252`, `applyMigration9` at `migrations.go:402`
+  for the batched-rewrite shape).
+- Query building: `buildItemsQuery` (`item_repository.go:411`) and
+  `itemPageConditions` (`pagination.go:155`). Search is one more condition in
+  each; the shared SQL fragment must be spelled once, the way the current
+  `instr()` duplication is guarded by a comment at `pagination.go:174`.
+- API parameter validation: `parseItemFilters` (`internal/api/items.go:142`)
+  and the helpers in `internal/api/params.go`.
+- HTML handling precedent: `internal/scraper/scraper.go`.
+- Cursor encode/decode: `internal/api/cursor.go`.
+
+## What we're NOT doing
+
+- **`include=snippet`.** `snippet()` works for free with an external-content
+  table, but nothing in feedspool renders search results yet, and it is purely
+  additive whenever it is wanted.
+- **Exposing a relevance score in the item DTO.** Same reasoning.
+- **Anything from #30.** No embeddings, no clustering, no provider config. This
+  spec leaves a substrate; it does not consume it.
+- **`NEAR`, column filters (`title:foo`), or `OR` in the query language.** The
+  parser treats them as literal text. Adding operators later is additive.
+- **Changing `GetItems`' filter or sort semantics beyond adding search and
+  relevance.** #60 just rewrote that function; this is not a second pass at it.
+- **Touching `MarkItemsArchived` or the purge paths.** Triggers cover them.
+- **A `total` or result-count field on search responses.** Same reasoning as the
+  v1 spec: a second scan, wrong by the time the client reads it.
+
+## Open questions
+
+- **How aggressive should the FTS truncation cap be?** Default: 256 KiB of
+  stripped body, as a bloat guard rather than a recall limit — long-form
+  articles run well under it. Revisit only if the smoke test against a real
+  database shows items hitting the cap.
+- **Should `porter` stemming be on?** Default: yes. It helps recall
+  ("networking" finds "network") at a small cost to exact known-item lookup.
+  `generator_version` exists precisely so this can be changed later with a
+  forced reindex, so it is a reversible call rather than a load-bearing one.

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -25,6 +25,13 @@ const (
 	maxFeedLimit     = 500
 )
 
+// maxQueryLength caps q. No search box comes close; the cap is here because
+// net/http's default request-line limit otherwise admits a flat AND chain of
+// roughly 200,000 terms, FTS5 puts no depth limit on that shape, and the
+// database pool is one connection wide -- so a single such request would hold
+// up every other caller for as long as it ran.
+const maxQueryLength = 2048
+
 // Config is everything the API needs from its host.
 type Config struct {
 	DB *database.DB

--- a/internal/api/cursor.go
+++ b/internal/api/cursor.go
@@ -71,6 +71,12 @@ func decodeItemCursor(encoded string) (*database.ItemCursor, error) {
 	if payload.DateRank != 0 && payload.DateRank != 1 {
 		return nil, fmt.Errorf("cursor date rank %d is out of range", payload.DateRank)
 	}
+	// SQLite clamps a negative OFFSET to zero, so a forged negative offset
+	// would return page 1 and hand back a still-negative next cursor -- the
+	// paging loop this decoder's contract says cannot happen.
+	if payload.Offset < 0 {
+		return nil, fmt.Errorf("cursor offset %d is out of range", payload.Offset)
+	}
 
 	return &database.ItemCursor{
 		DateRank:      payload.DateRank,

--- a/internal/api/cursor.go
+++ b/internal/api/cursor.go
@@ -13,11 +13,17 @@ import (
 // is detectable rather than silently misparsed into a wrong position.
 const cursorVersion = 1
 
+// Relevance and Offset are omitempty and cursorVersion stays 1 on purpose: the
+// decoder uses DisallowUnknownFields, and a cursor issued before relevance
+// existed decodes with both fields zero, which is exactly the date-mode cursor
+// it already was.
 type itemCursorPayload struct {
 	Version       int     `json:"v"`
 	DateRank      int     `json:"r"`
 	EffectiveDate float64 `json:"d"`
 	ID            int64   `json:"i"`
+	Relevance     bool    `json:"m,omitempty"`
+	Offset        int     `json:"o,omitempty"`
 }
 
 // encodeItemCursor renders a cursor as an opaque string. The encoding is
@@ -32,9 +38,11 @@ func encodeItemCursor(cursor *database.ItemCursor) string {
 		DateRank:      cursor.DateRank,
 		EffectiveDate: cursor.EffectiveDate,
 		ID:            cursor.ID,
+		Relevance:     cursor.Relevance,
+		Offset:        cursor.Offset,
 	})
 	if err != nil {
-		// The payload is four scalars; Marshal cannot fail on it.
+		// The payload is a handful of scalars; Marshal cannot fail on it.
 		return ""
 	}
 	return base64.RawURLEncoding.EncodeToString(payload)
@@ -68,6 +76,8 @@ func decodeItemCursor(encoded string) (*database.ItemCursor, error) {
 		DateRank:      payload.DateRank,
 		EffectiveDate: payload.EffectiveDate,
 		ID:            payload.ID,
+		Relevance:     payload.Relevance,
+		Offset:        payload.Offset,
 	}, nil
 }
 

--- a/internal/api/foundation_test.go
+++ b/internal/api/foundation_test.go
@@ -330,4 +330,16 @@ func TestAnnotationDTOPassesThroughUnparseableTimestamp(t *testing.T) {
 	}
 }
 
+// The decoder range-checks DateRank; Offset needs the same treatment. A
+// negative offset is not a position SQLite can honor -- it clamps to zero --
+// so accepting one hands the caller a cursor that never advances.
+func TestDecodeItemCursorRejectsNegativeOffset(t *testing.T) {
+	for _, offset := range []int{-1, -9007199254740991} {
+		encoded := encodeItemCursor(&database.ItemCursor{Relevance: true, Offset: offset})
+		if got, err := decodeItemCursor(encoded); err == nil {
+			t.Errorf("decodeItemCursor(offset %d) = %+v, want an error", offset, got)
+		}
+	}
+}
+
 func boolPtr(value bool) *bool { return &value }

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -778,6 +778,88 @@ func TestDiscoveredAtKeepsSubSecondPrecisionForPolling(t *testing.T) {
 	}
 }
 
+// A NUL byte in q used to reach FTS5 verbatim. SQLite reads the bound MATCH
+// operand as a NUL-terminated C string, so the expression truncated
+// mid-literal, FTS5 raised "unterminated string", and the handler surfaced it
+// as a 500 -- for a plain query-string parameter, from any client.
+func TestListItemsSearchToleratesControlCharactersInQuery(t *testing.T) {
+	h := newTestHarness(t, "")
+	h.seedSearchable(t, searchCorpusSize)
+
+	clean, _ := h.getCollection(t, searchPath("&limit=100"))
+	want := itemIDsFrom(t, clean)
+	if len(want) != searchCorpusSize {
+		t.Fatalf("baseline matches = %d, want %d", len(want), searchCorpusSize)
+	}
+
+	cases := []struct{ name, query string }{
+		{"leading nul", "\x00" + searchTerm},
+		{"trailing nul", searchTerm + "\x00"},
+		{"surrounding nuls", "\x00" + searchTerm + "\x00"},
+		{"other c0 controls", "\x01" + searchTerm + "\x1f"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, _ := h.getCollection(t, pathItems+"?limit=100&q="+url.QueryEscape(tc.query))
+			if got := itemIDsFrom(t, data); !slices.Equal(got, want) {
+				t.Errorf("q=%q matched %d items, want the same %d as q=%q",
+					tc.query, len(got), len(want), searchTerm)
+			}
+		})
+	}
+
+	// A query of nothing but control characters reduces to no filter at all,
+	// which is the same as omitting q rather than an error.
+	status, payload := h.get(t, pathItems+"?limit=100&q="+url.QueryEscape("\x00"))
+	if status != http.StatusOK {
+		t.Fatalf("q=%%00 status = %d, want 200: %s", status, payload)
+	}
+}
+
+// q is capped. Without one, a request-line-sized flat AND chain executes
+// happily and holds the single database connection for the duration.
+func TestListItemsRejectsOverlongQuery(t *testing.T) {
+	h := newTestHarness(t, "")
+	h.seedSearchable(t, 1)
+
+	atLimit := strings.Repeat("a", maxQueryLength)
+	if status, payload := h.get(t, pathItems+"?q="+atLimit); status != http.StatusOK {
+		t.Fatalf("a q of exactly %d characters returned %d: %s", maxQueryLength, status, payload)
+	}
+
+	// The cap counts characters, not bytes, so a multi-byte query is not
+	// rejected earlier than an ASCII one of the same length.
+	multibyte := url.QueryEscape(strings.Repeat("\u00e9", maxQueryLength))
+	if status, payload := h.get(t, pathItems+"?q="+multibyte); status != http.StatusOK {
+		t.Fatalf("a q of %d multi-byte characters returned %d: %s", maxQueryLength, status, payload)
+	}
+
+	status, payload := h.get(t, pathItems+"?q="+atLimit+"a")
+	if status != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", status, payload)
+	}
+	assertErrorCode(t, payload, codeInvalidParameter)
+}
+
+// A forged cursor carrying a negative offset used to be accepted. SQLite
+// clamps a negative OFFSET to zero, so the caller got page 1 back together
+// with a still-negative next cursor, and a paging loop then re-read page 1
+// roughly |offset|/limit times without ever advancing or reporting a problem.
+func TestListItemsRejectsCursorWithNegativeOffset(t *testing.T) {
+	h := newTestHarness(t, "")
+	h.seedSearchable(t, searchCorpusSize)
+
+	for _, offset := range []int{-1, -9007199254740991} {
+		forged := encodeItemCursor(&database.ItemCursor{Relevance: true, Offset: offset})
+		path := searchPath(relevanceSuffix() + "&limit=5&" + paramCursor + "=" + url.QueryEscape(forged))
+		status, payload := h.get(t, path)
+		if status != http.StatusBadRequest {
+			t.Fatalf("offset %d status = %d, want 400: %s", offset, status, payload)
+		}
+		assertErrorCode(t, payload, codeInvalidCursor)
+	}
+}
+
 func mustGet(t *testing.T, h *testHarness, path string) []byte {
 	t.Helper()
 	status, payload := h.get(t, path)

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -311,27 +312,262 @@ func TestListItemsRejectsConflictingFeedFilters(t *testing.T) {
 	assertErrorCode(t, payload, codeInvalidParameter)
 }
 
-func TestListItemsSearchMatchesTitleOnly(t *testing.T) {
+// searchPath builds an item search URL for searchTerm, with extra appended.
+func searchPath(extra string) string {
+	return pathItems + "?q=" + searchTerm + extra
+}
+
+// relevanceSuffix is the query fragment that asks for relevance ordering.
+func relevanceSuffix() string {
+	return "&" + paramSort + "=" + database.SortRelevance
+}
+
+// seedSearchable inserts count items that all mention searchTerm -- in the
+// title for every other one, in the body otherwise -- so relevance has
+// something to rank and every item is a hit.
+func (h *testHarness) seedSearchable(t *testing.T, count int) {
+	t.Helper()
+	if err := h.db.UpsertFeed(&database.Feed{
+		URL: testFeedURL, Title: testFeedName, Type: database.FeedTypeRSS,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	for i := range count {
+		title := fmt.Sprintf("Dispatch %02d", i)
+		if i%2 == 0 {
+			title = fmt.Sprintf("%s digest %02d", searchTerm, i)
+		}
+		if err := h.db.UpsertItem(&database.Item{
+			FeedURL:       testFeedURL,
+			GUID:          fmt.Sprintf("search-%02d", i),
+			Title:         title,
+			Link:          fmt.Sprintf("https://example.com/s/%02d", i),
+			Summary:       "<p>Assorted notes on other subjects entirely.</p>",
+			Content:       "<div>" + strings.Repeat(searchTerm+" ", 1+i%3) + "notes</div>",
+			PublishedDate: base.Add(time.Duration(i) * time.Hour),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// itemIDsFrom pulls the item ids out of a decoded collection, in order.
+func itemIDsFrom(t *testing.T, data []any) []string {
+	t.Helper()
+	out := make([]string, 0, len(data))
+	for _, entry := range data {
+		item, ok := entry.(map[string]any)
+		if !ok {
+			t.Fatalf("collection entry is not an object: %v", entry)
+		}
+		id, ok := item[fieldID].(string)
+		if !ok {
+			t.Fatalf("item carries no id: %v", item)
+		}
+		out = append(out, id)
+	}
+	return out
+}
+
+// getCollection issues a request the test expects to succeed and decodes it.
+func (h *testHarness) getCollection(t *testing.T, path string) (data []any, nextCursor string) {
+	t.Helper()
+	status, payload := h.get(t, path)
+	if status != http.StatusOK {
+		t.Fatalf("GET %s status = %d: %s", path, status, payload)
+	}
+	data, nextCursor, _ = decodeCollection(t, payload)
+	return data, nextCursor
+}
+
+// Replaces TestListItemsSearchMatchesTitleOnly. Rewritten rather than deleted:
+// the old test pinned the title-substring contract, and this one is the record
+// that the contract changed deliberately.
+func TestListItemsSearchMatchesBodyAndSummary(t *testing.T) {
 	h := newTestHarness(t, "")
 	h.seed(t)
 
-	status, payload := h.get(t, "/api/v1/items?q=Article+3")
-	if status != http.StatusOK {
-		t.Fatalf("status = %d: %s", status, payload)
+	// Each query pairs a term from one field with the digit that appears only
+	// in item 3, so only that item matches all of them.
+	for _, query := range []string{"Article+3", "body+3", "summary+3"} {
+		t.Run(query, func(t *testing.T) {
+			data, _ := h.getCollection(t, pathItems+"?q="+query)
+			if len(data) != 1 {
+				t.Fatalf("q=%s results = %d, want 1", query, len(data))
+			}
+			item, ok := data[0].(map[string]any)
+			if !ok {
+				t.Fatalf("collection entry is not an object: %v", data[0])
+			}
+			if item[fieldTitle] != "Article 3" {
+				t.Errorf("q=%s matched %v, want Article 3", query, item[fieldTitle])
+			}
+		})
 	}
-	data, _, _ := decodeCollection(t, payload)
-	if len(data) != 1 {
-		t.Fatalf("results = %d, want 1", len(data))
+}
+
+// Relevance paginates by an offset carried inside the opaque cursor. Absent
+// writes, that has to keep the same totality property the keyset cursor has:
+// every match exactly once, in the order a single unpaged request gives.
+func TestListItemsRelevancePaginatesWithoutGapsOrRepeats(t *testing.T) {
+	h := newTestHarness(t, "")
+	h.seedSearchable(t, searchCorpusSize)
+
+	unpaged, next := h.getCollection(t, searchPath(relevanceSuffix()+"&limit=100"))
+	if next != "" {
+		t.Fatalf("unpaged request returned a cursor with only %d matches", searchCorpusSize)
+	}
+	want := itemIDsFrom(t, unpaged)
+	if len(want) != searchCorpusSize {
+		t.Fatalf("unpaged results = %d, want %d", len(want), searchCorpusSize)
 	}
 
-	// "body 3" appears in the content but not the title, so q must not match.
-	status, payload = h.get(t, "/api/v1/items?q=body+3")
-	if status != http.StatusOK {
-		t.Fatalf("status = %d: %s", status, payload)
+	var got []string
+	cursor := ""
+	for pages := 0; ; pages++ {
+		if pages > 10 {
+			t.Fatal("relevance pagination did not terminate")
+		}
+		path := searchPath(relevanceSuffix() + "&limit=10")
+		if cursor != "" {
+			path += "&" + paramCursor + "=" + url.QueryEscape(cursor)
+		}
+		data, nextCursor := h.getCollection(t, path)
+		got = append(got, itemIDsFrom(t, data)...)
+		if nextCursor == "" {
+			break
+		}
+		cursor = nextCursor
 	}
-	data, _, _ = decodeCollection(t, payload)
-	if len(data) != 0 {
-		t.Errorf("q matched content; results = %d, want 0", len(data))
+
+	if !slices.Equal(got, want) {
+		t.Errorf("paged relevance = %v, want the unpaged order %v", got, want)
+	}
+	distinct := map[string]bool{}
+	for _, id := range got {
+		if distinct[id] {
+			t.Fatalf("item %s was returned twice across a page boundary", id)
+		}
+		distinct[id] = true
+	}
+	if len(distinct) != searchCorpusSize {
+		t.Errorf("distinct ids paged = %d, want %d", len(distinct), searchCorpusSize)
+	}
+}
+
+// A cursor from one ordering means nothing in another: a relevance cursor
+// carries an offset, a date cursor carries a keyset position. Replaying the
+// wrong one has to be an error rather than a silently wrong page.
+func TestListItemsRejectsCursorFromAnotherSort(t *testing.T) {
+	h := newTestHarness(t, "")
+	h.seedSearchable(t, searchCorpusSize)
+
+	_, relevanceCursor := h.getCollection(t, searchPath(relevanceSuffix()+"&limit=5"))
+	_, dateCursor := h.getCollection(t, searchPath("&limit=5"))
+	if relevanceCursor == "" || dateCursor == "" {
+		t.Fatalf("cursors = (%q, %q), want both non-empty", relevanceCursor, dateCursor)
+	}
+
+	cases := []struct{ name, path string }{
+		{
+			"relevance cursor replayed as newest",
+			searchPath("&limit=5&" + paramCursor + "=" + url.QueryEscape(relevanceCursor)),
+		},
+		{
+			"date cursor replayed as relevance",
+			searchPath(relevanceSuffix() + "&limit=5&" + paramCursor + "=" + url.QueryEscape(dateCursor)),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			status, payload := h.get(t, tc.path)
+			if status != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400: %s", status, payload)
+			}
+			assertErrorCode(t, payload, codeInvalidCursor)
+		})
+	}
+}
+
+func TestListItemsRelevanceRequiresQuery(t *testing.T) {
+	h := newTestHarness(t, "")
+	h.seedSearchable(t, searchCorpusSize)
+
+	status, payload := h.get(t, pathItems+"?"+paramSort+"="+database.SortRelevance)
+	if status != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", status, payload)
+	}
+	assertErrorCode(t, payload, codeInvalidParameter)
+
+	// A bare "*" is a non-empty q that the parser reduces to no expression, so
+	// it slips past the check above and leaves relevance with nothing to rank.
+	// That is still the caller's mistake, not a 500.
+	status, payload = h.get(t, pathItems+"?q=*&"+paramSort+"="+database.SortRelevance)
+	if status != http.StatusBadRequest {
+		t.Fatalf("q=* status = %d, want 400: %s", status, payload)
+	}
+	assertErrorCode(t, payload, codeInvalidParameter)
+
+	// The same sort with a query is accepted, so the rejections above are about
+	// the missing query rather than about relevance not being a known ordering.
+	if data, _ := h.getCollection(t, searchPath(relevanceSuffix())); len(data) == 0 {
+		t.Error("sort=relevance with a query returned nothing")
+	}
+}
+
+// A query with nothing to match is the user's mistake, not the server's.
+func TestListItemsOnlyExclusionsIsBadRequest(t *testing.T) {
+	h := newTestHarness(t, "")
+	h.seedSearchable(t, searchCorpusSize)
+
+	status, payload := h.get(t, pathItems+"?q=-draft")
+	if status != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", status, payload)
+	}
+	assertErrorCode(t, payload, codeInvalidParameter)
+}
+
+// A query does not imply relevance. This is an explicit spec decision -- a
+// feed reader's search is usually "what is new about X" -- and it keeps the
+// default path on the keyset cursor rather than quietly moving every search
+// onto offset pagination. Asserting it makes a later change to the default
+// deliberate.
+func TestListItemsDefaultsToNewestWithAQuery(t *testing.T) {
+	h := newTestHarness(t, "")
+	h.seedSearchable(t, searchCorpusSize)
+
+	data, next := h.getCollection(t, searchPath("&limit=5"))
+	if len(data) != 5 {
+		t.Fatalf("results = %d, want 5", len(data))
+	}
+
+	previous := ""
+	for _, entry := range data {
+		item, ok := entry.(map[string]any)
+		if !ok {
+			t.Fatalf("collection entry is not an object: %v", entry)
+		}
+		published, ok := item["published_date"].(string)
+		if !ok {
+			t.Fatalf("item carries no published_date: %v", item)
+		}
+		if previous != "" && published >= previous {
+			t.Errorf("published_date %s follows %s; the default ordering is not newest-first",
+				published, previous)
+		}
+		previous = published
+	}
+
+	cursor, err := decodeItemCursor(next)
+	if err != nil {
+		t.Fatalf("decodeItemCursor(%q) error = %v", next, err)
+	}
+	if cursor.Relevance || cursor.Offset != 0 {
+		t.Errorf("cursor = %+v, want a keyset cursor; a query must not imply relevance", *cursor)
+	}
+	if cursor.ID == 0 {
+		t.Errorf("cursor = %+v, want a keyset position", *cursor)
 	}
 }
 
@@ -513,7 +749,7 @@ func TestSinceAcceptsTheTimestampsWeEmit(t *testing.T) {
 // whole-second timestamps; a run against a real database caught it.
 func TestDiscoveredAtKeepsSubSecondPrecisionForPolling(t *testing.T) {
 	h := newTestHarness(t, "")
-	if err := h.db.UpsertFeed(&database.Feed{URL: testFeedURL, Title: "Feed"}); err != nil {
+	if err := h.db.UpsertFeed(&database.Feed{URL: testFeedURL, Title: testFeedName}); err != nil {
 		t.Fatal(err)
 	}
 	stamp := time.Date(2026, 8, 25, 19, 56, 20, 530695000, time.UTC)

--- a/internal/api/items.go
+++ b/internal/api/items.go
@@ -5,14 +5,19 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/lmorchard/feedspool-go/internal/database"
+	"github.com/lmorchard/feedspool-go/internal/search"
 )
 
+// Bound to the database constants rather than re-spelled, so a rename cannot
+// leave the two packages disagreeing about what "relevance" is called.
 const (
-	sortNewest = "newest"
-	sortOldest = "oldest"
+	sortNewest    = database.SortNewest
+	sortOldest    = database.SortOldest
+	sortRelevance = database.SortRelevance
 )
 
 // cursorError marks a parse failure as a cursor problem so the handler reports
@@ -39,6 +44,14 @@ func (s *Server) handleListItems(w http.ResponseWriter, r *http.Request) {
 
 	items, next, err := s.cfg.DB.ListItems(page)
 	if err != nil {
+		// A query with nothing to match, or a relevance sort with nothing to
+		// rank, is the caller's mistake rather than a database failure, so
+		// neither may fall through to a 500.
+		if errors.Is(err, search.ErrOnlyExclusions) ||
+			errors.Is(err, database.ErrRelevanceNeedsSearch) {
+			writeError(w, http.StatusBadRequest, codeInvalidParameter, err.Error())
+			return
+		}
 		writeInternalError(w, err, "list items")
 		return
 	}
@@ -88,6 +101,15 @@ func (s *Server) buildItemPage(query url.Values) (*database.ItemPage, includeSet
 		}
 	}
 
+	// A cursor from one ordering means nothing in another: a relevance cursor
+	// carries an offset, a date cursor carries a keyset position. Replaying the
+	// wrong one would silently return a wrong page rather than an error. The
+	// check lives here rather than in decodeItemCursor because this is where
+	// the requested sort is known.
+	if after != nil && after.Relevance != (filters.sort == sortRelevance) {
+		return nil, nil, cursorError{fmt.Errorf("cursor does not match %s=%s", paramSort, filters.sort)}
+	}
+
 	return &database.ItemPage{
 		FeedURL:   feedURL,
 		FeedQuery: feedQuery,
@@ -98,6 +120,7 @@ func (s *Server) buildItemPage(query url.Values) (*database.ItemPage, includeSet
 		Seen:      filters.seen,
 		Archived:  filters.archived,
 		Ascending: filters.ascending,
+		Sort:      filters.sort,
 		Limit:     limit,
 		After:     after,
 	}, include, nil
@@ -137,6 +160,10 @@ type itemFilters struct {
 	seen      *bool
 	archived  *bool
 	ascending bool
+	// sort is kept alongside ascending because relevance is not a direction:
+	// the cursor-mode check and the page's ordering both need to know which of
+	// the three orderings was requested, not just which way it runs.
+	sort string
 }
 
 func parseItemFilters(query url.Values) (itemFilters, error) {
@@ -168,9 +195,14 @@ func parseItemFilters(query url.Values) (itemFilters, error) {
 	if sort == "" {
 		sort = sortNewest
 	}
-	if sort != sortNewest && sort != sortOldest {
-		return filters, fmt.Errorf("%s must be %s or %s", paramSort, sortNewest, sortOldest)
+	if sort != sortNewest && sort != sortOldest && sort != sortRelevance {
+		return filters, fmt.Errorf("%s must be %s, %s or %s",
+			paramSort, sortNewest, sortOldest, sortRelevance)
 	}
+	if sort == sortRelevance && strings.TrimSpace(query.Get(paramQuery)) == "" {
+		return filters, fmt.Errorf("%s=%s requires %s", paramSort, sortRelevance, paramQuery)
+	}
+	filters.sort = sort
 	filters.ascending = sort == sortOldest
 
 	return filters, nil

--- a/internal/api/items.go
+++ b/internal/api/items.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/lmorchard/feedspool-go/internal/database"
 	"github.com/lmorchard/feedspool-go/internal/search"
@@ -191,6 +192,12 @@ func parseItemFilters(query url.Values) (itemFilters, error) {
 		return filters, fmt.Errorf("%s: %w", paramArchived, err)
 	}
 
+	rawQuery := query.Get(paramQuery)
+	if length := utf8.RuneCountInString(rawQuery); length > maxQueryLength {
+		return filters, fmt.Errorf("%s is %d characters; the maximum is %d",
+			paramQuery, length, maxQueryLength)
+	}
+
 	sort := query.Get(paramSort)
 	if sort == "" {
 		sort = sortNewest
@@ -199,7 +206,7 @@ func parseItemFilters(query url.Values) (itemFilters, error) {
 		return filters, fmt.Errorf("%s must be %s, %s or %s",
 			paramSort, sortNewest, sortOldest, sortRelevance)
 	}
-	if sort == sortRelevance && strings.TrimSpace(query.Get(paramQuery)) == "" {
+	if sort == sortRelevance && strings.TrimSpace(rawQuery) == "" {
 		return filters, fmt.Errorf("%s=%s requires %s", paramSort, sortRelevance, paramQuery)
 	}
 	filters.sort = sort

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -174,8 +174,10 @@ paths:
         - name: q
           in: query
           description: |
-            Case-insensitive substring match on the item title only -- not body
-            or summary. Identical to `feedspool items --search`.
+            Full-text search over the item title, summary and body. Terms are
+            ANDed; `"quoted phrases"`, `-exclusions` and `prefix*` are
+            supported; everything else is matched literally. Identical to
+            `feedspool items --search`.
           schema: { type: string }
         - name: since
           in: query
@@ -199,7 +201,11 @@ paths:
           schema: { type: string, enum: ["true", "false", "any"], default: "false" }
         - name: sort
           in: query
-          schema: { type: string, enum: [newest, oldest], default: newest }
+          description: |
+            `relevance` requires `q` and is the only ordering that does not use
+            a keyset cursor; its cursors are not interchangeable with the
+            others.
+          schema: { type: string, enum: [newest, oldest, relevance], default: newest }
         - name: limit
           in: query
           schema: { type: integer, minimum: 1, maximum: 200, default: 50 }

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -178,7 +178,11 @@ paths:
             ANDed; `"quoted phrases"`, `-exclusions` and `prefix*` are
             supported; everything else is matched literally. Identical to
             `feedspool items --search`.
-          schema: { type: string }
+
+            At most 2048 characters; longer queries are rejected with
+            `400 invalid_parameter`. A query of nothing but exclusions is
+            rejected the same way.
+          schema: { type: string, maxLength: 2048 }
         - name: since
           in: query
           description: |

--- a/internal/api/testconst_test.go
+++ b/internal/api/testconst_test.go
@@ -9,6 +9,7 @@ const (
 	testFeedURL2 = "https://other.example.org/rss"
 	jsonType     = "application/json"
 	testVersion  = "test"
+	testFeedName = "Feed"
 
 	kindSeen  = "seen"
 	kindTag   = "tag"
@@ -25,7 +26,13 @@ const (
 	unknownItemID = "ffffffffffffffff"
 	fieldItemIDs  = "item_ids"
 	pathStatus    = "/api/v1/status"
+	pathItems     = "/api/v1/items"
 	fieldKindKey  = "kind"
+
+	// searchTerm appears in every item seedSearchable inserts, and
+	// searchCorpusSize is how many of them there are.
+	searchTerm       = "kubernetes"
+	searchCorpusSize = 25
 )
 
 // jsonBody marshals a request body for tests that build one dynamically.

--- a/internal/database/backfill.go
+++ b/internal/database/backfill.go
@@ -41,6 +41,11 @@ func (db *DB) RunBackfill(gen DerivedBackfill, batchSize int, progress func(done
 	if err != nil {
 		return err
 	}
+	// Name and version together identify a run. After a version bump this line
+	// is what says whether the reindex it was supposed to force actually found
+	// anything to do.
+	logrus.Debugf("Starting %s backfill v%d: %d items outstanding, batch size %d",
+		gen.Name(), gen.Version(), total, batchSize)
 
 	var done, afterID int64
 	for {
@@ -107,7 +112,8 @@ func (db *DB) runBackfillBatch(gen DerivedBackfill, afterID int64, batchSize int
 	}
 
 	if err := gen.Recompute(tx, ids); err != nil {
-		return nil, fmt.Errorf("failed to recompute %s for %d items: %w", gen.Name(), len(ids), err)
+		return nil, fmt.Errorf("failed to recompute %s v%d for %d items: %w",
+			gen.Name(), gen.Version(), len(ids), err)
 	}
 
 	if err := tx.Commit(); err != nil {

--- a/internal/database/backfill.go
+++ b/internal/database/backfill.go
@@ -1,0 +1,118 @@
+package database
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+)
+
+// DerivedBackfill describes an artifact derived from items that must be
+// recomputed when the item changes or the generator's version moves. #58
+// implements it for FTS text; #30 implements it for embeddings.
+type DerivedBackfill interface {
+	Name() string
+	Version() int
+	// NextBatch returns up to limit item IDs still needing work, all with
+	// id > afterID, in ascending id order.
+	NextBatch(tx *sql.Tx, afterID int64, limit int) ([]int64, error)
+	// Recompute derives and stores the artifact for those item IDs.
+	Recompute(tx *sql.Tx, ids []int64) error
+	// Remaining reports how many items still need work, for progress output.
+	Remaining(tx *sql.Tx) (int64, error)
+}
+
+const defaultBackfillBatchSize = 500
+
+// RunBackfill processes the generator in committed batches, so an interrupted
+// run resumes where it stopped instead of restarting, and a large database is
+// never held in one transaction.
+//
+// progress may be nil. It is called after each committed batch with the number
+// of items this run has processed and the number it found outstanding when it
+// started; a resumed run therefore counts from zero against the smaller
+// remainder, not against the whole corpus.
+func (db *DB) RunBackfill(gen DerivedBackfill, batchSize int, progress func(done, total int64)) error {
+	if batchSize <= 0 {
+		batchSize = defaultBackfillBatchSize
+	}
+
+	total, err := db.backfillRemaining(gen)
+	if err != nil {
+		return err
+	}
+
+	var done, afterID int64
+	for {
+		ids, err := db.runBackfillBatch(gen, afterID, batchSize)
+		if err != nil {
+			return err
+		}
+		if len(ids) == 0 {
+			return nil
+		}
+		// Advancing the cursor past the largest ID in the batch is what makes
+		// the loop terminate: a row the generator cannot bring up to date is
+		// skipped on the next pass instead of being selected forever.
+		afterID = ids[len(ids)-1]
+		done += int64(len(ids))
+		if progress != nil {
+			progress(done, total)
+		}
+	}
+}
+
+// backfillRemaining reads the outstanding count in its own short transaction.
+func (db *DB) backfillRemaining(gen DerivedBackfill) (int64, error) {
+	tx, err := db.conn.Begin()
+	if err != nil {
+		return 0, fmt.Errorf("failed to begin %s backfill count: %w", gen.Name(), err)
+	}
+	// Read-only, so it is always rolled back rather than committed.
+	defer func() {
+		if rollbackErr := tx.Rollback(); rollbackErr != nil {
+			logrus.WithError(rollbackErr).Warn("Failed to roll back backfill count transaction")
+		}
+	}()
+
+	remaining, err := gen.Remaining(tx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to count remaining %s work: %w", gen.Name(), err)
+	}
+	return remaining, nil
+}
+
+// runBackfillBatch recomputes one batch and commits it, returning the IDs it
+// processed. An empty result means there is nothing left to do.
+func (db *DB) runBackfillBatch(gen DerivedBackfill, afterID int64, batchSize int) ([]int64, error) {
+	tx, err := db.conn.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("failed to begin %s backfill batch: %w", gen.Name(), err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			if rollbackErr := tx.Rollback(); rollbackErr != nil {
+				logrus.WithError(rollbackErr).Warn("Failed to roll back backfill batch")
+			}
+		}
+	}()
+
+	ids, err := gen.NextBatch(tx, afterID, batchSize)
+	if err != nil {
+		return nil, fmt.Errorf("failed to select %s backfill batch: %w", gen.Name(), err)
+	}
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	if err := gen.Recompute(tx, ids); err != nil {
+		return nil, fmt.Errorf("failed to recompute %s for %d items: %w", gen.Name(), len(ids), err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("failed to commit %s backfill batch: %w", gen.Name(), err)
+	}
+	committed = true
+	return ids, nil
+}

--- a/internal/database/backfill_test.go
+++ b/internal/database/backfill_test.go
@@ -34,6 +34,11 @@ func TestRunBackfillIsResumable(t *testing.T) {
 		batchSize = 10
 	)
 	db := seedSearchableItems(t, itemCount)
+	// Phase 3's UpsertItem derives item_text on write, so the seeded items are
+	// already indexed. Discard that to reproduce the case this test is about:
+	// existing items whose derived text is missing or stale, which is what
+	// gives the interrupted backfill real work to interrupt.
+	execSQL(t, db, `DELETE FROM item_text`)
 
 	var reported [][2]int64
 	interrupted := &interruptedBackfill{

--- a/internal/database/backfill_test.go
+++ b/internal/database/backfill_test.go
@@ -1,0 +1,128 @@
+package database
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/lmorchard/feedspool-go/internal/itemtext"
+)
+
+// errBackfillInterrupted stands in for a crash, a SIGINT, or a disk error
+// partway through a long backfill.
+var errBackfillInterrupted = errors.New("backfill interrupted")
+
+// interruptedBackfill runs the real generator for allowedBatches batches and
+// then fails, leaving whatever was already committed on disk.
+type interruptedBackfill struct {
+	DerivedBackfill
+	allowedBatches int
+	batches        int
+}
+
+func (g *interruptedBackfill) NextBatch(tx *sql.Tx, afterID int64, limit int) ([]int64, error) {
+	if g.batches >= g.allowedBatches {
+		return nil, errBackfillInterrupted
+	}
+	g.batches++
+	return g.DerivedBackfill.NextBatch(tx, afterID, limit)
+}
+
+func TestRunBackfillIsResumable(t *testing.T) {
+	const (
+		itemCount = 25
+		batchSize = 10
+	)
+	db := seedSearchableItems(t, itemCount)
+
+	var reported [][2]int64
+	interrupted := &interruptedBackfill{
+		DerivedBackfill: newItemTextBackfill(itemtext.DefaultOptions()),
+		allowedBatches:  1,
+	}
+	err := db.RunBackfill(interrupted, batchSize, func(done, total int64) {
+		reported = append(reported, [2]int64{done, total})
+	})
+	if !errors.Is(err, errBackfillInterrupted) {
+		t.Fatalf("RunBackfill() error = %v, want %v", err, errBackfillInterrupted)
+	}
+	if got := countItemTextRows(t, db); got != batchSize {
+		t.Errorf("after the interrupted run item_text has %d rows, want the one committed batch of %d",
+			got, batchSize)
+	}
+	if len(reported) != 1 || reported[0] != [2]int64{batchSize, itemCount} {
+		t.Errorf("progress reported %v, want one call of (%d, %d)", reported, batchSize, itemCount)
+	}
+	integrityCheck(t, db)
+
+	// Resuming picks up where the interrupted run stopped rather than starting over.
+	reported = reported[:0]
+	if err := db.RunBackfill(
+		newItemTextBackfill(itemtext.DefaultOptions()), batchSize,
+		func(done, total int64) { reported = append(reported, [2]int64{done, total}) },
+	); err != nil {
+		t.Fatalf("resumed RunBackfill() error = %v", err)
+	}
+	if len(reported) == 0 || reported[0][1] != itemCount-batchSize {
+		t.Errorf("resumed run reported %v, want a remaining total of %d", reported, itemCount-batchSize)
+	}
+	if got := countItemTextRows(t, db); got != itemCount {
+		t.Errorf("item_text has %d rows, want %d", got, itemCount)
+	}
+	if got := countIndexedItems(t, db); got != itemCount {
+		t.Errorf("index holds %d items, want %d", got, itemCount)
+	}
+	integrityCheck(t, db)
+}
+
+// TestRunBackfillTerminatesOnUnfixableRow guards the ascending-ID cursor.
+// Without it, a row the generator cannot bring up to date would be selected
+// forever and the loop would never end.
+func TestRunBackfillTerminatesOnUnfixableRow(t *testing.T) {
+	const itemCount = 3
+	db := seedSearchableItems(t, itemCount)
+
+	stuck := &noOpBackfill{db: db}
+	if err := db.RunBackfill(stuck, 1, nil); err != nil {
+		t.Fatalf("RunBackfill() error = %v", err)
+	}
+	// One batch per item, plus the empty batch that ends the loop.
+	if want := itemCount + 1; stuck.batches != want {
+		t.Errorf("generator saw %d batches, want %d -- the cursor did not advance", stuck.batches, want)
+	}
+}
+
+// noOpBackfill reports every item as needing work and never writes anything.
+type noOpBackfill struct {
+	db      *DB
+	batches int
+}
+
+func (g *noOpBackfill) Name() string { return "noop" }
+func (g *noOpBackfill) Version() int { return 1 }
+
+func (g *noOpBackfill) NextBatch(tx *sql.Tx, afterID int64, limit int) ([]int64, error) {
+	g.batches++
+	rows, err := tx.Query(`SELECT id FROM items WHERE id > ? ORDER BY id LIMIT ?`, afterID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+func (g *noOpBackfill) Recompute(_ *sql.Tx, _ []int64) error { return nil }
+
+func (g *noOpBackfill) Remaining(tx *sql.Tx) (int64, error) {
+	var remaining int64
+	err := tx.QueryRow(`SELECT COUNT(*) FROM items`).Scan(&remaining)
+	return remaining, err
+}

--- a/internal/database/item_repository.go
+++ b/internal/database/item_repository.go
@@ -432,6 +432,7 @@ type ItemFilter struct {
 	FeedURL   string
 	FeedQuery string
 	Search    string
+	Sort      string
 	Limit     int
 	Since     time.Time
 	Until     time.Time
@@ -441,7 +442,10 @@ type ItemFilter struct {
 
 // GetItems retrieves items with filtering options.
 func (db *DB) GetItems(filter *ItemFilter) ([]*Item, error) {
-	query, args := buildItemsQuery(filter)
+	query, args, err := buildItemsQuery(filter)
+	if err != nil {
+		return nil, err
+	}
 	rows, err := db.conn.Query(query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get items: %w", err)
@@ -468,12 +472,23 @@ func (db *DB) GetItems(filter *ItemFilter) ([]*Item, error) {
 	return items, nil
 }
 
-func buildItemsQuery(filter *ItemFilter) (query string, args []interface{}) {
+func buildItemsQuery(filter *ItemFilter) (query string, args []interface{}, err error) {
+	searchExpr, err := itemsSearchExpression(filter.Search)
+	if err != nil {
+		return "", nil, err
+	}
+	if filter.Sort == SortRelevance && searchExpr == "" {
+		return "", nil, errRelevanceNeedsSearch
+	}
+
 	query = `
 		SELECT i.id, i.feed_url, i.guid, i.title, i.link, i.published_date, i.first_seen,
 			i.content, i.summary, i.archived, i.item_json
 		FROM items i
 	`
+	if searchExpr != "" {
+		query += itemsFTSJoin
+	}
 	var conditions []string
 
 	if filter.Unseen {
@@ -498,9 +513,9 @@ func buildItemsQuery(filter *ItemFilter) (query string, args []interface{}) {
 		conditions = append(conditions, "instr(lower(i.feed_url), lower(?)) > 0")
 		args = append(args, filter.FeedQuery)
 	}
-	if filter.Search != "" {
-		conditions = append(conditions, "instr(lower(i.title), lower(?)) > 0")
-		args = append(args, filter.Search)
+	if searchExpr != "" {
+		conditions = append(conditions, itemsFTSMatch)
+		args = append(args, searchExpr)
 	}
 	if !filter.Since.IsZero() {
 		conditions = append(conditions, aliasedEffectiveDateExpression+" >= julianday(?)")
@@ -514,10 +529,10 @@ func buildItemsQuery(filter *ItemFilter) (query string, args []interface{}) {
 		query += " WHERE " + strings.Join(conditions, " AND ")
 	}
 
-	query += " ORDER BY " + aliasedEffectiveDateExpression + " DESC"
+	query += itemsOrderByClause(filter.Sort)
 	if filter.Limit > 0 {
 		query += sqlLimitClause
 		args = append(args, filter.Limit)
 	}
-	return query, args
+	return query, args, nil
 }

--- a/internal/database/item_repository.go
+++ b/internal/database/item_repository.go
@@ -1,10 +1,13 @@
 package database
 
 import (
+	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
+	"github.com/lmorchard/feedspool-go/internal/itemtext"
 	"github.com/sirupsen/logrus"
 )
 
@@ -25,7 +28,27 @@ const (
 		" IS NOT NULL AND " + effectiveDateExpression + " <= julianday(?)"
 )
 
-// UpsertItem inserts or updates an item record in the database.
+// upsertItemQuery is RETURNING id, not a bare INSERT: LastInsertId is not
+// meaningful for the ON CONFLICT DO UPDATE branch, which is the common case
+// on re-fetch, and the returned id is what attaches the derived item_text row
+// below to the right item.
+const upsertItemQuery = `
+	INSERT INTO items (feed_url, guid, title, link, published_date, first_seen,
+		content, summary, archived, item_json)
+	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	ON CONFLICT(feed_url, guid) DO UPDATE SET
+		title = excluded.title,
+		link = excluded.link,
+		content = excluded.content,
+		summary = excluded.summary,
+		archived = excluded.archived,
+		item_json = excluded.item_json
+	RETURNING id
+`
+
+// UpsertItem inserts or updates an item record and keeps its derived search
+// text current, all in one transaction so a crash cannot leave the item
+// written but the index stale.
 func (db *DB) UpsertItem(item *Item) error {
 	var publishedDate interface{}
 	if !item.PublishedDate.IsZero() {
@@ -35,28 +58,65 @@ func (db *DB) UpsertItem(item *Item) error {
 	if item.FirstSeen.Valid {
 		firstSeen = formatDatabaseTime(item.FirstSeen.Time)
 	}
-	query := `
-		INSERT INTO items (feed_url, guid, title, link, published_date, first_seen,
-			content, summary, archived, item_json)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-		ON CONFLICT(feed_url, guid) DO UPDATE SET
-			title = excluded.title,
-			link = excluded.link,
-			content = excluded.content,
-			summary = excluded.summary,
-			archived = excluded.archived,
-			item_json = excluded.item_json
-	`
 
-	_, err := db.conn.Exec(query,
+	tx, err := db.conn.Begin()
+	if err != nil {
+		return fmt.Errorf("failed to begin item upsert: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			if rollbackErr := tx.Rollback(); rollbackErr != nil {
+				logrus.WithError(rollbackErr).Warn("Failed to roll back item upsert")
+			}
+		}
+	}()
+
+	var id int64
+	err = tx.QueryRow(upsertItemQuery,
 		item.FeedURL, item.GUID, item.Title, item.Link, publishedDate, firstSeen,
-		item.Content, item.Summary, item.Archived, item.ItemJSON)
+		item.Content, item.Summary, item.Archived, item.ItemJSON).Scan(&id)
 	if err != nil {
 		return fmt.Errorf("failed to upsert item: %w", err)
 	}
 
+	if err := upsertItemTextIfChanged(tx, id, item); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit item upsert: %w", err)
+	}
+	committed = true
+
 	logrus.Debugf("Upserted item: %s - %s", item.FeedURL, item.GUID)
 	return nil
+}
+
+// upsertItemTextIfChanged derives and stores item_text unless the stored hash
+// and generator version already match. Re-fetching an unchanged feed is the
+// common case, and this keeps that case to one indexed lookup instead of an
+// HTML parse per item -- it also avoids firing the update trigger, which
+// would delete and reinsert identical index rows.
+func upsertItemTextIfChanged(tx *sql.Tx, id int64, item *Item) error {
+	hash := itemtext.SourceHash(item.Title, item.Summary, item.Content)
+
+	var storedHash string
+	var storedVersion int
+	err := tx.QueryRow(
+		`SELECT source_hash, generator_version FROM item_text WHERE item_id = ?`, id,
+	).Scan(&storedHash, &storedVersion)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		// No derived text yet -- fall through and derive it.
+	case err != nil:
+		return fmt.Errorf("failed to read item text for item %d: %w", id, err)
+	case storedHash == hash && storedVersion == itemtext.Version:
+		return nil
+	}
+
+	text := itemtext.Derive(item.Title, item.Summary, item.Content, itemtext.DefaultOptions())
+	return upsertItemTextTx(tx, id, text, hash)
 }
 
 // GetItemsByLink retrieves every item with the exact link in deterministic order.

--- a/internal/database/item_repository.go
+++ b/internal/database/item_repository.go
@@ -93,25 +93,33 @@ func (db *DB) UpsertItem(item *Item) error {
 	return nil
 }
 
-// upsertItemTextIfChanged derives and stores item_text unless the stored hash
-// and generator version already match. Re-fetching an unchanged feed is the
+// upsertItemTextIfChanged derives and stores item_text unless the stored hash,
+// generator and generator version already match. Re-fetching an unchanged feed is the
 // common case, and this keeps that case to one indexed lookup instead of an
 // HTML parse per item -- it also avoids firing the update trigger, which
 // would delete and reinsert identical index rows.
 func upsertItemTextIfChanged(tx *sql.Tx, id int64, item *Item) error {
 	hash := itemtext.SourceHash(item.Title, item.Summary, item.Content)
 
-	var storedHash string
+	var storedHash, storedGenerator string
 	var storedVersion int
 	err := tx.QueryRow(
-		`SELECT source_hash, generator_version FROM item_text WHERE item_id = ?`, id,
-	).Scan(&storedHash, &storedVersion)
+		`SELECT source_hash, generator, generator_version FROM item_text WHERE item_id = ?`, id,
+	).Scan(&storedHash, &storedGenerator, &storedVersion)
 	switch {
 	case errors.Is(err, sql.ErrNoRows):
 		// No derived text yet -- fall through and derive it.
 	case err != nil:
 		return fmt.Errorf("failed to read item text for item %d: %w", id, err)
-	case storedHash == hash && storedVersion == itemtext.Version:
+	// generator is compared as well as its version, so this stays in step with
+	// itemTextStalenessCondition, which the reindex backfill uses. Both are
+	// no-ops while itemtext.Generator is the only generator; the moment a
+	// second one writes item_text (#30), a version match under a different
+	// generator's name would otherwise read as up to date here but as stale
+	// there.
+	case storedHash == hash &&
+		storedGenerator == itemtext.Generator &&
+		storedVersion == itemtext.Version:
 		return nil
 	}
 

--- a/internal/database/item_repository.go
+++ b/internal/database/item_repository.go
@@ -478,7 +478,7 @@ func buildItemsQuery(filter *ItemFilter) (query string, args []interface{}, err 
 		return "", nil, err
 	}
 	if filter.Sort == SortRelevance && searchExpr == "" {
-		return "", nil, errRelevanceNeedsSearch
+		return "", nil, ErrRelevanceNeedsSearch
 	}
 
 	query = `

--- a/internal/database/item_repository_test.go
+++ b/internal/database/item_repository_test.go
@@ -2,11 +2,14 @@ package database
 
 import (
 	"database/sql"
+	"errors"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/lmorchard/feedspool-go/internal/itemtext"
+	"github.com/lmorchard/feedspool-go/internal/search"
 )
 
 func TestUpsertAndGetItem(t *testing.T) {
@@ -545,7 +548,7 @@ func TestDeleteArchivedItems(t *testing.T) {
 	}
 }
 
-func TestGetItemsWithFeedAndTitleSubstringFilters(t *testing.T) {
+func TestGetItemsWithFeedAndSearchFilters(t *testing.T) {
 	db := setupTestDB(t)
 	discoveredAt := time.Date(2026, 8, 25, 14, 0, 0, 0, time.FixedZone("PDT", -7*60*60))
 	feeds := []string{
@@ -598,21 +601,27 @@ func TestGetItemsWithFeedAndTitleSubstringFilters(t *testing.T) {
 		t.Errorf("boundary GetItems() returned %d items, want half-open cursor window", len(atCursor))
 	}
 
-	literal, err := db.GetItems(&ItemFilter{Search: "%"})
+	// Punctuation is literal text, not syntax: "C++" reaches FTS5 quoted, so it
+	// matches nothing here instead of raising a query-syntax error the way a
+	// raw MATCH would.
+	literal, err := db.GetItems(&ItemFilter{Search: "C++"})
 	if err != nil {
 		t.Fatalf("literal GetItems() error = %v", err)
 	}
 	if len(literal) != 0 {
-		t.Errorf("literal GetItems() returned %d wildcard matches, want 0", len(literal))
+		t.Errorf("literal GetItems() returned %d punctuation matches, want 0", len(literal))
 	}
 }
 
 func TestGetItemsTimeWindowUsesIndex(t *testing.T) {
 	db := setupTestDB(t)
-	query, args := buildItemsQuery(&ItemFilter{
+	query, args, err := buildItemsQuery(&ItemFilter{
 		Since: time.Date(2026, 8, 24, 0, 0, 0, 0, time.UTC),
 		Until: time.Date(2026, 8, 25, 0, 0, 0, 0, time.UTC),
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	rows, err := db.conn.Query("EXPLAIN QUERY PLAN "+query, args...)
 	if err != nil {
@@ -824,5 +833,245 @@ func TestUpsertItemReindexesOnVersionBump(t *testing.T) {
 	}
 	if version != itemtext.Version {
 		t.Errorf("generator_version = %d, want %d", version, itemtext.Version)
+	}
+}
+
+const (
+	// searchTitleTerm, searchSummaryTerm and searchBodyTerm each appear in
+	// exactly one field of exactly one fixture item. The summary and body terms
+	// are the ones title-substring search could never reach.
+	searchTitleTerm   = "chronicle"
+	searchSummaryTerm = replacementBodyTerm
+	searchBodyTerm    = seedBodyTerm
+
+	searchTitleGUID   = "search-title"
+	searchSummaryGUID = "search-summary"
+	searchBodyGUID    = "search-body"
+
+	// relevanceTerm is the query the ranking fixtures compete on.
+	relevanceTerm      = "kubernetes"
+	relevanceTitleGUID = "relevance-title"
+	relevanceBodyGUID  = "relevance-body"
+
+	// searchFiller is unremarkable prose that pads a fixture so bm25 has a
+	// document length to normalize against.
+	searchFiller = "Assorted notes on other subjects entirely."
+)
+
+// itemGUIDs renders the GUIDs of a result set in order, for comparison and for
+// readable failure messages.
+func itemGUIDs(items []*Item) string {
+	guids := make([]string, 0, len(items))
+	for _, item := range items {
+		guids = append(guids, item.GUID)
+	}
+	return strings.Join(guids, ",")
+}
+
+// sortedItemGUIDs renders result GUIDs order-independently, for assertions
+// about which rows matched rather than how they were ranked.
+func sortedItemGUIDs(items []*Item) string {
+	guids := make([]string, 0, len(items))
+	for _, item := range items {
+		guids = append(guids, item.GUID)
+	}
+	slices.Sort(guids)
+	return strings.Join(guids, ",")
+}
+
+// seedSearchFieldFixtures inserts one item per searchable field, each carrying
+// its distinguishing term in that field alone.
+func seedSearchFieldFixtures(t *testing.T, db *DB) {
+	t.Helper()
+	items := []*Item{
+		{
+			FeedURL: fixtureFeedURL, GUID: searchTitleGUID,
+			Title:   "A " + searchTitleTerm + " of small events",
+			Summary: "<p>" + searchFiller + "</p>",
+			Content: "<div>" + searchFiller + "</div>",
+		},
+		{
+			FeedURL: fixtureFeedURL, GUID: searchSummaryGUID,
+			Title:   "Second item",
+			Summary: "<p>A " + searchSummaryTerm + " passes overhead.</p>",
+			Content: "<div>" + searchFiller + "</div>",
+		},
+		{
+			FeedURL: fixtureFeedURL, GUID: searchBodyGUID,
+			Title:   "Third item",
+			Summary: "<p>" + searchFiller + "</p>",
+			Content: "<div>The " + searchBodyTerm + " is moored in the hangar.</div>",
+		},
+	}
+	for _, item := range items {
+		if err := db.UpsertItem(item); err != nil {
+			t.Fatalf("seeding %s: %v", item.GUID, err)
+		}
+	}
+}
+
+func TestGetItemsSearchMatchesBodyAndSummary(t *testing.T) {
+	db := setupItemTextFixtureDB(t)
+	seedSearchFieldFixtures(t, db)
+
+	cases := []struct {
+		name, query, want string
+	}{
+		{"title", searchTitleTerm, searchTitleGUID},
+		{"summary", searchSummaryTerm, searchSummaryGUID},
+		{"body", searchBodyTerm, searchBodyGUID},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := db.GetItems(&ItemFilter{Search: tc.query})
+			if err != nil {
+				t.Fatalf("GetItems(%q) error = %v", tc.query, err)
+			}
+			if itemGUIDs(got) != tc.want {
+				t.Errorf("GetItems(%q) = [%s], want [%s]", tc.query, itemGUIDs(got), tc.want)
+			}
+		})
+	}
+	integrityCheck(t, db)
+}
+
+func TestGetItemsSearchComposesWithFilters(t *testing.T) {
+	const (
+		alphaOldGUID    = "alpha-old"
+		alphaRecentGUID = "alpha-recent"
+		betaRecentGUID  = "beta-recent"
+	)
+	db := setupTestDB(t)
+	for _, feedURL := range []string{testAlphaFeedURL, testBetaFeedURL} {
+		if err := db.UpsertFeed(&Feed{URL: feedURL}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	matching := "<div>The " + searchBodyTerm + " is moored in the hangar.</div>"
+	items := []*Item{
+		{
+			FeedURL: testAlphaFeedURL, GUID: alphaOldGUID, Title: "Alpha old",
+			Content: matching, PublishedDate: time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			FeedURL: testAlphaFeedURL, GUID: alphaRecentGUID, Title: "Alpha recent",
+			Content: matching, PublishedDate: time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			FeedURL: testBetaFeedURL, GUID: betaRecentGUID, Title: "Beta recent",
+			Content: matching, PublishedDate: time.Date(2026, 8, 21, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			FeedURL: testBetaFeedURL, GUID: "beta-other", Title: "Beta other",
+			Content:       "<div>" + searchFiller + "</div>",
+			PublishedDate: time.Date(2026, 8, 22, 0, 0, 0, 0, time.UTC),
+		},
+	}
+	for _, item := range items {
+		if err := db.UpsertItem(item); err != nil {
+			t.Fatalf("seeding %s: %v", item.GUID, err)
+		}
+	}
+	if err := db.AddAnnotation(
+		testAlphaFeedURL, alphaRecentGUID, "seen", sql.NullString{}, sql.NullString{},
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	window := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name   string
+		filter ItemFilter
+		want   string
+	}{
+		{
+			"feed url",
+			ItemFilter{Search: searchBodyTerm, FeedURL: testAlphaFeedURL},
+			alphaOldGUID + "," + alphaRecentGUID,
+		},
+		{
+			"time window",
+			ItemFilter{Search: searchBodyTerm, Since: window, Until: window.AddDate(0, 1, 0)},
+			alphaRecentGUID + "," + betaRecentGUID,
+		},
+		{"seen", ItemFilter{Search: searchBodyTerm, Seen: true}, alphaRecentGUID},
+		{
+			"unseen",
+			ItemFilter{Search: searchBodyTerm, Unseen: true},
+			alphaOldGUID + "," + betaRecentGUID,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			filter := tc.filter
+			got, err := db.GetItems(&filter)
+			if err != nil {
+				t.Fatalf("GetItems() error = %v", err)
+			}
+			if sortedItemGUIDs(got) != tc.want {
+				t.Errorf("GetItems() = [%s], want [%s]; search must intersect the other filters, not replace them",
+					sortedItemGUIDs(got), tc.want)
+			}
+		})
+	}
+}
+
+func TestGetItemsRelevanceRanksTitleAboveBody(t *testing.T) {
+	db := setupItemTextFixtureDB(t)
+	// The body match is both newer and repeats the term, so date order and an
+	// unweighted bm25 would each put it first. Only the column weights, which
+	// rate a title hit above a body hit, produce the wanted order.
+	items := []*Item{
+		{
+			FeedURL: fixtureFeedURL, GUID: relevanceTitleGUID,
+			Title:         "Notes on " + relevanceTerm,
+			Summary:       "<p>" + searchFiller + "</p>",
+			Content:       "<div>" + searchFiller + "</div>",
+			PublishedDate: time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			FeedURL: fixtureFeedURL, GUID: relevanceBodyGUID,
+			Title:         "Weekly links",
+			Summary:       "<p>" + searchFiller + "</p>",
+			Content:       "<div>" + strings.Repeat(relevanceTerm+" ", 8) + "</div>",
+			PublishedDate: time.Date(2026, 8, 21, 0, 0, 0, 0, time.UTC),
+		},
+	}
+	for _, item := range items {
+		if err := db.UpsertItem(item); err != nil {
+			t.Fatalf("seeding %s: %v", item.GUID, err)
+		}
+	}
+
+	byDate, err := db.GetItems(&ItemFilter{Search: relevanceTerm})
+	if err != nil {
+		t.Fatalf("GetItems() error = %v", err)
+	}
+	if want := relevanceBodyGUID + "," + relevanceTitleGUID; itemGUIDs(byDate) != want {
+		t.Fatalf("default GetItems() = [%s], want [%s]; the fixture must rank differently by date",
+			itemGUIDs(byDate), want)
+	}
+
+	ranked, err := db.GetItems(&ItemFilter{Search: relevanceTerm, Sort: SortRelevance})
+	if err != nil {
+		t.Fatalf("relevance GetItems() error = %v", err)
+	}
+	if want := relevanceTitleGUID + "," + relevanceBodyGUID; itemGUIDs(ranked) != want {
+		t.Errorf("relevance GetItems() = [%s], want [%s]; bm25 column weights rank a title hit above a body hit",
+			itemGUIDs(ranked), want)
+	}
+}
+
+func TestGetItemsSearchRejectsOnlyExclusions(t *testing.T) {
+	db := setupItemTextFixtureDB(t)
+	seedSearchFieldFixtures(t, db)
+
+	got, err := db.GetItems(&ItemFilter{Search: "-draft"})
+	if !errors.Is(err, search.ErrOnlyExclusions) {
+		t.Fatalf("GetItems() error = %v, want %v", err, search.ErrOnlyExclusions)
+	}
+	if got != nil {
+		t.Errorf("GetItems() returned %d items alongside the error, want none", len(got))
 	}
 }

--- a/internal/database/item_repository_test.go
+++ b/internal/database/item_repository_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/lmorchard/feedspool-go/internal/itemtext"
 )
 
 func TestUpsertAndGetItem(t *testing.T) {
@@ -664,5 +666,163 @@ func TestGetItemsEffectiveDateOrderingUsesIndex(t *testing.T) {
 	}
 	if !strings.Contains(plan.String(), "idx_items_feed_effective_date") || strings.Contains(plan.String(), "USE TEMP B-TREE") {
 		t.Fatalf("per-feed effective-date query plan does not use composite index:\n%s", plan.String())
+	}
+}
+
+// newUpsertItemTextFixture builds an item with markup in its content, ready
+// to exercise the item_text derivation UpsertItem performs.
+func newUpsertItemTextFixture(term string) *Item {
+	return &Item{
+		FeedURL:       fixtureFeedURL,
+		GUID:          fixtureGUID,
+		Title:         testItemTitle,
+		Link:          fixtureItemLink,
+		PublishedDate: time.Now().UTC().Truncate(time.Second),
+		Content:       seededItemContent(0, term),
+		Summary:       fixtureItemSummary,
+	}
+}
+
+// setupItemTextFixtureDB seeds a feed so UpsertItem's foreign key succeeds.
+func setupItemTextFixtureDB(t *testing.T) *DB {
+	t.Helper()
+	db := setupTestDB(t)
+	if err := db.UpsertFeed(&Feed{URL: fixtureFeedURL}); err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+// itemTextBody reads the derived body text for an item.
+func itemTextBody(t *testing.T, db *DB, itemID int64) string {
+	t.Helper()
+	var body string
+	if err := db.conn.QueryRow(
+		`SELECT body FROM item_text WHERE item_id = ?`, itemID,
+	).Scan(&body); err != nil {
+		t.Fatalf("reading item_text body for item %d: %v", itemID, err)
+	}
+	return body
+}
+
+func TestUpsertItemIndexesNewItem(t *testing.T) {
+	db := setupItemTextFixtureDB(t)
+	item := newUpsertItemTextFixture(seedBodyTerm)
+
+	if err := db.UpsertItem(item); err != nil {
+		t.Fatalf("db.UpsertItem() error = %v", err)
+	}
+
+	stored, err := db.GetItem(item.FeedURL, item.GUID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored == nil {
+		t.Fatal("db.GetItem() returned nil after upsert")
+	}
+
+	want := itemtext.Derive(item.Title, item.Summary, item.Content, itemtext.DefaultOptions()).Body
+	if got := itemTextBody(t, db, stored.ID); got != want {
+		t.Errorf("item_text body = %q, want %q", got, want)
+	}
+
+	if got := countMatching(t, db, seedBodyTerm); got != 1 {
+		t.Errorf("body term matches %d items, want 1", got)
+	}
+	integrityCheck(t, db)
+}
+
+func TestUpsertItemSkipsDerivationWhenUnchanged(t *testing.T) {
+	db := setupItemTextFixtureDB(t)
+	item := newUpsertItemTextFixture(seedBodyTerm)
+
+	if err := db.UpsertItem(item); err != nil {
+		t.Fatalf("first db.UpsertItem() error = %v", err)
+	}
+	stored, err := db.GetItem(item.FeedURL, item.GUID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, ok := itemTextComputedAt(t, db)[stored.ID]
+	if !ok {
+		t.Fatal("no item_text row after first upsert")
+	}
+
+	if err := db.UpsertItem(item); err != nil {
+		t.Fatalf("second db.UpsertItem() error = %v", err)
+	}
+	after, ok := itemTextComputedAt(t, db)[stored.ID]
+	if !ok {
+		t.Fatal("item_text row disappeared after second upsert")
+	}
+
+	if after != before {
+		t.Errorf("computed_at moved from %q to %q; unchanged content should skip derivation", before, after)
+	}
+}
+
+func TestUpsertItemReindexesChangedContent(t *testing.T) {
+	db := setupItemTextFixtureDB(t)
+	item := newUpsertItemTextFixture(seedBodyTerm)
+
+	if err := db.UpsertItem(item); err != nil {
+		t.Fatalf("first db.UpsertItem() error = %v", err)
+	}
+	if got := countMatching(t, db, seedBodyTerm); got != 1 {
+		t.Fatalf("initial body term matches %d items, want 1", got)
+	}
+
+	item.Content = seededItemContent(0, replacementBodyTerm)
+	if err := db.UpsertItem(item); err != nil {
+		t.Fatalf("second db.UpsertItem() error = %v", err)
+	}
+
+	if got := countMatching(t, db, seedBodyTerm); got != 0 {
+		t.Errorf("retired body term still matches %d items, want 0", got)
+	}
+	if got := countMatching(t, db, replacementBodyTerm); got != 1 {
+		t.Errorf("new body term matches %d items, want 1", got)
+	}
+	integrityCheck(t, db)
+}
+
+func TestUpsertItemReindexesOnVersionBump(t *testing.T) {
+	db := setupItemTextFixtureDB(t)
+	item := newUpsertItemTextFixture(seedBodyTerm)
+
+	if err := db.UpsertItem(item); err != nil {
+		t.Fatalf("first db.UpsertItem() error = %v", err)
+	}
+	stored, err := db.GetItem(item.FeedURL, item.GUID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	execSQL(t, db, `UPDATE item_text SET generator_version = ? WHERE item_id = ?`, itemtext.Version-1, stored.ID)
+	before, ok := itemTextComputedAt(t, db)[stored.ID]
+	if !ok {
+		t.Fatal("no item_text row after hand-setting generator_version")
+	}
+
+	if err := db.UpsertItem(item); err != nil {
+		t.Fatalf("second db.UpsertItem() error = %v", err)
+	}
+
+	after, ok := itemTextComputedAt(t, db)[stored.ID]
+	if !ok {
+		t.Fatal("item_text row disappeared after second upsert")
+	}
+	if after == before {
+		t.Errorf("computed_at unchanged at %q; a version bump should force recompute despite a matching hash", before)
+	}
+
+	var version int
+	if err := db.conn.QueryRow(
+		`SELECT generator_version FROM item_text WHERE item_id = ?`, stored.ID,
+	).Scan(&version); err != nil {
+		t.Fatal(err)
+	}
+	if version != itemtext.Version {
+		t.Errorf("generator_version = %d, want %d", version, itemtext.Version)
 	}
 }

--- a/internal/database/item_repository_test.go
+++ b/internal/database/item_repository_test.go
@@ -604,7 +604,7 @@ func TestGetItemsWithFeedAndSearchFilters(t *testing.T) {
 	// Punctuation is literal text, not syntax: "C++" reaches FTS5 quoted, so it
 	// matches nothing here instead of raising a query-syntax error the way a
 	// raw MATCH would.
-	literal, err := db.GetItems(&ItemFilter{Search: "C++"})
+	literal, err := db.GetItems(&ItemFilter{Search: searchPunctuationQuery})
 	if err != nil {
 		t.Fatalf("literal GetItems() error = %v", err)
 	}
@@ -856,6 +856,18 @@ const (
 	// searchFiller is unremarkable prose that pads a fixture so bm25 has a
 	// document length to normalize against.
 	searchFiller = "Assorted notes on other subjects entirely."
+
+	// searchPunctuationQuery is punctuation the parser must hand FTS5 as
+	// literal text rather than as syntax, and searchOnlyExclusion is a query
+	// with nothing left to match. Both surfaces have to treat them alike.
+	searchPunctuationQuery = "C++"
+	searchOnlyExclusion    = "-draft"
+
+	// Subtest names for the one-term-per-field cases, shared by the CLI and
+	// API versions of the same table.
+	caseTitle   = "title"
+	caseSummary = "summary"
+	caseBody    = "body"
 )
 
 // itemGUIDs renders the GUIDs of a result set in order, for comparison and for
@@ -917,9 +929,9 @@ func TestGetItemsSearchMatchesBodyAndSummary(t *testing.T) {
 	cases := []struct {
 		name, query, want string
 	}{
-		{"title", searchTitleTerm, searchTitleGUID},
-		{"summary", searchSummaryTerm, searchSummaryGUID},
-		{"body", searchBodyTerm, searchBodyGUID},
+		{caseTitle, searchTitleTerm, searchTitleGUID},
+		{caseSummary, searchSummaryTerm, searchSummaryGUID},
+		{caseBody, searchBodyTerm, searchBodyGUID},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1017,11 +1029,15 @@ func TestGetItemsSearchComposesWithFilters(t *testing.T) {
 	}
 }
 
-func TestGetItemsRelevanceRanksTitleAboveBody(t *testing.T) {
-	db := setupItemTextFixtureDB(t)
-	// The body match is both newer and repeats the term, so date order and an
-	// unweighted bm25 would each put it first. Only the column weights, which
-	// rate a title hit above a body hit, produce the wanted order.
+// seedRelevanceFixtures inserts two items that compete on relevanceTerm. The
+// body match is both newer and repeats the term, so date order and an
+// unweighted bm25 would each put it first. Only the column weights, which rate
+// a title hit above a body hit, produce the title-first order.
+//
+// Both GetItems and ListItems rank from these, which is the point: the two
+// surfaces have to agree about ranking as well as about matching.
+func seedRelevanceFixtures(t *testing.T, db *DB) {
+	t.Helper()
 	items := []*Item{
 		{
 			FeedURL: fixtureFeedURL, GUID: relevanceTitleGUID,
@@ -1043,6 +1059,11 @@ func TestGetItemsRelevanceRanksTitleAboveBody(t *testing.T) {
 			t.Fatalf("seeding %s: %v", item.GUID, err)
 		}
 	}
+}
+
+func TestGetItemsRelevanceRanksTitleAboveBody(t *testing.T) {
+	db := setupItemTextFixtureDB(t)
+	seedRelevanceFixtures(t, db)
 
 	byDate, err := db.GetItems(&ItemFilter{Search: relevanceTerm})
 	if err != nil {
@@ -1067,7 +1088,7 @@ func TestGetItemsSearchRejectsOnlyExclusions(t *testing.T) {
 	db := setupItemTextFixtureDB(t)
 	seedSearchFieldFixtures(t, db)
 
-	got, err := db.GetItems(&ItemFilter{Search: "-draft"})
+	got, err := db.GetItems(&ItemFilter{Search: searchOnlyExclusion})
 	if !errors.Is(err, search.ErrOnlyExclusions) {
 		t.Fatalf("GetItems() error = %v, want %v", err, search.ErrOnlyExclusions)
 	}
@@ -1099,8 +1120,8 @@ func TestGetItemsEmptySearchExpressionAddsNoFilter(t *testing.T) {
 		{Search: "*", Sort: SortRelevance},
 		{Sort: SortRelevance},
 	} {
-		if _, err := db.GetItems(&filter); !errors.Is(err, errRelevanceNeedsSearch) {
-			t.Errorf("GetItems(%+v) error = %v, want %v", filter, err, errRelevanceNeedsSearch)
+		if _, err := db.GetItems(&filter); !errors.Is(err, ErrRelevanceNeedsSearch) {
+			t.Errorf("GetItems(%+v) error = %v, want %v", filter, err, ErrRelevanceNeedsSearch)
 		}
 	}
 }

--- a/internal/database/item_repository_test.go
+++ b/internal/database/item_repository_test.go
@@ -1075,3 +1075,42 @@ func TestGetItemsSearchRejectsOnlyExclusions(t *testing.T) {
 		t.Errorf("GetItems() returned %d items alongside the error, want none", len(got))
 	}
 }
+
+func TestGetItemsEmptySearchExpressionAddsNoFilter(t *testing.T) {
+	db := setupItemTextFixtureDB(t)
+	seedSearchFieldFixtures(t, db)
+
+	// A bare "*" is a non-empty --search that the parser reduces to the empty
+	// expression, meaning "no search filter". The query must then carry neither
+	// the FTS join nor the MATCH, and return every row.
+	everything := sortedItemGUIDs(mustGetItems(t, db, &ItemFilter{}))
+	all, err := db.GetItems(&ItemFilter{Search: "*"})
+	if err != nil {
+		t.Fatalf("GetItems() error = %v", err)
+	}
+	if sortedItemGUIDs(all) != everything {
+		t.Errorf("GetItems(%q) = [%s], want the unfiltered [%s]", "*", sortedItemGUIDs(all), everything)
+	}
+
+	// There is correspondingly nothing to rank, and the CLI's own check cannot
+	// catch this one: --search "*" is not the empty string. Both spellings of
+	// "relevance with no ranking" have to fail here instead.
+	for _, filter := range []ItemFilter{
+		{Search: "*", Sort: SortRelevance},
+		{Sort: SortRelevance},
+	} {
+		if _, err := db.GetItems(&filter); !errors.Is(err, errRelevanceNeedsSearch) {
+			t.Errorf("GetItems(%+v) error = %v, want %v", filter, err, errRelevanceNeedsSearch)
+		}
+	}
+}
+
+// mustGetItems runs a filter the test expects to succeed.
+func mustGetItems(t *testing.T, db *DB, filter *ItemFilter) []*Item {
+	t.Helper()
+	items, err := db.GetItems(filter)
+	if err != nil {
+		t.Fatalf("GetItems(%+v) error = %v", filter, err)
+	}
+	return items
+}

--- a/internal/database/item_text.go
+++ b/internal/database/item_text.go
@@ -1,0 +1,180 @@
+package database
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/lmorchard/feedspool-go/internal/itemtext"
+	"github.com/sirupsen/logrus"
+)
+
+// itemTextStalenessCondition selects items whose derived text is missing or was
+// produced by a different generator or an older version of it. A changed item
+// is handled on the live write path, which is the only thing that changes item
+// text, so the backfill does not need to re-hash every row on every run.
+const itemTextStalenessCondition = `t.item_id IS NULL OR t.generator <> ? OR t.generator_version <> ?`
+
+// itemTextBackfill derives HTML-free search text for items that lack it.
+type itemTextBackfill struct{ opts itemtext.Options }
+
+// newItemTextBackfill returns the generator that maintains item_text.
+func newItemTextBackfill(opts itemtext.Options) *itemTextBackfill {
+	return &itemTextBackfill{opts: opts}
+}
+
+func (g *itemTextBackfill) Name() string { return itemtext.Generator }
+func (g *itemTextBackfill) Version() int { return itemtext.Version }
+
+// NextBatch returns the next stale item IDs in ascending order.
+func (g *itemTextBackfill) NextBatch(tx *sql.Tx, afterID int64, limit int) ([]int64, error) {
+	rows, err := tx.Query(
+		`
+		SELECT i.id
+		FROM items i LEFT JOIN item_text t ON t.item_id = i.id
+		WHERE i.id > ? AND (`+itemTextStalenessCondition+`)
+		ORDER BY i.id
+		LIMIT ?`,
+		afterID, itemtext.Generator, itemtext.Version, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query stale item text: %w", err)
+	}
+	defer rows.Close()
+
+	ids := make([]int64, 0, limit)
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("failed to scan stale item id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate stale item ids: %w", err)
+	}
+	return ids, nil
+}
+
+// Remaining counts the items whose derived text is still stale.
+func (g *itemTextBackfill) Remaining(tx *sql.Tx) (int64, error) {
+	var remaining int64
+	if err := tx.QueryRow(
+		`
+		SELECT COUNT(*)
+		FROM items i LEFT JOIN item_text t ON t.item_id = i.id
+		WHERE `+itemTextStalenessCondition,
+		itemtext.Generator, itemtext.Version,
+	).Scan(&remaining); err != nil {
+		return 0, fmt.Errorf("failed to count stale item text: %w", err)
+	}
+	return remaining, nil
+}
+
+// Recompute derives and stores the text for the given item IDs.
+func (g *itemTextBackfill) Recompute(tx *sql.Tx, ids []int64) error {
+	sources, err := readItemTextSources(tx, ids)
+	if err != nil {
+		return err
+	}
+	for _, source := range sources {
+		text := itemtext.Derive(source.title, source.summary, source.content, g.opts)
+		hash := itemtext.SourceHash(source.title, source.summary, source.content)
+		if err := upsertItemTextTx(tx, source.id, text, hash); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// itemTextSource is the raw item text a derivation reads from.
+type itemTextSource struct {
+	id                      int64
+	title, summary, content string
+}
+
+// readItemTextSources reads every source row before any writing begins: the
+// pool is capped at one connection, so a write issued while a result set is
+// still open would contend with it.
+func readItemTextSources(tx *sql.Tx, ids []int64) ([]itemTextSource, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	placeholders := make([]string, len(ids))
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+
+	// COALESCE guards databases old enough that these columns are nullable. The
+	// current schema declares them NOT NULL DEFAULT '', but a migration that
+	// aborts on one legacy NULL title would leave the whole spool unindexed.
+	//nolint:gosec // Safe: only formatting placeholder count, not user input
+	query := fmt.Sprintf(
+		`
+		SELECT id, COALESCE(title, ''), COALESCE(summary, ''), COALESCE(content, '')
+		FROM items WHERE id IN (%s)`,
+		strings.Join(placeholders, ","),
+	)
+	rows, err := tx.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read item text sources: %w", err)
+	}
+	defer rows.Close()
+
+	sources := make([]itemTextSource, 0, len(ids))
+	for rows.Next() {
+		var source itemTextSource
+		if err := rows.Scan(&source.id, &source.title, &source.summary, &source.content); err != nil {
+			return nil, fmt.Errorf("failed to scan item text source: %w", err)
+		}
+		sources = append(sources, source)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate item text sources: %w", err)
+	}
+	return sources, nil
+}
+
+// upsertItemTextTx is the only place item_text rows are written. The backfill
+// runner and UpsertItem both go through it.
+func upsertItemTextTx(tx *sql.Tx, itemID int64, text itemtext.Text, sourceHash string) error {
+	_, err := tx.Exec(
+		`
+		INSERT INTO item_text
+			(item_id, title, summary, body, source_hash, generator, generator_version, computed_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(item_id) DO UPDATE SET
+			title = excluded.title, summary = excluded.summary, body = excluded.body,
+			source_hash = excluded.source_hash, generator = excluded.generator,
+			generator_version = excluded.generator_version, computed_at = excluded.computed_at`,
+		itemID, text.Title, text.Summary, text.Body, sourceHash,
+		itemtext.Generator, itemtext.Version, formatDatabaseTime(time.Now().UTC()),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to upsert item text for item %d: %w", itemID, err)
+	}
+	return nil
+}
+
+// ReindexItemText brings the derived text and search index up to date. force
+// discards every derived row first, which the triggers turn into a full index
+// clear, so a tokenizer change can be applied without a schema migration.
+func (db *DB) ReindexItemText(force bool, progress func(done, total int64)) error {
+	if force {
+		if _, err := db.conn.Exec(`DELETE FROM item_text`); err != nil {
+			return fmt.Errorf("failed to discard derived item text: %w", err)
+		}
+	}
+	return db.RunBackfill(newItemTextBackfill(itemtext.DefaultOptions()), defaultBackfillBatchSize, progress)
+}
+
+// ItemTextProgressLogger reports backfill progress at info level, which is what
+// makes a long migration on a large spool visibly alive rather than hung.
+func ItemTextProgressLogger() func(done, total int64) {
+	return func(done, total int64) {
+		logrus.Infof("Indexed %d/%d items", done, total)
+	}
+}

--- a/internal/database/item_text.go
+++ b/internal/database/item_text.go
@@ -36,7 +36,7 @@ func (g *itemTextBackfill) NextBatch(tx *sql.Tx, afterID int64, limit int) ([]in
 		WHERE i.id > ? AND (`+itemTextStalenessCondition+`)
 		ORDER BY i.id
 		LIMIT ?`,
-		afterID, itemtext.Generator, itemtext.Version, limit,
+		afterID, g.Name(), g.Version(), limit,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query stale item text: %w", err)
@@ -65,7 +65,7 @@ func (g *itemTextBackfill) Remaining(tx *sql.Tx) (int64, error) {
 		SELECT COUNT(*)
 		FROM items i LEFT JOIN item_text t ON t.item_id = i.id
 		WHERE `+itemTextStalenessCondition,
-		itemtext.Generator, itemtext.Version,
+		g.Name(), g.Version(),
 	).Scan(&remaining); err != nil {
 		return 0, fmt.Errorf("failed to count stale item text: %w", err)
 	}
@@ -108,9 +108,12 @@ func readItemTextSources(tx *sql.Tx, ids []int64) ([]itemTextSource, error) {
 		args[i] = id
 	}
 
-	// COALESCE guards databases old enough that these columns are nullable. The
-	// current schema declares them NOT NULL DEFAULT '', but a migration that
-	// aborts on one legacy NULL title would leave the whole spool unindexed.
+	// COALESCE is here for the hand-written legacy fixtures in
+	// migrations_test.go, which declare these columns nullable. No schema
+	// feedspool has ever shipped does -- the version-1 baseline already had them
+	// NOT NULL DEFAULT '' -- so this is not guarding real databases. It stays
+	// because treating a NULL title as empty text is a better failure mode than
+	// aborting a migration and leaving a whole spool unindexed.
 	//nolint:gosec // Safe: only formatting placeholder count, not user input
 	query := fmt.Sprintf(
 		`
@@ -175,6 +178,6 @@ func (db *DB) ReindexItemText(force bool, progress func(done, total int64)) erro
 // makes a long migration on a large spool visibly alive rather than hung.
 func ItemTextProgressLogger() func(done, total int64) {
 	return func(done, total int64) {
-		logrus.Infof("Indexed %d/%d items", done, total)
+		logrus.Infof("Indexed %d/%d outstanding items", done, total)
 	}
 }

--- a/internal/database/item_text.go
+++ b/internal/database/item_text.go
@@ -14,6 +14,10 @@ import (
 // produced by a different generator or an older version of it. A changed item
 // is handled on the live write path, which is the only thing that changes item
 // text, so the backfill does not need to re-hash every row on every run.
+//
+// upsertItemTextIfChanged is the write-path half of this definition and
+// compares the same generator and generator_version (plus the source hash the
+// predicate deliberately skips). Change one and change the other.
 const itemTextStalenessCondition = `t.item_id IS NULL OR t.generator <> ? OR t.generator_version <> ?`
 
 // itemTextBackfill derives HTML-free search text for items that lack it.

--- a/internal/database/item_text_test.go
+++ b/internal/database/item_text_test.go
@@ -81,6 +81,16 @@ func countItemTextRows(t *testing.T, db *DB) int {
 	return count
 }
 
+// countArchivedItems reports how many items are flagged archived.
+func countArchivedItems(t *testing.T, db *DB) int {
+	t.Helper()
+	var count int
+	if err := db.conn.QueryRow(`SELECT COUNT(*) FROM items WHERE archived = 1`).Scan(&count); err != nil {
+		t.Fatalf("counting archived items: %v", err)
+	}
+	return count
+}
+
 // firstItemID returns the lowest item ID, which is the first seeded item.
 func firstItemID(t *testing.T, db *DB) int64 {
 	t.Helper()
@@ -172,6 +182,11 @@ func TestItemTextTriggersCoverEveryDeletePath(t *testing.T) {
 			// must be untouched.
 			if err := db.MarkItemsArchived(fixtureFeedURL, nil); err != nil {
 				t.Fatal(err)
+			}
+			// Confirm the call did something. Were MarkItemsArchived to become a
+			// no-op, "the index is unchanged" would hold for the wrong reason.
+			if got := countArchivedItems(t, db); got != seedCount {
+				t.Fatalf("%d items are archived, want %d", got, seedCount)
 			}
 		}, seedCount},
 	}
@@ -316,6 +331,130 @@ func TestMigration11BackfillsExistingItems(t *testing.T) {
 		t.Errorf("index holds %d items, want %d", got, seedCount)
 	}
 	integrityCheck(t, db)
+}
+
+// TestMigration11SchemaStageDoesNotRecordVersion pins half of the stage
+// ordering: the DDL stage on its own must never record the schema version,
+// because the version is what says "fully indexed". Re-running the full
+// migration over the schema stage 1 already created also exercises the DDL
+// idempotency an interrupted run depends on.
+//
+// The other half -- that a backfill which fails leaves the version unrecorded
+// -- is TestMigration11LeavesVersionUnrecordedWhenIndexingFails below.
+func TestMigration11SchemaStageDoesNotRecordVersion(t *testing.T) {
+	const seedCount = 2
+	db := seedSearchableItems(t, seedCount)
+	rewindPastMigration11(t, db)
+
+	// Stage 1 alone.
+	if err := db.applyMigration11Schema(); err != nil {
+		t.Fatalf("applyMigration11Schema() error = %v", err)
+	}
+	for _, name := range []string{"item_text", "items_fts"} {
+		if !tableExists(t, db, name) {
+			t.Errorf("%s does not exist after the schema stage", name)
+		}
+	}
+	version, err := db.GetMigrationVersion()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version != migrationVersion10 {
+		t.Errorf("version = %d after the schema stage, want %d -- the DDL stage must not record it",
+			version, migrationVersion10)
+	}
+	if got := countItemTextRows(t, db); got != 0 {
+		t.Errorf("item_text has %d rows after the schema stage, want 0", got)
+	}
+
+	// The full migration over that same schema: idempotent DDL, then backfill,
+	// then the version.
+	if err := db.applyMigration11(); err != nil {
+		t.Fatalf("applyMigration11() error = %v", err)
+	}
+	version, err = db.GetMigrationVersion()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version != migrationVersion11 {
+		t.Errorf("version = %d after the full migration, want %d", version, migrationVersion11)
+	}
+	if got := countItemTextRows(t, db); got != seedCount {
+		t.Errorf("item_text has %d rows, want %d", got, seedCount)
+	}
+	if got := countIndexedItems(t, db); got != seedCount {
+		t.Errorf("index holds %d items, want %d", got, seedCount)
+	}
+	integrityCheck(t, db)
+}
+
+// TestMigration11LeavesVersionUnrecordedWhenIndexingFails is the one that
+// matters: if the backfill does not finish, the migration must not be marked
+// done, or search silently misses those items forever.
+//
+// The failure is induced without any production seam. A BEFORE INSERT trigger
+// that raises ABORT makes upsertItemTextTx fail, which is a real error arriving
+// by the real path -- no injection point, no test-only branch in the migration.
+//
+// It does not simulate a process killed mid-batch; nothing short of an actual
+// crash does. But it does cover the property that matters operationally, which
+// the schema-stage test alone cannot: a migration whose indexing stage returns
+// an error leaves the version unbumped, and the next run finishes the job.
+func TestMigration11LeavesVersionUnrecordedWhenIndexingFails(t *testing.T) {
+	const seedCount = 2
+	db := seedSearchableItems(t, seedCount)
+	rewindPastMigration11(t, db)
+
+	// The schema has to exist before the abort trigger can be attached to it.
+	if err := db.applyMigration11Schema(); err != nil {
+		t.Fatal(err)
+	}
+	execSQL(t, db, `CREATE TRIGGER item_text_abort BEFORE INSERT ON item_text
+		BEGIN SELECT RAISE(ABORT, 'induced indexing failure'); END`)
+
+	if err := db.applyMigration11(); err == nil {
+		t.Fatal("applyMigration11() succeeded, want the induced indexing failure")
+	}
+	version, err := db.GetMigrationVersion()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version == migrationVersion11 {
+		t.Fatalf("version = %d after a failed backfill; a half-indexed database must not be marked done",
+			migrationVersion11)
+	}
+	if got := countItemTextRows(t, db); got != 0 {
+		t.Errorf("item_text has %d rows after the aborted backfill, want 0", got)
+	}
+
+	// Resuming: the next run re-applies the idempotent DDL and finishes.
+	execSQL(t, db, `DROP TRIGGER item_text_abort`)
+	if err := db.applyMigration11(); err != nil {
+		t.Fatalf("resumed applyMigration11() error = %v", err)
+	}
+	version, err = db.GetMigrationVersion()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version != migrationVersion11 {
+		t.Errorf("version = %d after the resumed migration, want %d", version, migrationVersion11)
+	}
+	if got := countIndexedItems(t, db); got != seedCount {
+		t.Errorf("index holds %d items, want %d", got, seedCount)
+	}
+	integrityCheck(t, db)
+}
+
+// tableExists reports whether a table or virtual table is present.
+func tableExists(t *testing.T, db *DB, name string) bool {
+	t.Helper()
+	var count int
+	if err := db.conn.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?`, name,
+	).Scan(&count); err != nil {
+		t.Fatalf("checking for table %s: %v", name, err)
+	}
+	return count > 0
 }
 
 // rewindPastMigration11 drops everything migration 11 creates, leaving a

--- a/internal/database/item_text_test.go
+++ b/internal/database/item_text_test.go
@@ -1,0 +1,358 @@
+package database
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/lmorchard/feedspool-go/internal/itemtext"
+)
+
+const (
+	// ftsIntegrityCheckSQL asks FTS5 to compare its index against the content
+	// table. An external-content index that has drifted returns wrong results
+	// rather than erroring, so an explicit check is the only thing that catches
+	// a missing trigger.
+	//
+	// The argument is load-bearing, and its sense is the opposite of what the
+	// name suggests. Measured against this driver: with no argument, or with 0,
+	// FTS5 checks only that the index is internally consistent -- which stays
+	// true while the index and item_text disagree, so both an orphaned and a
+	// missing entry sail through. Argument 1 is the one that reads the content
+	// table back, and it reports SQLITE_CORRUPT for either.
+	ftsIntegrityCheckSQL = `INSERT INTO items_fts(items_fts, rank) VALUES('integrity-check', 1)`
+
+	// ftsMatchCountSQL counts index entries, not content rows. A bare
+	// "SELECT COUNT(*) FROM items_fts" would read the content table and report
+	// the same number whether or not the index was maintained, which would make
+	// every trigger case below pass vacuously.
+	ftsMatchCountSQL = `SELECT COUNT(*) FROM items_fts WHERE items_fts MATCH ?`
+
+	// seedSharedTerm appears in the title of every seeded item, so a match count
+	// on it is a count of indexed items.
+	seedSharedTerm = "headline"
+
+	// seedBodyTerm appears in the body of every seeded item.
+	seedBodyTerm = "zeppelin"
+
+	// replacementBodyTerm is the term an update swaps in for seedBodyTerm.
+	replacementBodyTerm = "dirigible"
+)
+
+// execSQL runs a statement that the test expects to succeed.
+func execSQL(t *testing.T, db *DB, query string, args ...any) {
+	t.Helper()
+	if _, err := db.conn.Exec(query, args...); err != nil {
+		t.Fatalf("exec %q: %v", query, err)
+	}
+}
+
+// integrityCheck fails the test if the FTS index disagrees with item_text.
+func integrityCheck(t *testing.T, db *DB) {
+	t.Helper()
+	if _, err := db.conn.Exec(ftsIntegrityCheckSQL); err != nil {
+		t.Fatalf("fts integrity-check failed: %v", err)
+	}
+}
+
+// countMatching reports how many items the index returns for a bare term.
+func countMatching(t *testing.T, db *DB, term string) int {
+	t.Helper()
+	var count int
+	if err := db.conn.QueryRow(ftsMatchCountSQL, term).Scan(&count); err != nil {
+		t.Fatalf("counting matches for %q: %v", term, err)
+	}
+	return count
+}
+
+// countIndexedItems reports how many seeded items the index still returns.
+func countIndexedItems(t *testing.T, db *DB) int {
+	t.Helper()
+	return countMatching(t, db, seedSharedTerm)
+}
+
+// countItemTextRows reports how many derived-text rows exist.
+func countItemTextRows(t *testing.T, db *DB) int {
+	t.Helper()
+	var count int
+	if err := db.conn.QueryRow(`SELECT COUNT(*) FROM item_text`).Scan(&count); err != nil {
+		t.Fatalf("counting item_text rows: %v", err)
+	}
+	return count
+}
+
+// firstItemID returns the lowest item ID, which is the first seeded item.
+func firstItemID(t *testing.T, db *DB) int64 {
+	t.Helper()
+	var id int64
+	if err := db.conn.QueryRow(`SELECT MIN(id) FROM items`).Scan(&id); err != nil {
+		t.Fatalf("reading first item id: %v", err)
+	}
+	return id
+}
+
+// seededItemContent is the raw HTML body seeded for item i.
+func seededItemContent(index int, term string) string {
+	return fmt.Sprintf("<div>Body of item %d, a %s</div>", index, term)
+}
+
+// seedSearchableItems inserts count items under fixtureFeedURL with
+// deterministic, searchable text. published_date is always set:
+// DeleteArchivedItems filters on the effective date being non-NULL, so an item
+// without one would make the archived-purge case below assert nothing.
+func seedSearchableItems(t *testing.T, count int) *DB {
+	t.Helper()
+	db := setupTestDB(t)
+	if err := db.UpsertFeed(&Feed{URL: fixtureFeedURL}); err != nil {
+		t.Fatalf("seeding feed: %v", err)
+	}
+	published := time.Now().UTC().Add(-time.Hour)
+	for i := range count {
+		item := &Item{
+			FeedURL:       fixtureFeedURL,
+			GUID:          fmt.Sprintf("seed-guid-%d", i),
+			Title:         fmt.Sprintf("Item %d %s", i, seedSharedTerm),
+			Link:          fmt.Sprintf("https://example.com/item-%d", i),
+			PublishedDate: published.Add(time.Duration(i) * time.Minute),
+			Summary:       fmt.Sprintf("<p>Summary of item %d</p>", i),
+			Content:       seededItemContent(i, seedBodyTerm),
+		}
+		if err := db.UpsertItem(item); err != nil {
+			t.Fatalf("seeding item %d: %v", i, err)
+		}
+	}
+	return db
+}
+
+// seedIndexedItems seeds items and brings the derived text and index up to date.
+func seedIndexedItems(t *testing.T, count int) *DB {
+	t.Helper()
+	db := seedSearchableItems(t, count)
+	if err := db.ReindexItemText(false, nil); err != nil {
+		t.Fatalf("indexing seeded items: %v", err)
+	}
+	if got := countIndexedItems(t, db); got != count {
+		t.Fatalf("seed indexed %d items, want %d", got, count)
+	}
+	return db
+}
+
+func TestItemTextTriggersCoverEveryDeletePath(t *testing.T) {
+	const seedCount = 2
+	cases := []struct {
+		name     string
+		act      func(t *testing.T, db *DB)
+		wantRows int // expected items left in the index, from a seed of 2
+	}{
+		{"direct delete", func(t *testing.T, db *DB) {
+			execSQL(t, db, `DELETE FROM item_text WHERE item_id = ?`, firstItemID(t, db))
+		}, 1},
+		{"one-level cascade from items", func(t *testing.T, db *DB) {
+			execSQL(t, db, `DELETE FROM items WHERE id = ?`, firstItemID(t, db))
+		}, 1},
+		{"two-level cascade from feeds", func(t *testing.T, db *DB) {
+			// feeds -> items -> item_text -> trigger. DeleteFeed reaches the
+			// index no other way; there is no FTS code on the purge path.
+			if err := db.DeleteFeed(fixtureFeedURL); err != nil {
+				t.Fatal(err)
+			}
+		}, 0},
+		{"archived purge", func(t *testing.T, db *DB) {
+			execSQL(t, db, `UPDATE items SET archived = 1`)
+			deleted, err := db.DeleteArchivedItems(time.Now().Add(time.Hour))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if deleted != seedCount {
+				t.Fatalf("purge deleted %d items, want %d", deleted, seedCount)
+			}
+		}, 0},
+		{"marking archived indexes nothing away", func(t *testing.T, db *DB) {
+			// archived is a filter on items, not a text change, so the index
+			// must be untouched.
+			if err := db.MarkItemsArchived(fixtureFeedURL, nil); err != nil {
+				t.Fatal(err)
+			}
+		}, seedCount},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			db := seedIndexedItems(t, seedCount)
+			testCase.act(t, db)
+			if got := countIndexedItems(t, db); got != testCase.wantRows {
+				t.Errorf("index holds %d items, want %d", got, testCase.wantRows)
+			}
+			integrityCheck(t, db)
+		})
+	}
+}
+
+// TestItemTextUpdateRetiresStaleTerms guards the update trigger's 'delete'
+// command. An update trigger that inserts without first deleting leaves both
+// the old and the new body searchable, and integrity-check still passes, so
+// only the stale-term assertion catches it.
+func TestItemTextUpdateRetiresStaleTerms(t *testing.T) {
+	db := seedIndexedItems(t, 1)
+	if got := countMatching(t, db, seedBodyTerm); got != 1 {
+		t.Fatalf("seeded body term matches %d items, want 1", got)
+	}
+
+	execSQL(
+		t, db,
+		`UPDATE items SET content = ? WHERE id = ?`,
+		seededItemContent(0, replacementBodyTerm), firstItemID(t, db),
+	)
+	// Phase 3 owns the live write path; here a version rewind is what makes the
+	// backfill recompute the row, which drives item_text through an UPDATE.
+	execSQL(t, db, `UPDATE item_text SET generator_version = generator_version - 1`)
+	if err := db.ReindexItemText(false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := countMatching(t, db, seedBodyTerm); got != 0 {
+		t.Errorf("retired body term still matches %d items, want 0", got)
+	}
+	if got := countMatching(t, db, replacementBodyTerm); got != 1 {
+		t.Errorf("new body term matches %d items, want 1", got)
+	}
+	if got := countIndexedItems(t, db); got != 1 {
+		t.Errorf("untouched title term matches %d items, want 1", got)
+	}
+	integrityCheck(t, db)
+}
+
+func TestReindexItemTextRecomputesOnVersionBump(t *testing.T) {
+	const seedCount = 3
+	db := seedIndexedItems(t, seedCount)
+	before := itemTextComputedAt(t, db)
+
+	execSQL(t, db, `UPDATE item_text SET generator_version = ?`, itemtext.Version-1)
+	if err := db.ReindexItemText(false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	var stale int
+	if err := db.conn.QueryRow(
+		`SELECT COUNT(*) FROM item_text WHERE generator <> ? OR generator_version <> ?`,
+		itemtext.Generator, itemtext.Version,
+	).Scan(&stale); err != nil {
+		t.Fatal(err)
+	}
+	if stale != 0 {
+		t.Errorf("%d rows still carry the old generator version", stale)
+	}
+
+	after := itemTextComputedAt(t, db)
+	if len(after) != len(before) {
+		t.Fatalf("row count changed from %d to %d", len(before), len(after))
+	}
+	for id, timestamp := range after {
+		if timestamp == before[id] {
+			t.Errorf("item %d kept computed_at %q, so it was not recomputed", id, timestamp)
+		}
+	}
+	integrityCheck(t, db)
+}
+
+func TestReindexItemTextForceRebuilds(t *testing.T) {
+	const (
+		junkTerm  = "corrupted"
+		seedCount = 3
+	)
+	db := seedIndexedItems(t, seedCount)
+
+	// Corrupt the derived text by hand. Without force the backfill would leave
+	// it alone: the rows are already at the current generator version.
+	execSQL(t, db, `UPDATE item_text SET body = ?`, junkTerm)
+	if got := countMatching(t, db, junkTerm); got != seedCount {
+		t.Fatalf("corrupted body matches %d items, want %d", got, seedCount)
+	}
+
+	if err := db.ReindexItemText(true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := countMatching(t, db, junkTerm); got != 0 {
+		t.Errorf("corrupted term still matches %d items, want 0", got)
+	}
+	if got := countMatching(t, db, seedBodyTerm); got != seedCount {
+		t.Errorf("rebuilt body term matches %d items, want %d", got, seedCount)
+	}
+	want := itemtext.Derive("", "", seededItemContent(0, seedBodyTerm), itemtext.DefaultOptions()).Body
+	var body string
+	if err := db.conn.QueryRow(
+		`SELECT body FROM item_text WHERE item_id = ?`, firstItemID(t, db),
+	).Scan(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body != want {
+		t.Errorf("rebuilt body = %q, want %q", body, want)
+	}
+	integrityCheck(t, db)
+}
+
+// TestMigration11BackfillsExistingItems walks the path a real spool takes:
+// items already on disk, no derived text, no index.
+func TestMigration11BackfillsExistingItems(t *testing.T) {
+	const seedCount = 3
+	db := seedSearchableItems(t, seedCount)
+	rewindPastMigration11(t, db)
+
+	if err := db.RunMigrations(); err != nil {
+		t.Fatalf("RunMigrations() error = %v", err)
+	}
+
+	version, err := db.GetMigrationVersion()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version != maxMigrationVersion {
+		t.Errorf("migration version = %d, want %d", version, maxMigrationVersion)
+	}
+	if got := countItemTextRows(t, db); got != seedCount {
+		t.Errorf("item_text has %d rows, want %d", got, seedCount)
+	}
+	if got := countIndexedItems(t, db); got != seedCount {
+		t.Errorf("index holds %d items, want %d", got, seedCount)
+	}
+	integrityCheck(t, db)
+}
+
+// rewindPastMigration11 drops everything migration 11 creates, leaving a
+// database that looks like it was last opened by an older feedspool.
+func rewindPastMigration11(t *testing.T, db *DB) {
+	t.Helper()
+	for _, statement := range []string{
+		`DROP TRIGGER IF EXISTS item_text_ai`,
+		`DROP TRIGGER IF EXISTS item_text_ad`,
+		`DROP TRIGGER IF EXISTS item_text_au`,
+		`DROP TABLE IF EXISTS items_fts`,
+		`DROP TABLE IF EXISTS item_text`,
+	} {
+		execSQL(t, db, statement)
+	}
+	execSQL(t, db, `DELETE FROM schema_migrations WHERE version = ?`, migrationVersion11)
+}
+
+// itemTextComputedAt maps each derived row to its computed_at timestamp.
+func itemTextComputedAt(t *testing.T, db *DB) map[int64]string {
+	t.Helper()
+	rows, err := db.conn.Query(`SELECT item_id, computed_at FROM item_text`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	stamps := make(map[int64]string)
+	for rows.Next() {
+		var id int64
+		var computedAt string
+		if err := rows.Scan(&id, &computedAt); err != nil {
+			t.Fatal(err)
+		}
+		stamps[id] = computedAt
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	return stamps
+}

--- a/internal/database/item_text_test.go
+++ b/internal/database/item_text_test.go
@@ -37,6 +37,9 @@ const (
 
 	// replacementBodyTerm is the term an update swaps in for seedBodyTerm.
 	replacementBodyTerm = "dirigible"
+
+	// seedGUIDFormat builds the GUID of the nth seeded item.
+	seedGUIDFormat = "seed-guid-%d"
 )
 
 // execSQL runs a statement that the test expects to succeed.
@@ -120,7 +123,7 @@ func seedSearchableItems(t *testing.T, count int) *DB {
 	for i := range count {
 		item := &Item{
 			FeedURL:       fixtureFeedURL,
-			GUID:          fmt.Sprintf("seed-guid-%d", i),
+			GUID:          fmt.Sprintf(seedGUIDFormat, i),
 			Title:         fmt.Sprintf("Item %d %s", i, seedSharedTerm),
 			Link:          fmt.Sprintf("https://example.com/item-%d", i),
 			PublishedDate: published.Add(time.Duration(i) * time.Minute),
@@ -306,6 +309,62 @@ func TestReindexItemTextForceRebuilds(t *testing.T) {
 	integrityCheck(t, db)
 }
 
+// The live write path and itemTextStalenessCondition have to agree on what
+// "current" means. The predicate treats a row written by a different generator
+// as stale even at a matching version; UpsertItem has to as well, or a row left
+// behind by a second generator (#30) would look current to every fetch and
+// never be rewritten with the text this generator would derive.
+func TestUpsertItemRederivesTextLeftByAnotherGenerator(t *testing.T) {
+	const (
+		junkTerm       = "corrupted"
+		otherGenerator = "some-other-generator"
+	)
+	db := seedIndexedItems(t, 1)
+	id := firstItemID(t, db)
+
+	// The hash and version stay exactly as the write path last wrote them, so
+	// only the generator name can make this row stale. The mangled body is what
+	// makes a re-derivation observable.
+	execSQL(
+		t, db,
+		`UPDATE item_text SET generator = ?, body = ? WHERE item_id = ?`,
+		otherGenerator, junkTerm, id,
+	)
+	if got := countMatching(t, db, junkTerm); got != 1 {
+		t.Fatalf("mangled body matches %d items, want 1", got)
+	}
+
+	// Re-fetching the feed writes the identical item back, which is the case
+	// upsertItemTextIfChanged short-circuits.
+	item, err := db.getItemByKey(fixtureFeedURL, fmt.Sprintf(seedGUIDFormat, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if item == nil {
+		t.Fatal("seeded item is missing")
+	}
+	if err := db.UpsertItem(item); err != nil {
+		t.Fatal(err)
+	}
+
+	var generator, body string
+	if err := db.conn.QueryRow(
+		`SELECT generator, body FROM item_text WHERE item_id = ?`, id,
+	).Scan(&generator, &body); err != nil {
+		t.Fatal(err)
+	}
+	if generator != itemtext.Generator {
+		t.Errorf("generator = %q, want %q", generator, itemtext.Generator)
+	}
+	if got := countMatching(t, db, junkTerm); got != 0 {
+		t.Errorf("mangled term still matches %d items, want 0", got)
+	}
+	if got := countMatching(t, db, seedBodyTerm); got != 1 {
+		t.Errorf("re-derived body term matches %d items, want 1", got)
+	}
+	integrityCheck(t, db)
+}
+
 // TestMigration11BackfillsExistingItems walks the path a real spool takes:
 // items already on disk, no derived text, no index.
 func TestMigration11BackfillsExistingItems(t *testing.T) {
@@ -378,6 +437,53 @@ func TestMigration11SchemaStageDoesNotRecordVersion(t *testing.T) {
 	}
 	if version != migrationVersion11 {
 		t.Errorf("version = %d after the full migration, want %d", version, migrationVersion11)
+	}
+	if got := countItemTextRows(t, db); got != seedCount {
+		t.Errorf("item_text has %d rows, want %d", got, seedCount)
+	}
+	if got := countIndexedItems(t, db); got != seedCount {
+		t.Errorf("index holds %d items, want %d", got, seedCount)
+	}
+	integrityCheck(t, db)
+}
+
+// Two processes can enter migration 11 at once: IsInitialized runs migrations,
+// so a running `serve` and a cron `fetch` both do on the first post-upgrade
+// open, and this migration's window is tens of seconds rather than one fast
+// transaction. Both do the work idempotently, and the loser then has nothing
+// left to do but record the version -- which must not fail as a duplicate.
+//
+// A second in-process run stands in for the loser: identical DDL, a backfill
+// with nothing left to do, and a version row that already exists. It does not
+// reproduce the interleaving, but the duplicate version record is the only part
+// of that race that ever failed.
+func TestMigration11RecordsItsVersionIdempotently(t *testing.T) {
+	const seedCount = 2
+	db := seedSearchableItems(t, seedCount)
+	rewindPastMigration11(t, db)
+
+	if err := db.applyMigration11(); err != nil {
+		t.Fatalf("first applyMigration11() error = %v", err)
+	}
+	if err := db.applyMigration11(); err != nil {
+		t.Fatalf("second applyMigration11() error = %v", err)
+	}
+
+	version, err := db.GetMigrationVersion()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version != migrationVersion11 {
+		t.Errorf("version = %d, want %d", version, migrationVersion11)
+	}
+	var records int
+	if err := db.conn.QueryRow(
+		`SELECT COUNT(*) FROM schema_migrations WHERE version = ?`, migrationVersion11,
+	).Scan(&records); err != nil {
+		t.Fatal(err)
+	}
+	if records != 1 {
+		t.Errorf("schema_migrations holds %d rows for version %d, want 1", records, migrationVersion11)
 	}
 	if got := countItemTextRows(t, db); got != seedCount {
 		t.Errorf("item_text has %d rows, want %d", got, seedCount)

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -552,7 +552,18 @@ func (db *DB) applyMigration11() error {
 	}
 
 	// Its own implicit transaction, entered only once the index is complete.
-	if _, err := db.conn.Exec("INSERT INTO schema_migrations (version) VALUES (?)", migrationVersion11); err != nil {
+	//
+	// OR IGNORE, unlike every other migration here: IsInitialized runs
+	// migrations, so a running `serve` and a cron `fetch` can both enter this
+	// backfill on the first post-upgrade open, and this one's window is tens of
+	// seconds rather than a single fast transaction. Both do the work
+	// idempotently -- SQLite serializes the writes and the upserts are
+	// content-identical -- so the loser has nothing left to do but record the
+	// version, and a UNIQUE violation there would fail a migration that in fact
+	// succeeded.
+	if _, err := db.conn.Exec(
+		"INSERT OR IGNORE INTO schema_migrations (version) VALUES (?)", migrationVersion11,
+	); err != nil {
 		return fmt.Errorf("failed to record migration %d: %w", migrationVersion11, err)
 	}
 	return nil

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -18,7 +18,8 @@ const (
 	migrationVersion8   = 8  // Add feed parser type and scrape selector
 	migrationVersion9   = 9  // Add effective-date query index
 	migrationVersion10  = 10 // Deduplicate annotations and enforce uniqueness
-	maxMigrationVersion = migrationVersion10
+	migrationVersion11  = 11 // Add derived item text and the FTS5 search index
+	maxMigrationVersion = migrationVersion11
 )
 
 // getMigrations returns the database migration scripts.
@@ -86,6 +87,49 @@ func getMigrations() map[int]string {
 		);
 		CREATE UNIQUE INDEX IF NOT EXISTS idx_item_annotations_unique
 			ON item_annotations(feed_url, item_guid, kind, COALESCE(value, ''));`,
+		// This DDL is deliberately identical to the tail of schema.sql, the same
+		// arrangement item_annotations has with migration 6: a fresh database gets
+		// it from the schema and an existing one gets it from here, and both end
+		// up in the same place. IF NOT EXISTS throughout keeps re-running it free,
+		// which is what lets an interrupted migration 11 simply start over.
+		//
+		// items_fts is an external-content index: it stores the terms and reads
+		// column values back out of item_text. That is why a 'delete' command has
+		// to carry the OLD values -- once item_text holds the new text, the old
+		// terms cannot be recovered from anywhere.
+		migrationVersion11: `CREATE TABLE IF NOT EXISTS item_text (
+			item_id           INTEGER PRIMARY KEY REFERENCES items(id) ON DELETE CASCADE,
+			title             TEXT NOT NULL DEFAULT '',
+			summary           TEXT NOT NULL DEFAULT '',
+			body              TEXT NOT NULL DEFAULT '',
+			source_hash       TEXT NOT NULL,
+			generator         TEXT NOT NULL,
+			generator_version INTEGER NOT NULL,
+			computed_at       DATETIME NOT NULL
+		);
+		CREATE INDEX IF NOT EXISTS idx_item_text_generator
+			ON item_text(generator, generator_version);
+
+		CREATE VIRTUAL TABLE IF NOT EXISTS items_fts USING fts5(
+			title, summary, body,
+			content='item_text', content_rowid='item_id',
+			tokenize="porter unicode61 remove_diacritics 2"
+		);
+
+		CREATE TRIGGER IF NOT EXISTS item_text_ai AFTER INSERT ON item_text BEGIN
+			INSERT INTO items_fts(rowid, title, summary, body)
+			VALUES (new.item_id, new.title, new.summary, new.body);
+		END;
+		CREATE TRIGGER IF NOT EXISTS item_text_ad AFTER DELETE ON item_text BEGIN
+			INSERT INTO items_fts(items_fts, rowid, title, summary, body)
+			VALUES ('delete', old.item_id, old.title, old.summary, old.body);
+		END;
+		CREATE TRIGGER IF NOT EXISTS item_text_au AFTER UPDATE ON item_text BEGIN
+			INSERT INTO items_fts(items_fts, rowid, title, summary, body)
+			VALUES ('delete', old.item_id, old.title, old.summary, old.body);
+			INSERT INTO items_fts(rowid, title, summary, body)
+			VALUES (new.item_id, new.title, new.summary, new.body);
+		END;`,
 	}
 }
 
@@ -171,6 +215,8 @@ func (db *DB) applySpecificMigration(version int) error {
 		return db.applyMigration9()
 	case migrationVersion10:
 		return db.applyMigration10()
+	case migrationVersion11:
+		return db.applyMigration11()
 	default:
 		// For any new migrations, just apply them directly
 		migrations := getMigrations()
@@ -484,4 +530,55 @@ func normalizedMigrationTime(value interface{}) interface{} {
 func (db *DB) applyMigration10() error {
 	migrations := getMigrations()
 	return db.ApplyMigration(migrationVersion10, migrations[migrationVersion10])
+}
+
+// applyMigration11 adds the derived item_text table, the items_fts index, and
+// the triggers that maintain it, then indexes whatever is already on disk.
+//
+// The three stages are deliberately not one transaction. The version is
+// recorded last, so it means "fully indexed": if the backfill is interrupted,
+// the version stays unbumped, the next run re-applies the idempotent DDL, and
+// the backfill picks up from the batches it already committed. Bumping the
+// version first would mark a half-indexed database as done and search would
+// silently miss those items forever.
+func (db *DB) applyMigration11() error {
+	if err := db.applyMigration11Schema(); err != nil {
+		return err
+	}
+
+	logrus.Info("Building the full-text search index; this may take a while on a large spool")
+	if err := db.ReindexItemText(false, ItemTextProgressLogger()); err != nil {
+		return fmt.Errorf("failed to build the full-text search index: %w", err)
+	}
+
+	// Its own implicit transaction, entered only once the index is complete.
+	if _, err := db.conn.Exec("INSERT INTO schema_migrations (version) VALUES (?)", migrationVersion11); err != nil {
+		return fmt.Errorf("failed to record migration %d: %w", migrationVersion11, err)
+	}
+	return nil
+}
+
+// applyMigration11Schema creates the search schema in its own transaction.
+func (db *DB) applyMigration11Schema() error {
+	tx, err := db.conn.Begin()
+	if err != nil {
+		return fmt.Errorf("failed to begin migration %d: %w", migrationVersion11, err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			if rollbackErr := tx.Rollback(); rollbackErr != nil {
+				logrus.WithError(rollbackErr).Warn("Failed to rollback migration")
+			}
+		}
+	}()
+
+	if _, err := tx.Exec(getMigrations()[migrationVersion11]); err != nil {
+		return fmt.Errorf("failed to create the item text schema: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit migration %d schema: %w", migrationVersion11, err)
+	}
+	committed = true
+	return nil
 }

--- a/internal/database/migrations_test.go
+++ b/internal/database/migrations_test.go
@@ -36,6 +36,10 @@ func setupTestDBForMigrations(t *testing.T) (db *DB, tempDir string) {
 }
 
 // setupOldDatabase creates a database with the old schema (without latest_item_date column).
+//
+// items keeps its id column: every schema feedspool has ever shipped has had
+// one, including the version-1 baseline this fixture stands in for, and the
+// item repository selects it everywhere. Migration 11 keys derived text off it.
 func setupOldDatabase(t *testing.T) *DB {
 	t.Helper()
 
@@ -54,6 +58,7 @@ func setupOldDatabase(t *testing.T) *DB {
 		);
 		
 		CREATE TABLE items (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			feed_url TEXT,
 			guid TEXT,
 			title TEXT,
@@ -63,7 +68,7 @@ func setupOldDatabase(t *testing.T) *DB {
 			summary TEXT,
 			archived BOOLEAN DEFAULT FALSE,
 			item_json TEXT,
-			PRIMARY KEY (feed_url, guid),
+			UNIQUE (feed_url, guid),
 			FOREIGN KEY (feed_url) REFERENCES feeds(url) ON DELETE CASCADE
 		);
 		
@@ -400,6 +405,7 @@ func TestRunMigrationsWithExistingColumn(t *testing.T) {
 		);
 		
 		CREATE TABLE items (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			feed_url TEXT,
 			guid TEXT,
 			title TEXT,
@@ -409,7 +415,7 @@ func TestRunMigrationsWithExistingColumn(t *testing.T) {
 			summary TEXT,
 			archived BOOLEAN DEFAULT FALSE,
 			item_json TEXT,
-			PRIMARY KEY (feed_url, guid),
+			UNIQUE (feed_url, guid),
 			FOREIGN KEY (feed_url) REFERENCES feeds(url) ON DELETE CASCADE
 		);
 	`

--- a/internal/database/pagination.go
+++ b/internal/database/pagination.go
@@ -70,6 +70,14 @@ type ItemPage struct {
 	After *ItemCursor
 }
 
+// isRelevance reports whether this page is ranked by bm25 rather than by date.
+// It is derived in three places -- the ordering, the cursor it hands back, and
+// whether the keyset predicate applies at all -- and the third is negated, so
+// the answer lives here rather than being re-spelled at each site.
+func (p *ItemPage) isRelevance() bool {
+	return p.Sort == SortRelevance
+}
+
 // FeedPage describes one page of a feed query, ordered by URL. URL is the
 // primary key -- never NULL, always unique -- so the cursor needs no tiebreak.
 type FeedPage struct {
@@ -113,7 +121,7 @@ func (db *DB) ListItems(page *ItemPage) ([]*Item, *ItemCursor, error) {
 	}
 	// The same guard buildItemsQuery carries, for the same reason: bm25 reads
 	// the joined FTS table, and without a search there is no join.
-	relevance := page.Sort == SortRelevance
+	relevance := page.isRelevance()
 	if relevance && searchExpr == "" {
 		return nil, nil, ErrRelevanceNeedsSearch
 	}
@@ -146,7 +154,7 @@ func (db *DB) ListItems(page *ItemPage) ([]*Item, *ItemCursor, error) {
 func buildItemPageQuery(page *ItemPage, searchExpr string, limit int) (
 	query string, args []interface{}, offset int,
 ) {
-	relevance := page.Sort == SortRelevance
+	relevance := page.isRelevance()
 	conditions, args := itemPageConditions(page, searchExpr)
 	query = "SELECT " + itemSelectColumns + ", " + dateRankExpression + " AS date_rank, " +
 		aliasedEffectiveDateExpression + " AS effective_date\n\tFROM items i"
@@ -223,7 +231,7 @@ func scanItemPageRows(rows *sql.Rows) ([]*Item, []ItemCursor, error) {
 func itemPageConditions(page *ItemPage, searchExpr string) (conditions []string, args []interface{}) {
 	// Relevance paginates by an offset carried in the cursor, so there is no
 	// keyset position to filter on; the predicate is for the date orderings.
-	if page.After != nil && page.Sort != SortRelevance {
+	if page.After != nil && !page.isRelevance() {
 		condition, cursorArgs := itemCursorCondition(page.After, page.Ascending)
 		conditions = append(conditions, condition)
 		args = append(args, cursorArgs...)

--- a/internal/database/pagination.go
+++ b/internal/database/pagination.go
@@ -40,6 +40,14 @@ type ItemCursor struct {
 	DateRank      int
 	EffectiveDate float64
 	ID            int64
+
+	// Relevance and Offset are used only by Sort == SortRelevance. A bm25
+	// ordering has no stable natural key -- the score depends on corpus
+	// statistics, so any write shifts every score -- and a keyset built on it
+	// would silently skip rows. Offset can only repeat or drop a row, which is
+	// the ordinary offset caveat and a strictly better failure.
+	Relevance bool
+	Offset    int
 }
 
 // ItemPage describes one page of an item query. A nil *bool means "no filter"
@@ -54,8 +62,12 @@ type ItemPage struct {
 	Seen      *bool
 	Archived  *bool
 	Ascending bool
-	Limit     int
-	After     *ItemCursor
+	// Sort is one of SortNewest, SortOldest or SortRelevance. Empty means
+	// SortNewest. Ascending carries the direction for the two date orderings;
+	// Sort exists because relevance is not a direction.
+	Sort  string
+	Limit int
+	After *ItemCursor
 }
 
 // FeedPage describes one page of a feed query, ordered by URL. URL is the
@@ -95,26 +107,18 @@ func (db *DB) ListItems(page *ItemPage) ([]*Item, *ItemCursor, error) {
 		limit = 1
 	}
 
-	conditions, args := itemPageConditions(page)
-	query := "SELECT " + itemSelectColumns + ", " + dateRankExpression + " AS date_rank, " +
-		aliasedEffectiveDateExpression + " AS effective_date\n\tFROM items i"
-	if len(conditions) > 0 {
-		query += " WHERE " + strings.Join(conditions, " AND ")
+	searchExpr, err := itemsSearchExpression(page.Search)
+	if err != nil {
+		return nil, nil, err
+	}
+	// The same guard buildItemsQuery carries, for the same reason: bm25 reads
+	// the joined FTS table, and without a search there is no join.
+	relevance := page.Sort == SortRelevance
+	if relevance && searchExpr == "" {
+		return nil, nil, ErrRelevanceNeedsSearch
 	}
 
-	direction := "DESC"
-	if page.Ascending {
-		direction = "ASC"
-	}
-	// date_rank always ascends so undated rows stay at the tail in both
-	// directions; only the date and id components flip.
-	//nolint:gosec // direction is one of two literals above; all values are bound
-	query += fmt.Sprintf(" ORDER BY date_rank ASC, effective_date %s, i.id %s", direction, direction)
-
-	// Fetch one extra row to learn whether another page exists without a
-	// second count query.
-	query += " LIMIT ?"
-	args = append(args, limit+1)
+	query, args, offset := buildItemPageQuery(page, searchExpr, limit)
 
 	rows, err := db.conn.Query(query, args...)
 	if err != nil {
@@ -122,6 +126,73 @@ func (db *DB) ListItems(page *ItemPage) ([]*Item, *ItemCursor, error) {
 	}
 	defer rows.Close()
 
+	items, cursors, err := scanItemPageRows(rows)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if len(items) <= limit {
+		return items, nil, nil
+	}
+	if relevance {
+		return items[:limit], &ItemCursor{Relevance: true, Offset: offset + limit}, nil
+	}
+	next := cursors[limit-1]
+	return items[:limit], &next, nil
+}
+
+// buildItemPageQuery assembles the page query and returns the offset it starts
+// from, which is zero for every ordering but relevance.
+func buildItemPageQuery(page *ItemPage, searchExpr string, limit int) (
+	query string, args []interface{}, offset int,
+) {
+	relevance := page.Sort == SortRelevance
+	conditions, args := itemPageConditions(page, searchExpr)
+	query = "SELECT " + itemSelectColumns + ", " + dateRankExpression + " AS date_rank, " +
+		aliasedEffectiveDateExpression + " AS effective_date\n\tFROM items i"
+	if searchExpr != "" {
+		query += itemsFTSJoin
+	}
+	if len(conditions) > 0 {
+		query += " WHERE " + strings.Join(conditions, " AND ")
+	}
+
+	if relevance {
+		// Shared with the CLI so the two surfaces cannot rank differently.
+		query += itemsOrderByClause(SortRelevance)
+	} else {
+		direction := "DESC"
+		if page.Ascending {
+			direction = "ASC"
+		}
+		// date_rank always ascends so undated rows stay at the tail in both
+		// directions; only the date and id components flip. direction is one of
+		// the two literals above; every value is bound.
+		query += fmt.Sprintf(" ORDER BY date_rank ASC, effective_date %s, i.id %s", direction, direction)
+	}
+
+	// Fetch one extra row to learn whether another page exists without a
+	// second count query.
+	query += " LIMIT ?"
+	args = append(args, limit+1)
+
+	// Relevance resumes by offset rather than by keyset, because a bm25 score
+	// is not a stable key: it moves with the corpus, so a keyset built on it
+	// would skip rows outright.
+	if relevance {
+		if page.After != nil {
+			offset = page.After.Offset
+		}
+		query += " OFFSET ?"
+		args = append(args, offset)
+	}
+	return query, args, offset
+}
+
+// scanItemPageRows reads a page's rows into items and their matching keyset
+// cursor positions. The cursors are meaningless in relevance mode, which
+// paginates by offset and ignores them.
+func scanItemPageRows(rows *sql.Rows) ([]*Item, []ItemCursor, error) {
 	items := []*Item{}
 	cursors := []ItemCursor{}
 	for rows.Next() {
@@ -144,16 +215,15 @@ func (db *DB) ListItems(page *ItemPage) ([]*Item, *ItemCursor, error) {
 	if err := rows.Err(); err != nil {
 		return nil, nil, fmt.Errorf("error iterating over items: %w", err)
 	}
-
-	if len(items) <= limit {
-		return items, nil, nil
-	}
-	next := cursors[limit-1]
-	return items[:limit], &next, nil
+	return items, cursors, nil
 }
 
-func itemPageConditions(page *ItemPage) (conditions []string, args []interface{}) {
-	if page.After != nil {
+// itemPageConditions builds the WHERE conditions for one page. searchExpr is
+// the already-parsed FTS5 expression, empty when the page carries no search.
+func itemPageConditions(page *ItemPage, searchExpr string) (conditions []string, args []interface{}) {
+	// Relevance paginates by an offset carried in the cursor, so there is no
+	// keyset position to filter on; the predicate is for the date orderings.
+	if page.After != nil && page.Sort != SortRelevance {
 		condition, cursorArgs := itemCursorCondition(page.After, page.Ascending)
 		conditions = append(conditions, condition)
 		args = append(args, cursorArgs...)
@@ -170,10 +240,11 @@ func itemPageConditions(page *ItemPage) (conditions []string, args []interface{}
 		conditions = append(conditions, "i.link = ?")
 		args = append(args, page.Link)
 	}
-	if page.Search != "" {
-		// Matches ItemFilter.Search exactly: title substring, case-insensitive.
-		conditions = append(conditions, "instr(lower(i.title), lower(?)) > 0")
-		args = append(args, page.Search)
+	if searchExpr != "" {
+		// The same fragment buildItemsQuery binds, so the CLI and the API
+		// cannot disagree about what a query matches.
+		conditions = append(conditions, itemsFTSMatch)
+		args = append(args, searchExpr)
 	}
 	if page.Seen != nil {
 		existence := "EXISTS"

--- a/internal/database/pagination_test.go
+++ b/internal/database/pagination_test.go
@@ -2,9 +2,13 @@ package database
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/lmorchard/feedspool-go/internal/search"
 )
 
 const (
@@ -198,6 +202,32 @@ func TestListItemsPagesThroughUndatedBlock(t *testing.T) {
 	}
 }
 
+// seedRelevanceCorpus inserts count items that all match relevanceTerm, with
+// the term in the title of every other one and repeated a varying number of
+// times in the body, so the bm25 ordering is neither the insertion order nor
+// the date order.
+func seedRelevanceCorpus(t *testing.T, db *DB, count int) {
+	t.Helper()
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	for i := range count {
+		title := fmt.Sprintf("Dispatch %03d", i)
+		if i%2 == 0 {
+			title = fmt.Sprintf("%s digest %03d", relevanceTerm, i)
+		}
+		if err := db.UpsertItem(&Item{
+			FeedURL:       fixtureFeedURL,
+			GUID:          fmt.Sprintf("relevance-%03d", i),
+			Title:         title,
+			Link:          fmt.Sprintf("https://example.com/r/%03d", i),
+			Summary:       "<p>" + searchFiller + "</p>",
+			Content:       "<div>" + strings.Repeat(relevanceTerm+" ", 1+i%3) + searchFiller + "</div>",
+			PublishedDate: base.Add(time.Duration(i) * time.Hour),
+		}); err != nil {
+			t.Fatalf("seeding relevance corpus: %v", err)
+		}
+	}
+}
+
 func TestListItemsFiltersBySearch(t *testing.T) {
 	db := setupTestDB(t)
 	seedItems(t, db, paginationTestFeed, 5)
@@ -209,6 +239,140 @@ func TestListItemsFiltersBySearch(t *testing.T) {
 	}
 	if len(items) != 1 || items[0].GUID != "guid-003" {
 		t.Errorf("search returned %d items, want exactly guid-003", len(items))
+	}
+}
+
+// The API's search used to be a title substring. It is now the same FTS5
+// expression the CLI runs, so it reaches the summary and the body too.
+func TestListItemsSearchMatchesBodyAndSummary(t *testing.T) {
+	db := setupItemTextFixtureDB(t)
+	seedSearchFieldFixtures(t, db)
+
+	cases := []struct {
+		name, query, want string
+	}{
+		{caseTitle, searchTitleTerm, searchTitleGUID},
+		{caseSummary, searchSummaryTerm, searchSummaryGUID},
+		{caseBody, searchBodyTerm, searchBodyGUID},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			items, _, err := db.ListItems(&ItemPage{Limit: 10, Search: tc.query})
+			if err != nil {
+				t.Fatalf("ListItems(%q) error = %v", tc.query, err)
+			}
+			if itemGUIDs(items) != tc.want {
+				t.Errorf("ListItems(%q) = [%s], want [%s]", tc.query, itemGUIDs(items), tc.want)
+			}
+		})
+	}
+	integrityCheck(t, db)
+}
+
+func TestListItemsRelevanceRanksTitleAboveBody(t *testing.T) {
+	db := setupItemTextFixtureDB(t)
+	seedRelevanceFixtures(t, db)
+
+	byDate, _, err := db.ListItems(&ItemPage{Limit: 10, Search: relevanceTerm})
+	if err != nil {
+		t.Fatalf("ListItems() error = %v", err)
+	}
+	if want := relevanceBodyGUID + "," + relevanceTitleGUID; itemGUIDs(byDate) != want {
+		t.Fatalf("newest ListItems() = [%s], want [%s]; the fixture must rank differently by date",
+			itemGUIDs(byDate), want)
+	}
+
+	ranked, _, err := db.ListItems(&ItemPage{Limit: 10, Search: relevanceTerm, Sort: SortRelevance})
+	if err != nil {
+		t.Fatalf("relevance ListItems() error = %v", err)
+	}
+	if want := relevanceTitleGUID + "," + relevanceBodyGUID; itemGUIDs(ranked) != want {
+		t.Errorf("relevance ListItems() = [%s], want [%s]; bm25 column weights rank a title hit above a body hit",
+			itemGUIDs(ranked), want)
+	}
+}
+
+// Relevance paginates by an offset carried in the cursor rather than by a
+// keyset, because bm25 scores shift with every write and so make no stable
+// key. Absent writes, the totality property is the same: every row exactly
+// once, in the same order a single unpaged query would give.
+func TestListItemsRelevancePagesByOffsetWithoutGapsOrRepeats(t *testing.T) {
+	db := setupItemTextFixtureDB(t)
+	seedRelevanceCorpus(t, db, 25)
+
+	oneShot, next, err := db.ListItems(&ItemPage{Limit: 100, Search: relevanceTerm, Sort: SortRelevance})
+	if err != nil {
+		t.Fatalf("ListItems() error = %v", err)
+	}
+	if next != nil {
+		t.Fatalf("unpaged ListItems() returned a cursor; the fixture is bigger than expected")
+	}
+	if len(oneShot) != 25 {
+		t.Fatalf("unpaged ListItems() = %d items, want 25", len(oneShot))
+	}
+
+	paged := drainItems(t, db, &ItemPage{Limit: 10, Search: relevanceTerm, Sort: SortRelevance})
+	if itemGUIDs(paged) != itemGUIDs(oneShot) {
+		t.Errorf("paged relevance = [%s], want the unpaged [%s]", itemGUIDs(paged), itemGUIDs(oneShot))
+	}
+}
+
+// The offset lives in the cursor, not in the caller, so a client that only
+// echoes the token back still advances.
+func TestListItemsRelevanceCursorCarriesTheOffset(t *testing.T) {
+	db := setupItemTextFixtureDB(t)
+	seedRelevanceCorpus(t, db, 25)
+
+	page := &ItemPage{Limit: 10, Search: relevanceTerm, Sort: SortRelevance}
+	_, next, err := db.ListItems(page)
+	if err != nil {
+		t.Fatalf("ListItems() error = %v", err)
+	}
+	if next == nil {
+		t.Fatal("ListItems() returned no cursor with 25 matching items and limit 10")
+	}
+	if !next.Relevance || next.Offset != 10 {
+		t.Errorf("cursor = %+v, want Relevance true and Offset 10", *next)
+	}
+
+	page.After = next
+	_, second, err := db.ListItems(page)
+	if err != nil {
+		t.Fatalf("second ListItems() error = %v", err)
+	}
+	if second == nil || second.Offset != 20 {
+		t.Errorf("second cursor = %+v, want Offset 20", second)
+	}
+}
+
+// bm25 reads the joined FTS table, so relevance without a search has nothing
+// to rank -- the same guard buildItemsQuery carries, for the same reason.
+func TestListItemsRelevanceRequiresSearch(t *testing.T) {
+	db := setupItemTextFixtureDB(t)
+	seedSearchFieldFixtures(t, db)
+
+	// A bare "*" is a non-empty Search that the parser reduces to the empty
+	// expression, so both spellings of "relevance with nothing to rank" fail.
+	for _, page := range []ItemPage{
+		{Limit: 10, Sort: SortRelevance},
+		{Limit: 10, Sort: SortRelevance, Search: "*"},
+	} {
+		if _, _, err := db.ListItems(&page); !errors.Is(err, ErrRelevanceNeedsSearch) {
+			t.Errorf("ListItems(%+v) error = %v, want %v", page, err, ErrRelevanceNeedsSearch)
+		}
+	}
+}
+
+func TestListItemsSearchRejectsOnlyExclusions(t *testing.T) {
+	db := setupItemTextFixtureDB(t)
+	seedSearchFieldFixtures(t, db)
+
+	items, _, err := db.ListItems(&ItemPage{Limit: 10, Search: searchOnlyExclusion})
+	if !errors.Is(err, search.ErrOnlyExclusions) {
+		t.Fatalf("ListItems() error = %v, want %v", err, search.ErrOnlyExclusions)
+	}
+	if items != nil {
+		t.Errorf("ListItems() returned %d items alongside the error, want none", len(items))
 	}
 }
 

--- a/internal/database/schema.sql
+++ b/internal/database/schema.sql
@@ -60,3 +60,45 @@ CREATE INDEX IF NOT EXISTS idx_item_annotations_kind   ON item_annotations(kind,
 -- distinct, which is what makes a repeated "seen" a no-op rather than a dupe.
 CREATE UNIQUE INDEX IF NOT EXISTS idx_item_annotations_unique
     ON item_annotations(feed_url, item_guid, kind, COALESCE(value, ''));
+
+-- Derived, HTML-free text for each item, plus the bookkeeping that says which
+-- generator produced it. Go owns inserts and updates here, because stripping
+-- HTML is Go code; the triggers below own the search index. This DDL is
+-- deliberately duplicated in migration 11 -- the same arrangement item_annotations
+-- has with migration 6 -- so fresh and migrated databases converge on it.
+CREATE TABLE IF NOT EXISTS item_text (
+    item_id           INTEGER PRIMARY KEY REFERENCES items(id) ON DELETE CASCADE,
+    title             TEXT NOT NULL DEFAULT '',
+    summary           TEXT NOT NULL DEFAULT '',
+    body              TEXT NOT NULL DEFAULT '',
+    source_hash       TEXT NOT NULL,
+    generator         TEXT NOT NULL,
+    generator_version INTEGER NOT NULL,
+    computed_at       DATETIME NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_item_text_generator
+    ON item_text(generator, generator_version);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS items_fts USING fts5(
+    title, summary, body,
+    content='item_text', content_rowid='item_id',
+    tokenize="porter unicode61 remove_diacritics 2"
+);
+
+-- An external-content index stores no column values of its own, so a 'delete'
+-- command has to carry the OLD ones: by the time the update trigger runs,
+-- item_text already holds the new text and the old terms are unrecoverable.
+CREATE TRIGGER IF NOT EXISTS item_text_ai AFTER INSERT ON item_text BEGIN
+    INSERT INTO items_fts(rowid, title, summary, body)
+    VALUES (new.item_id, new.title, new.summary, new.body);
+END;
+CREATE TRIGGER IF NOT EXISTS item_text_ad AFTER DELETE ON item_text BEGIN
+    INSERT INTO items_fts(items_fts, rowid, title, summary, body)
+    VALUES ('delete', old.item_id, old.title, old.summary, old.body);
+END;
+CREATE TRIGGER IF NOT EXISTS item_text_au AFTER UPDATE ON item_text BEGIN
+    INSERT INTO items_fts(items_fts, rowid, title, summary, body)
+    VALUES ('delete', old.item_id, old.title, old.summary, old.body);
+    INSERT INTO items_fts(rowid, title, summary, body)
+    VALUES (new.item_id, new.title, new.summary, new.body);
+END;

--- a/internal/database/search_agreement_test.go
+++ b/internal/database/search_agreement_test.go
@@ -1,0 +1,118 @@
+package database
+
+import (
+	"slices"
+	"testing"
+)
+
+const (
+	// agreementTitleTerm and friends each appear in a different field of the
+	// corpus below, so a surface that only reaches one field cannot agree with
+	// one that reaches all three.
+	agreementTitleTerm    = "networking"
+	agreementPhrase       = "release notes"
+	agreementQuotedPhrase = `"release notes"`
+
+	// agreementPageLimit is large enough that ListItems returns the whole
+	// corpus in one page, so the comparison is about matching rather than
+	// paging.
+	agreementPageLimit = 1000
+)
+
+// seedSearchAgreementCorpus builds a corpus with terms in the title only, the
+// summary only, the body only, several fields at once, and none of them.
+func seedSearchAgreementCorpus(t *testing.T, db *DB) {
+	t.Helper()
+	items := []*Item{
+		{
+			FeedURL: fixtureFeedURL, GUID: "agree-title",
+			Title:   "Container networking",
+			Summary: "<p>" + searchFiller + "</p>",
+			Content: "<div>" + searchFiller + "</div>",
+		},
+		{
+			FeedURL: fixtureFeedURL, GUID: "agree-summary",
+			Title:   "Weekly roundup",
+			Summary: "<p>Release notes for the scheduler.</p>",
+			Content: "<div>" + searchFiller + "</div>",
+		},
+		{
+			FeedURL: fixtureFeedURL, GUID: "agree-body",
+			Title:   "Third dispatch",
+			Summary: "<p>" + searchFiller + "</p>",
+			Content: "<div>The rust toolchain and its security posture.</div>",
+		},
+		{
+			FeedURL: fixtureFeedURL, GUID: "agree-everywhere",
+			Title:   "Networking release notes",
+			Summary: "<p>rust networking changes</p>",
+			Content: "<div>Secure networking, release notes, and more.</div>",
+		},
+		{
+			FeedURL: fixtureFeedURL, GUID: "agree-none",
+			Title:   "Unrelated",
+			Summary: "<p>" + searchFiller + "</p>",
+			Content: "<div>" + searchFiller + "</div>",
+		},
+	}
+	for _, item := range items {
+		if err := db.UpsertItem(item); err != nil {
+			t.Fatalf("seeding %s: %v", item.GUID, err)
+		}
+	}
+}
+
+// sortedItemIDs renders result row IDs order-independently, so the comparison
+// is about which rows matched rather than how each surface ordered them.
+func sortedItemIDs(items []*Item) []int64 {
+	ids := make([]int64, 0, len(items))
+	for _, item := range items {
+		ids = append(ids, item.ID)
+	}
+	slices.Sort(ids)
+	return ids
+}
+
+// TestSearchSurfacesAgree is the guard against the CLI (GetItems) and the API
+// (ListItems) drifting apart on what a query matches -- the failure mode #62
+// hit with annotation kinds. It is a structural invariant, not a regression
+// test: any query, any corpus, the two paths must return the same item IDs.
+//
+// It compares Search and nothing else, deliberately. ItemFilter and ItemPage
+// differ on the other filters by design -- ItemFilter has no Archived at all,
+// and their Since semantics differ (effective date versus discovery time, as
+// the #28 spec documents) -- so extending this to those fields would fail for
+// reasons that are correct behavior.
+func TestSearchSurfacesAgree(t *testing.T) {
+	db := setupItemTextFixtureDB(t)
+	seedSearchAgreementCorpus(t, db)
+
+	matched := 0
+	for _, query := range []string{
+		agreementTitleTerm, agreementPhrase, agreementQuotedPhrase,
+		"rust " + searchOnlyExclusion, "secur*", searchPunctuationQuery,
+		"absent", searchOnlyExclusion,
+	} {
+		cliItems, cliErr := db.GetItems(&ItemFilter{Search: query})
+		apiItems, _, apiErr := db.ListItems(&ItemPage{Search: query, Limit: agreementPageLimit})
+		// Errors must agree too: "-draft" has to fail on both surfaces or
+		// neither, otherwise one of them is silently returning everything.
+		if (cliErr == nil) != (apiErr == nil) {
+			t.Errorf("query %q: CLI err = %v, API err = %v", query, cliErr, apiErr)
+			continue
+		}
+		if cliErr != nil {
+			continue
+		}
+		cli, api := sortedItemIDs(cliItems), sortedItemIDs(apiItems)
+		if !slices.Equal(cli, api) {
+			t.Errorf("query %q: CLI returned %v, API returned %v", query, cli, api)
+			continue
+		}
+		matched += len(cli)
+	}
+	if matched == 0 {
+		t.Error("no query matched anything; the fixture cannot detect drift between the surfaces")
+	}
+	integrityCheck(t, db)
+}

--- a/internal/database/search_sql.go
+++ b/internal/database/search_sql.go
@@ -26,7 +26,9 @@ const (
 	itemsFTSRank = "bm25(items_fts, 10.0, 4.0, 1.0)"
 )
 
-// SortNewest and friends name the orderings both surfaces accept.
+// SortNewest and friends name the orderings both surfaces accept from a user.
+// They are not all orderings itemsOrderByClause emits -- see the note there
+// about SortOldest.
 const (
 	SortNewest    = "newest"
 	SortOldest    = "oldest"
@@ -56,6 +58,13 @@ func itemsSearchExpression(raw string) (string, error) {
 // itemsOrderByClause returns the ORDER BY for an item query. bm25 scores are
 // negative-better, so relevance ascends; the effective-date and id tiebreaks
 // make the ordering total for rows that score alike.
+//
+// SortOldest is deliberately not implemented here and falls through to
+// newest-first: it is the caller's to produce, and GetItems' caller does it by
+// reversing the returned slice in Go. Do not pass SortOldest and expect this
+// function to honor it. A paginating caller cannot reverse -- it holds one page,
+// not the whole result -- so an API that grows an oldest-first option needs a
+// real DESC-to-ASC branch here rather than this fallthrough.
 func itemsOrderByClause(sortOrder string) string {
 	if sortOrder == SortRelevance {
 		return " ORDER BY " + itemsFTSRank + " ASC, " + aliasedEffectiveDateExpression + " DESC, i.id DESC"

--- a/internal/database/search_sql.go
+++ b/internal/database/search_sql.go
@@ -35,10 +35,15 @@ const (
 	SortRelevance = "relevance"
 )
 
-// errRelevanceNeedsSearch guards the one combination the fragments above
+// ErrRelevanceNeedsSearch guards the one combination the fragments above
 // cannot express: bm25 reads the joined FTS table, and without a search there
 // is no join for it to read.
-var errRelevanceNeedsSearch = errors.New("sort by relevance requires a search query")
+//
+// Exported because the API has to tell it apart from a database failure. The
+// handler rejects sort=relevance with an empty q before ever reaching here,
+// but a query the parser reduces to nothing -- a bare "*" -- is non-empty and
+// gets through, and that is the caller's mistake rather than a 500.
+var ErrRelevanceNeedsSearch = errors.New("sort by relevance requires a search query")
 
 // itemsSearchExpression translates a raw search box into the FTS5 MATCH
 // expression the query binds. An empty result with a nil error means the query

--- a/internal/database/search_sql.go
+++ b/internal/database/search_sql.go
@@ -1,0 +1,64 @@
+package database
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/lmorchard/feedspool-go/internal/search"
+)
+
+// These three constants are the single source of truth for what a search
+// matches and how it ranks. buildItemsQuery (the CLI) builds from them today
+// and itemPageConditions (the API) will too, at which point a structural test
+// asserts the two surfaces cannot drift. The predecessor to this file was a
+// duplicated instr() expression in two places held in step only by a comment.
+//
+// The table is joined unaliased on purpose. MATCH and bm25() do not take a
+// table so much as the FTS table's hidden column, which is named after the
+// table itself -- so an alias f leaves "f MATCH ?" and "bm25(f, ...)" failing
+// with "no such column: f". Only "items_fts" or the wordier "f.items_fts"
+// resolve, and the unaliased spelling keeps all three fragments consistent.
+const (
+	itemsFTSJoin  = " JOIN items_fts ON items_fts.rowid = i.id"
+	itemsFTSMatch = "items_fts MATCH ?"
+	// Title outranks summary outranks body. Without column weights, a body
+	// mention buries an exact title match.
+	itemsFTSRank = "bm25(items_fts, 10.0, 4.0, 1.0)"
+)
+
+// SortNewest and friends name the orderings both surfaces accept.
+const (
+	SortNewest    = "newest"
+	SortOldest    = "oldest"
+	SortRelevance = "relevance"
+)
+
+// errRelevanceNeedsSearch guards the one combination the fragments above
+// cannot express: bm25 reads the joined FTS table, and without a search there
+// is no join for it to read.
+var errRelevanceNeedsSearch = errors.New("sort by relevance requires a search query")
+
+// itemsSearchExpression translates a raw search box into the FTS5 MATCH
+// expression the query binds. An empty result with a nil error means the query
+// carries no search filter, so neither the join nor the MATCH is added. A parse
+// error propagates to the caller rather than degrading into "match everything".
+func itemsSearchExpression(raw string) (string, error) {
+	if raw == "" {
+		return "", nil
+	}
+	expr, err := search.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse search query: %w", err)
+	}
+	return expr, nil
+}
+
+// itemsOrderByClause returns the ORDER BY for an item query. bm25 scores are
+// negative-better, so relevance ascends; the effective-date and id tiebreaks
+// make the ordering total for rows that score alike.
+func itemsOrderByClause(sortOrder string) string {
+	if sortOrder == SortRelevance {
+		return " ORDER BY " + itemsFTSRank + " ASC, " + aliasedEffectiveDateExpression + " DESC, i.id DESC"
+	}
+	return " ORDER BY " + aliasedEffectiveDateExpression + " DESC"
+}

--- a/internal/database/search_sql.go
+++ b/internal/database/search_sql.go
@@ -59,12 +59,17 @@ func itemsSearchExpression(raw string) (string, error) {
 // negative-better, so relevance ascends; the effective-date and id tiebreaks
 // make the ordering total for rows that score alike.
 //
-// SortOldest is deliberately not implemented here and falls through to
-// newest-first: it is the caller's to produce, and GetItems' caller does it by
-// reversing the returned slice in Go. Do not pass SortOldest and expect this
-// function to honor it. A paginating caller cannot reverse -- it holds one page,
-// not the whole result -- so an API that grows an oldest-first option needs a
-// real DESC-to-ASC branch here rather than this fallthrough.
+// Newest-first and relevance are the only orderings this function emits.
+// SortOldest falls through to newest-first by design, and GetItems' caller
+// reverses the returned slice in Go to produce it.
+//
+// That arrangement is settled, not a gap waiting to be filled. sqlLimitClause
+// is appended after this ORDER BY, so "--sort oldest --limit 10" means "the ten
+// newest, reversed for display". Adding a real ascending branch here would
+// quietly redefine it as "the ten oldest" -- a change to existing sort
+// semantics with nothing to do with search. ListItems does not route date
+// ordering through here either; it builds its own ORDER BY and handles
+// ascending from ItemPage.Ascending. No caller is waiting on a branch here.
 func itemsOrderByClause(sortOrder string) string {
 	if sortOrder == SortRelevance {
 		return " ORDER BY " + itemsFTSRank + " ASC, " + aliasedEffectiveDateExpression + " DESC, i.id DESC"

--- a/internal/itemtext/itemtext.go
+++ b/internal/itemtext/itemtext.go
@@ -1,0 +1,167 @@
+// Package itemtext derives the canonical text that represents a feed item:
+// title, summary, and body with HTML stripped, entities decoded, whitespace
+// collapsed, and each field truncated to a byte cap. It is pure and has no
+// database dependency. Phase-2 indexing feeds its output into SQLite FTS5;
+// issue #30's embedder is intended to call Derive with a smaller truncation
+// cap for its own token limits.
+package itemtext
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"unicode/utf8"
+
+	"golang.org/x/net/html"
+)
+
+// Generator and Version identify this derivation in item_text bookkeeping.
+// Bump Version whenever the output of Derive changes for the same input --
+// that is what forces a reindex.
+const (
+	Generator = "itemtext"
+	Version   = 1
+)
+
+// DefaultMaxTitleBytes, DefaultMaxSummaryBytes, and DefaultMaxBodyBytes are
+// bloat guards, not recall limits: long-form articles run well under them.
+// #30 will pass a far smaller cap for embedding token limits, which is why
+// this is an option rather than a constant in Derive.
+const (
+	DefaultMaxTitleBytes   = 4 * 1024
+	DefaultMaxSummaryBytes = 32 * 1024
+	DefaultMaxBodyBytes    = 256 * 1024
+)
+
+// sourceHashLength matches the truncated-hash idiom used by
+// internal/database.ItemHashID.
+const sourceHashLength = 32
+
+// sourceHashSep separates fields hashed by SourceHash so that, for example,
+// ("ab", "c") and ("a", "bc") do not collide.
+const sourceHashSep = "\x00"
+
+// Options bounds how many bytes of each field Derive keeps.
+type Options struct {
+	MaxTitleBytes   int
+	MaxSummaryBytes int
+	MaxBodyBytes    int
+}
+
+// DefaultOptions returns the byte caps used for FTS5 indexing.
+func DefaultOptions() Options {
+	return Options{
+		MaxTitleBytes:   DefaultMaxTitleBytes,
+		MaxSummaryBytes: DefaultMaxSummaryBytes,
+		MaxBodyBytes:    DefaultMaxBodyBytes,
+	}
+}
+
+// Text holds the derived, HTML-free representation of an item.
+type Text struct {
+	Title   string
+	Summary string
+	Body    string
+}
+
+// Derive strips HTML, decodes entities, collapses whitespace and truncates.
+func Derive(title, summary, content string, opts Options) Text {
+	return Text{
+		Title:   truncate(stripHTML(title), opts.MaxTitleBytes),
+		Summary: truncate(stripHTML(summary), opts.MaxSummaryBytes),
+		Body:    truncate(stripHTML(content), opts.MaxBodyBytes),
+	}
+}
+
+// SourceHash fingerprints the raw inputs so an unchanged item on re-fetch is
+// a string comparison rather than an HTML parse.
+func SourceHash(title, summary, content string) string {
+	sum := sha256.Sum256([]byte(title + sourceHashSep + summary + sourceHashSep + content))
+	return hex.EncodeToString(sum[:])[:sourceHashLength]
+}
+
+// stripHTML removes markup and collapses whitespace, leaving plain text.
+// Streaming tokenization keeps this cheap over a whole corpus; goquery would
+// build a document tree per item, which does not scale to a migration.
+//
+// script/style/noscript/template are HTML raw-text elements: the tokenizer's
+// lexer state machine treats everything after their start tag as element
+// content until a matching close tag, even without our own skip-depth
+// bookkeeping. If the input is malformed and one of these is never closed,
+// that "content" is the rest of the document, and skipDepth never returns to
+// 0 -- every subsequent TextToken, including real prose, is dropped. Feed
+// <description> fields are frequently truncated mid-document by publishers,
+// so this is not a rare edge case. When that happens, re-run the strip with
+// raw-text skipping disabled: the tokenizer still merges the unclosed
+// element's tag-adjacent text into one big Text token, so a little script or
+// CSS ends up in the index, but the trailing prose is not silently lost.
+// Indexing a little JavaScript beats indexing nothing. Well-formed documents
+// take the first pass and are unaffected.
+func stripHTML(raw string) string {
+	if text, ok := stripHTMLPass(raw, true); ok {
+		return text
+	}
+	text, _ := stripHTMLPass(raw, false)
+	return text
+}
+
+// stripHTMLPass tokenizes raw once. When skipRawText is true, text inside
+// script/style/noscript/template elements is dropped. It returns false if
+// the document ended with an unclosed skipped element (skipDepth > 0),
+// signaling that stripHTML should retry without raw-text skipping.
+func stripHTMLPass(raw string, skipRawText bool) (string, bool) {
+	tokenizer := html.NewTokenizer(strings.NewReader(raw))
+	var out strings.Builder
+	skipDepth := 0
+	for {
+		switch tokenizer.Next() {
+		case html.ErrorToken: // includes io.EOF
+			return strings.Join(strings.Fields(out.String()), " "), skipDepth == 0
+		case html.StartTagToken:
+			if skipRawText {
+				if name, _ := tokenizer.TagName(); isSkippedElement(name) {
+					skipDepth++
+				}
+			}
+		case html.EndTagToken:
+			if skipRawText {
+				if name, _ := tokenizer.TagName(); isSkippedElement(name) && skipDepth > 0 {
+					skipDepth--
+				}
+			}
+		case html.TextToken:
+			if skipDepth == 0 {
+				out.Write(tokenizer.Text()) // already entity-decoded
+				out.WriteByte(' ')
+			}
+		case html.SelfClosingTagToken, html.CommentToken, html.DoctypeToken:
+			// No text content to extract from these token types.
+		}
+	}
+}
+
+// isSkippedElement drops elements whose text content is markup, not prose.
+func isSkippedElement(name []byte) bool {
+	switch string(name) {
+	case "script", "style", "noscript", "template":
+		return true
+	}
+	return false
+}
+
+// truncate cuts s to at most max bytes, backing off to a UTF-8 rune boundary
+// so a multi-byte character is never split.
+func truncate(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	cut := s[:maxBytes]
+	for cut != "" {
+		r, size := utf8.DecodeLastRuneInString(cut)
+		if r != utf8.RuneError || size != 1 {
+			break
+		}
+		cut = cut[:len(cut)-1]
+	}
+	return cut
+}

--- a/internal/itemtext/itemtext_test.go
+++ b/internal/itemtext/itemtext_test.go
@@ -1,0 +1,126 @@
+package itemtext
+
+import (
+	"testing"
+	"unicode/utf8"
+)
+
+// plainTextInput and lessThanInput pass through Derive unchanged, so they
+// appear as both the input and the expected output in the table below.
+// beforeAfterWant is the shared expected output of the two well-formed
+// raw-text regression cases below.
+const (
+	plainTextInput  = "just plain text, nothing fancy"
+	lessThanInput   = "a < b and b > a"
+	beforeAfterWant = "before after"
+)
+
+func TestDeriveStripsMarkup(t *testing.T) {
+	got := Derive(
+		"Rust 1.87 &amp; friends",
+		"<p>A <b>short</b> summary</p>",
+		`<div>Hello <script>var x = "networking";</script> world</div>`,
+		DefaultOptions(),
+	)
+	if got.Title != "Rust 1.87 & friends" {
+		t.Errorf("title = %q", got.Title)
+	}
+	if got.Summary != "A short summary" {
+		t.Errorf("summary = %q", got.Summary)
+	}
+	if got.Body != "Hello world" {
+		t.Errorf("body = %q, script contents must not be indexed", got.Body)
+	}
+}
+
+func TestDeriveTruncatesOnRuneBoundary(t *testing.T) {
+	opts := DefaultOptions()
+	opts.MaxBodyBytes = 5
+	got := Derive("", "", "aé😀bcdef", opts)
+	if !utf8.ValidString(got.Body) {
+		t.Fatalf("body %q is not valid UTF-8", got.Body)
+	}
+	if len(got.Body) > opts.MaxBodyBytes {
+		t.Fatalf("body is %d bytes, cap is %d", len(got.Body), opts.MaxBodyBytes)
+	}
+}
+
+func TestSourceHashDistinguishesFieldBoundaries(t *testing.T) {
+	// Without a separator these two would hash identically.
+	if SourceHash("ab", "c", "") == SourceHash("a", "bc", "") {
+		t.Fatal("hash ignores the boundary between title and summary")
+	}
+	first := SourceHash("a", "b", "c")
+	second := SourceHash("a", "b", "c")
+	if first != second {
+		t.Fatal("hash is not stable")
+	}
+}
+
+func TestDeriveBodyTableDriven(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "plain text with no markup passes through",
+			input: plainTextInput,
+			want:  plainTextInput,
+		},
+		{
+			name:  "a less-than b survives as text",
+			input: lessThanInput,
+			want:  lessThanInput,
+		},
+		{
+			name:  "entity-only input decodes",
+			input: "&amp;&lt;&gt;",
+			want:  "&<>",
+		},
+		{
+			name:  "empty input yields empty output",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "whitespace and newlines collapse to single spaces",
+			input: "line one\n\n  line   two\ttabbed",
+			want:  "line one line two tabbed",
+		},
+		{
+			name:  "unclosed tags do not consume the rest of the document",
+			input: "<div>before<b>bold text after",
+			want:  "before bold text after",
+		},
+		{
+			name:  "unclosed script does not consume trailing text",
+			input: "<div>before<script>var x = 1; after script text but no closing tag",
+			want:  "before var x = 1; after script text but no closing tag",
+		},
+		{
+			name:  "unclosed style does not consume trailing text",
+			input: "<div>before<style>.a{color:red} after style text but no closing tag",
+			want:  "before .a{color:red} after style text but no closing tag",
+		},
+		{
+			name:  "well-formed script contents are still dropped",
+			input: "<div>before<script>var x = 1;</script>after</div>",
+			want:  beforeAfterWant,
+		},
+		{
+			name:  "well-formed style contents are still dropped",
+			input: "<div>before<style>.a{color:red}</style>after</div>",
+			want:  beforeAfterWant,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Derive("", "", tt.input, DefaultOptions())
+			if got.Body != tt.want {
+				t.Errorf("Derive body = %q, want %q", got.Body, tt.want)
+			}
+		})
+	}
+}

--- a/internal/search/execution_test.go
+++ b/internal/search/execution_test.go
@@ -1,0 +1,235 @@
+package search
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+
+	_ "modernc.org/sqlite" // pure-Go sqlite driver, the same one internal/database uses
+)
+
+// The fixture mirrors the shipped index: same column order, same tokenizer, so
+// an expression that executes here executes against a real spool.
+const (
+	fixtureDDL = `CREATE VIRTUAL TABLE items_fts USING fts5(
+		title, summary, body,
+		tokenize="porter unicode61 remove_diacritics 2"
+	)`
+	fixtureMatch = `SELECT count(*) FROM items_fts WHERE items_fts MATCH ?`
+	// The ranked form the API and the CLI both issue. bm25 is exercised as well
+	// as a bare MATCH because ordering by a rank function puts FTS5 into a
+	// different code path than counting does.
+	fixtureRanked = `SELECT rowid FROM items_fts
+		WHERE items_fts MATCH ? ORDER BY bm25(items_fts, 10.0, 4.0, 1.0) LIMIT 5`
+	fixtureRowIDs = `SELECT rowid FROM items_fts WHERE items_fts MATCH ? ORDER BY rowid`
+)
+
+// adversarialInputs are the shapes a caller can send that parseCases does not
+// already cover: FTS5 operators, punctuation-only phrases, quote pile-ups,
+// invalid UTF-8, and flat AND chains at the sizes the review probed. Every one
+// of these was verified to execute; they are kept so a later change to the
+// grammar cannot break them unnoticed.
+func adversarialInputs() []string {
+	return []string{
+		nul + "*",
+		"-" + nul,
+		`"` + nul + `"`,
+		soh + "\x02" + unitSep,
+		`""`,
+		`"*"`,
+		`"+"*`,
+		`""""`,
+		"^rust",
+		"...",
+		`"..."`,
+		"AND",
+		"OR",
+		"NOT",
+		"(rust)",
+		"{title body}:rust",
+		"NEAR(rust release, 3)",
+		"rust*release",
+		"-*",
+		`-"release notes"`,
+		"\U0001F600",
+		// Invalid UTF-8, which []rune folds to U+FFFD.
+		"\xff\xfe rust",
+		strings.TrimSpace(strings.Repeat("term ", 20)),
+		strings.TrimSpace(strings.Repeat("term ", 200)),
+		strings.TrimSpace(strings.Repeat("term ", 2000)),
+		// A quote-heavy input, where the doubling rule does all the work.
+		strings.Repeat(`"`, 64),
+	}
+}
+
+// TestParseOutputExecutesAgainstFTS5 is the invariant this package exists for:
+// whatever Parse returns without an error is a legal FTS5 expression. The
+// string comparisons in TestParse pin what the expression looks like; only
+// running it can show that FTS5 accepts it.
+//
+// The NUL cases are why this test exists. SQLite reads a bound MATCH operand as
+// a NUL-terminated C string, so an embedded U+0000 used to truncate the
+// expression mid-literal and raise "unterminated string", which the API
+// surfaced as a 500 -- exactly the failure this package promises to prevent.
+func TestParseOutputExecutesAgainstFTS5(t *testing.T) {
+	db := newFTS5Fixture(t)
+
+	cases := parseCases()
+	inputs := make([]string, 0, len(cases)+len(controlCharacterVariants())+len(adversarialInputs()))
+	for _, c := range cases {
+		inputs = append(inputs, c.in)
+	}
+	inputs = append(inputs, controlCharacterVariants()...)
+	inputs = append(inputs, adversarialInputs()...)
+
+	for _, in := range inputs {
+		t.Run(subtestName(in), func(t *testing.T) {
+			expr, err := Parse(in)
+			if err != nil {
+				// Only the documented rejection is acceptable here.
+				if !errors.Is(err, ErrOnlyExclusions) {
+					t.Fatalf("Parse(%q) returned an unexpected error: %v", in, err)
+				}
+				return
+			}
+			if expr == "" {
+				return // no search filter, so there is nothing to run
+			}
+			assertExecutes(t, db, in, expr)
+		})
+	}
+}
+
+// TestControlCharacterVariantsMatchTheBareTerm is the behavioral half of the
+// fix: folding a control character to whitespace is only correct if the term
+// still finds the same rows.
+func TestControlCharacterVariantsMatchTheBareTerm(t *testing.T) {
+	db := newFTS5Fixture(t)
+
+	baseline := matchedRowIDs(t, db, termRust)
+	if len(baseline) == 0 {
+		t.Fatalf("fixture has no rows matching %q", termRust)
+	}
+
+	for _, in := range controlCharacterVariants() {
+		t.Run(subtestName(in), func(t *testing.T) {
+			if got := matchedRowIDs(t, db, in); !slices.Equal(got, baseline) {
+				t.Errorf("Parse(%q) matched %v, want %v -- the same rows as %q",
+					in, got, baseline, termRust)
+			}
+		})
+	}
+}
+
+// assertExecutes runs the expression both as a bare MATCH and through bm25.
+func assertExecutes(t *testing.T, db *sql.DB, in, expr string) {
+	t.Helper()
+
+	var count int
+	if err := db.QueryRow(fixtureMatch, expr).Scan(&count); err != nil {
+		t.Fatalf("MATCH %q (from %q) failed: %v", expr, in, err)
+	}
+
+	rows, err := db.Query(fixtureRanked, expr)
+	if err != nil {
+		t.Fatalf("ranked MATCH %q (from %q) failed: %v", expr, in, err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var rowid int64
+		if err := rows.Scan(&rowid); err != nil {
+			t.Fatalf("scan for %q failed: %v", expr, err)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("ranked MATCH %q (from %q) failed mid-iteration: %v", expr, in, err)
+	}
+}
+
+// matchedRowIDs parses the input and returns the rowids it matches, in rowid
+// order so two queries are comparable.
+func matchedRowIDs(t *testing.T, db *sql.DB, in string) []int64 {
+	t.Helper()
+
+	expr, err := Parse(in)
+	if err != nil {
+		t.Fatalf("Parse(%q) returned error: %v", in, err)
+	}
+	if expr == "" {
+		t.Fatalf("Parse(%q) produced no expression", in)
+	}
+
+	rows, err := db.Query(fixtureRowIDs, expr)
+	if err != nil {
+		t.Fatalf("MATCH %q (from %q) failed: %v", expr, in, err)
+	}
+	defer rows.Close()
+
+	var ids []int64
+	for rows.Next() {
+		var rowid int64
+		if err := rows.Scan(&rowid); err != nil {
+			t.Fatalf("scan for %q failed: %v", expr, err)
+		}
+		ids = append(ids, rowid)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("MATCH %q (from %q) failed mid-iteration: %v", expr, in, err)
+	}
+	return ids
+}
+
+// newFTS5Fixture builds a small in-memory index with the shipped column layout
+// and tokenizer. The pool is capped at one connection because a modernc
+// ":memory:" database belongs to its connection rather than to the pool.
+func newFTS5Fixture(t *testing.T) *sql.DB {
+	t.Helper()
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open the fixture database: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = db.Close() })
+
+	if _, err := db.Exec(fixtureDDL); err != nil {
+		t.Fatalf("failed to create the fixture index: %v", err)
+	}
+
+	rows := [][3]string{
+		{"Rust 1.90 release notes", "What changed", "The rust release notes cover security fixes."},
+		{"C++ tips", "Assorted pointers", "Pointer arithmetic in C++ and other unsafe things."},
+		{"title:foo is not a column filter", "NEAR and OR as words", "A draft about nothing at all."},
+		{"Kubernetes digest", "Cluster notes", "term term term secure rollouts."},
+	}
+	for _, row := range rows {
+		if _, err := db.Exec(
+			`INSERT INTO items_fts(title, summary, body) VALUES (?, ?, ?)`,
+			row[0], row[1], row[2],
+		); err != nil {
+			t.Fatalf("failed to seed the fixture index: %v", err)
+		}
+	}
+
+	// This fixture is an ordinary FTS5 table rather than an external-content
+	// one, so there is no content table for the strong check to read back and
+	// the bare form is the only one that applies. internal/database uses the
+	// strong form, ('integrity-check', 1), against the real index.
+	if _, err := db.Exec(`INSERT INTO items_fts(items_fts) VALUES('integrity-check')`); err != nil {
+		t.Fatalf("fixture integrity-check failed: %v", err)
+	}
+	return db
+}
+
+// subtestName keeps control characters and very long inputs out of test names.
+func subtestName(in string) string {
+	name := fmt.Sprintf("%q", in)
+	const maxNameLength = 48
+	if len(name) > maxNameLength {
+		name = name[:maxNameLength] + fmt.Sprintf("...(%d bytes)", len(in))
+	}
+	return name
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -82,8 +82,17 @@ func Parse(raw string) (string, error) {
 // A token that reduces to empty text after stripping -- a bare "-" or a bare
 // "*" -- contributes nothing; this is how the bare "*" case ends up as "no
 // search filter" rather than an empty pair of quotes.
+//
+// Control characters are folded to spaces before any of that, so they separate
+// terms rather than becoming part of one. U+0000 is why: SQLite reads a bound
+// MATCH operand as a NUL-terminated C string, so an embedded NUL truncates the
+// expression mid-literal and FTS5 raises "unterminated string" -- the syntax
+// error this package exists to make impossible. Folding happens up front, and
+// therefore before the emptiness check below, so a token that was nothing but
+// control characters disappears the way whitespace does instead of emitting an
+// empty "".
 func tokenize(raw string) []term {
-	runes := []rune(raw)
+	runes := foldControls([]rune(raw))
 	n := len(runes)
 
 	var terms []term
@@ -149,4 +158,20 @@ func quoteFTS5(text string) string {
 
 func isSpace(r rune) bool {
 	return r == ' ' || r == '\t' || r == '\n' || r == '\r'
+}
+
+// foldControls replaces every C0 control character with a space, in place.
+// Only U+0000 actually breaks FTS5 -- see tokenize -- but the C0 block is the
+// set isSpace already treats as separators for tab, newline and carriage
+// return, so folding all of it keeps one rule instead of a special case. It is
+// the whole set that can reach FTS5 unrepresented, too: []rune has already
+// replaced invalid UTF-8 with U+FFFD by the time this runs.
+func foldControls(runes []rune) []rune {
+	const firstPrintable = 0x20
+	for i, r := range runes {
+		if r < firstPrintable {
+			runes[i] = ' '
+		}
+	}
+	return runes
 }

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1,0 +1,152 @@
+// Package search translates a user's search box into an FTS5 MATCH
+// expression. Raw FTS5 syntax cannot be handed user input directly: bare
+// punctuation such as C++, column filters like title:foo, and operators such
+// as NEAR are syntax that FTS5 would try to parse, turning a perfectly
+// reasonable query into a syntax error. Parse instead treats every term as
+// literal text, quoting it so FTS5 matches it verbatim.
+//
+// The package is pure -- no I/O, no database -- and has no callers yet.
+// Phase 5 wires it into the CLI, and phase 6 into the API.
+package search
+
+import (
+	"errors"
+	"strings"
+)
+
+// ErrOnlyExclusions is returned for a query with nothing to match, such as
+// "-draft". FTS5 cannot answer "everything except X", and returning zero rows
+// would read as a bug rather than as a rejected query.
+var ErrOnlyExclusions = errors.New("search query needs at least one term to match")
+
+// term is one token pulled from the raw query: quoted text ready to drop into
+// an FTS5 expression, with prefix already appended if the user asked for one.
+type term struct {
+	quoted string
+	negate bool
+}
+
+// Parse translates user input into an FTS5 MATCH expression. An empty result
+// with a nil error means "no search filter", matching today's behavior for an
+// empty q or --search.
+//
+// Every term is emitted double-quoted, so FTS5 operators a user did not
+// intend -- NEAR, AND, column filters like title:foo, bare punctuation such
+// as C++ -- are matched as literal text instead of being parsed as syntax or
+// raising a syntax error the caller would have to surface as a 500.
+//
+// Positives and negatives combine as "(pos1 AND pos2) NOT (neg1 OR neg2)".
+// The parentheses are load-bearing: FTS5 binds NOT tighter than AND, so the
+// unparenthesized "a AND b NOT c" would mean "a AND (b NOT c)".
+func Parse(raw string) (string, error) {
+	terms := tokenize(raw)
+
+	var positives, negatives []string
+
+	for _, t := range terms {
+		if t.negate {
+			negatives = append(negatives, t.quoted)
+		} else {
+			positives = append(positives, t.quoted)
+		}
+	}
+
+	switch {
+	case len(positives) == 0 && len(negatives) == 0:
+		return "", nil
+	case len(positives) == 0:
+		return "", ErrOnlyExclusions
+	case len(negatives) == 0:
+		return "(" + strings.Join(positives, " AND ") + ")", nil
+	default:
+		posGroup := "(" + strings.Join(positives, " AND ") + ")"
+		negGroup := "(" + strings.Join(negatives, " OR ") + ")"
+
+		return posGroup + " NOT " + negGroup, nil
+	}
+}
+
+// tokenize walks raw left to right, splitting it into terms on whitespace
+// except inside a double-quoted phrase, where whitespace is kept as part of
+// the phrase. Applied per token, in order:
+//
+//  1. a leading "-" marks the term negated, and is stripped;
+//  2. a double quote opens a phrase that runs to the next double quote, or to
+//     end of input if none follows -- an unterminated quote closes implicitly
+//     rather than erroring;
+//  3. otherwise the token runs to the next whitespace, and a trailing "*"
+//     marks it a prefix match and is stripped;
+//  4. whatever text remains is quoted verbatim for FTS5, doubling any
+//     embedded quote per FTS5 string literal rules.
+//
+// A token that reduces to empty text after stripping -- a bare "-" or a bare
+// "*" -- contributes nothing; this is how the bare "*" case ends up as "no
+// search filter" rather than an empty pair of quotes.
+func tokenize(raw string) []term {
+	runes := []rune(raw)
+	n := len(runes)
+
+	var terms []term
+
+	i := 0
+	for i < n {
+		for i < n && isSpace(runes[i]) {
+			i++
+		}
+		if i >= n {
+			break
+		}
+
+		negate := false
+		if runes[i] == '-' {
+			negate = true
+			i++
+		}
+
+		var text string
+
+		prefix := false
+		if i < n && runes[i] == '"' {
+			i++
+			start := i
+			for i < n && runes[i] != '"' {
+				i++
+			}
+			text = string(runes[start:i])
+			if i < n {
+				i++ // skip closing quote
+			}
+		} else {
+			start := i
+			for i < n && !isSpace(runes[i]) {
+				i++
+			}
+			text = string(runes[start:i])
+			prefix = strings.HasSuffix(text, "*")
+			text = strings.TrimSuffix(text, "*")
+		}
+
+		if text == "" {
+			continue // a bare "-", bare "*", or empty phrase contributes nothing
+		}
+
+		quoted := quoteFTS5(text)
+		if prefix {
+			quoted += "*"
+		}
+
+		terms = append(terms, term{quoted: quoted, negate: negate})
+	}
+
+	return terms
+}
+
+// quoteFTS5 wraps text in double quotes for use as an FTS5 string literal,
+// doubling any embedded double quote as FTS5 requires.
+func quoteFTS5(text string) string {
+	return `"` + strings.ReplaceAll(text, `"`, `""`) + `"`
+}
+
+func isSpace(r rune) bool {
+	return r == ' ' || r == '\t' || r == '\n' || r == '\r'
+}

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -10,13 +10,31 @@ import (
 // input, so it produces the same expression as the closed phrase.
 const releaseNotesWant = `("release notes")`
 
-func TestParse(t *testing.T) {
-	cases := []struct {
-		name, in, want string
-	}{
+// termRust is the sample term shared by the cases below, the
+// control-character variants, and the FTS5 fixture in execution_test.go.
+const termRust = "rust"
+
+// The control characters the variants are built from. Only nul actually breaks
+// FTS5 -- see tokenize -- but the rule covers the whole C0 block, so the other
+// two ride along to show it.
+const (
+	nul     = "\x00"
+	soh     = "\x01"
+	unitSep = "\x1f"
+)
+
+// parseCase is one input and the expression Parse has to produce for it.
+type parseCase struct{ name, in, want string }
+
+// parseCases is the shared corpus. TestParse asserts the expression each input
+// produces; TestParseOutputExecutesAgainstFTS5 runs those same expressions
+// against a real FTS5 index, so an input cannot be pinned in one test and
+// forgotten in the other.
+func parseCases() []parseCase {
+	return []parseCase{
 		{"empty", "", ""},
 		{"whitespace only", "   ", ""},
-		{"single term", "rust", `("rust")`},
+		{"single term", termRust, `("rust")`},
 		{"implicit and", "rust release", `("rust" AND "release")`},
 		{"phrase", `"release notes"`, releaseNotesWant},
 		{"exclusion", "rust -draft", `("rust") NOT ("draft")`},
@@ -28,9 +46,27 @@ func TestParse(t *testing.T) {
 		{"unterminated quote", `"release notes`, releaseNotesWant},
 		{"bare star", "*", ""},
 		{"embedded double quote in word", `say"quote"word`, `("say""quote""word")`},
+		// Control characters separate terms rather than reaching FTS5, where a
+		// NUL would truncate the bound expression mid-literal.
+		{"nul only", nul, ""},
+		{"nul inside a term", "ru" + nul + "st", `("ru" AND "st")`},
+		{"nul inside a phrase", `"release` + nul + `notes"`, releaseNotesWant},
 	}
+}
 
-	for _, c := range cases {
+// controlCharacterVariants are termRust with control characters glued on. Each
+// has to behave exactly as the bare term does.
+func controlCharacterVariants() []string {
+	return []string{
+		nul + termRust,
+		termRust + nul,
+		nul + termRust + nul,
+		soh + termRust + unitSep,
+	}
+}
+
+func TestParse(t *testing.T) {
+	for _, c := range parseCases() {
 		t.Run(c.name, func(t *testing.T) {
 			got, err := Parse(c.in)
 			if err != nil {
@@ -38,6 +74,23 @@ func TestParse(t *testing.T) {
 			}
 			if got != c.want {
 				t.Errorf("Parse(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// A control character glued to a term is a separator, not text, so the term is
+// found as though it were not there.
+func TestParseFoldsControlCharactersToWhitespace(t *testing.T) {
+	want := `("` + termRust + `")`
+	for _, in := range controlCharacterVariants() {
+		t.Run(subtestName(in), func(t *testing.T) {
+			got, err := Parse(in)
+			if err != nil {
+				t.Fatalf("Parse(%q) returned error: %v", in, err)
+			}
+			if got != want {
+				t.Errorf("Parse(%q) = %q, want %q", in, got, want)
 			}
 		})
 	}

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -1,0 +1,50 @@
+package search
+
+import (
+	"errors"
+	"testing"
+)
+
+// releaseNotesWant is the expected output for both a well-formed phrase and
+// an unterminated one: an unterminated quote closes implicitly at end of
+// input, so it produces the same expression as the closed phrase.
+const releaseNotesWant = `("release notes")`
+
+func TestParse(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{"empty", "", ""},
+		{"whitespace only", "   ", ""},
+		{"single term", "rust", `("rust")`},
+		{"implicit and", "rust release", `("rust" AND "release")`},
+		{"phrase", `"release notes"`, releaseNotesWant},
+		{"exclusion", "rust -draft", `("rust") NOT ("draft")`},
+		{"prefix", "secur*", `("secur"*)`},
+		{"operator as literal", "foo NEAR bar", `("foo" AND "NEAR" AND "bar")`},
+		{"column filter as literal", "title:foo", `("title:foo")`},
+		{"punctuation", "C++", `("C++")`},
+		{"embedded quote", `say "hi" there`, `("say" AND "hi" AND "there")`},
+		{"unterminated quote", `"release notes`, releaseNotesWant},
+		{"bare star", "*", ""},
+		{"embedded double quote in word", `say"quote"word`, `("say""quote""word")`},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := Parse(c.in)
+			if err != nil {
+				t.Fatalf("Parse(%q) returned error: %v", c.in, err)
+			}
+			if got != c.want {
+				t.Errorf("Parse(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestParseRejectsOnlyExclusions(t *testing.T) {
+	if _, err := Parse("-draft -wip"); !errors.Is(err, ErrOnlyExclusions) {
+		t.Fatalf("err = %v, want ErrOnlyExclusions", err)
+	}
+}


### PR DESCRIPTION
Closes #58.

Replaces the title-substring match on both surfaces with FTS5 over **title, summary and body**, ranked by `bm25()`. Adds `feedspool reindex`, migration 11, and the canonical item-text substrate #30 was promised.

## What changed for a user

`feedspool items --search` and `GET /api/v1/items?q=` now take the same small query language:

| Input | Meaning |
| --- | --- |
| `rust release` | both terms (implicit AND) |
| `"release notes"` | phrase |
| `-draft` | exclude |
| `secur*` | prefix |

Everything else is literal, so `C++`, `title:foo` and `NEAR` are searched for rather than parsed as operators — those are all FTS5 syntax errors if passed through raw.

`--sort relevance` / `sort=relevance` join `newest`/`oldest`. **`newest` stays the default even with a query** — a feed reader's search is usually "what's new about X", and it keeps the default path on the keyset cursor.

**This changes what `q` and `--search` match.** It is not a v1 break: the API merged after `v1.0.2` and has never been in a tagged release, so no stable release ever carried the substring behavior.

## Design

An external-content FTS5 table indexes a derived `item_text` table rather than `items` directly. That is forced: `content='items'` means FTS5 reads column values back out of `items`, so the indexed text must *be* the stored text — which rules out a Go-side HTML strip. The derivation lives in `internal/itemtext` with truncation as a *parameter*, because #30's embedder needs a much smaller cap and a baked-in number is how the two would drift.

Triggers on `item_text` maintain the index; Go maintains `item_text`. Deletes carry no transform and reach the `ON DELETE CASCADE` path Go code never sees — verified to fire at depth 2 (`feeds` → `items` → `item_text`) — so purge and feed-delete need no FTS code at all.

Relevance paginates by an offset inside the opaque cursor. A bm25 keyset would silently *skip* rows, since any write shifts every score; offset can only repeat or drop one.

## Verification on a real 19,750-item spool

Migration 23.5s, 19,750/19,750 indexed, `('integrity-check', 1)` clean, +24% on disk. CLI and API return identical items in identical rank order with `archived=any`; relevance paging 9x7 reproduced a single page exactly, same set and same order.

Ranking is visibly better than date order, not merely correct — `kubernetes` by date returns AI-digest aggregators mentioning it in passing; by relevance, four title matches about Kubernetes.

Both spec open questions closed with measurements: the 256 KiB cap is right (largest real body 258,150 bytes, nothing truncated), and `porter` stemming does enough work that prefix search is nearly redundant with it (`secur` 1327 hits, `secur*` 1332).

## Notes for review

Three defects were caught during implementation rather than after, and are worth knowing about:

- The bare `('integrity-check')` is nearly meaningless on an external-content table — it passes on an index that has drifted from its content table. Only `('integrity-check', 1)` detects it. `research.md` records the correction; the suite uses the strong form throughout.
- `f MATCH ?` and `bm25(f, ...)` do not run. FTS5's `MATCH` operand and `bm25()`'s first argument are the table's hidden column, named for the table and never an alias. The unaliased spelling is deliberate and commented.
- `q=%00foo` returned a 500 — a NUL byte truncated the bound `MATCH` operand at the C-string boundary. Control characters now fold to whitespace, and `internal/search/execution_test.go` runs every parser output through a real FTS5 `MATCH` so the class cannot recur.

Two follow-ups are recorded in `notes.md`: `reindex --force` empties the index before refilling it (window documented rather than closed; the better fix is marking rows stale instead of deleting), and migration progress is invisible at the default log level, which wants a progress callback through `RunMigrations`.

Spec, plan, research and notes are in `docs/dev-sessions/2026-08-26-1247-fts5-search/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
